### PR TITLE
feat: bin-full notifications with QR poster

### DIFF
--- a/app/models/BinFullNotificationMapper.ts
+++ b/app/models/BinFullNotificationMapper.ts
@@ -1,0 +1,11 @@
+import type { BinFullNotificationDTO } from '~/types';
+
+export function toDTO(raw: any): BinFullNotificationDTO {
+  return {
+    id: raw.id,
+    createdAt: raw.created_at,
+    clubId: raw.club_id,
+    courseName: raw.course_name,
+    readAt: raw.read_at,
+  };
+}

--- a/app/models/binFullNotification.server.ts
+++ b/app/models/binFullNotification.server.ts
@@ -1,0 +1,55 @@
+import { createConnection, createSupabaseServerClient } from '~/models/utils';
+import { toDTO } from '~/models/BinFullNotificationMapper';
+import type { BinFullNotificationDTO } from '~/types';
+import process from 'process';
+
+export async function createBinFullNotification(data: { courseName: string }): Promise<void> {
+  const supabase = createConnection();
+  const clubId = process.env.APP_CLUB_ID;
+
+  const { error } = await supabase.from('bin_full_notifications').insert({
+    club_id: clubId,
+    course_name: data.courseName,
+  });
+
+  if (error) {
+    console.error('Failed to create bin full notification:', error.message);
+  }
+}
+
+export async function getBinFullNotifications(request: Request): Promise<BinFullNotificationDTO[]> {
+  const supabase = createSupabaseServerClient(request);
+  const clubId = process.env.APP_CLUB_ID;
+
+  const { data } = await supabase
+    .from('bin_full_notifications')
+    .select('id, created_at, club_id, course_name, read_at')
+    .eq('club_id', clubId)
+    .order('created_at', { ascending: false });
+
+  return data ? data.map((row: any) => toDTO(row)) : [];
+}
+
+export async function markBinFullNotificationAsRead(id: number, request: Request): Promise<void> {
+  const supabase = createSupabaseServerClient(request);
+  const clubId = process.env.APP_CLUB_ID;
+
+  await supabase
+    .from('bin_full_notifications')
+    .update({ read_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('club_id', clubId);
+}
+
+export async function deleteBinFullNotification(id: number, request: Request): Promise<void> {
+  const supabase = createSupabaseServerClient(request);
+  const clubId = process.env.APP_CLUB_ID;
+
+  await supabase.from('bin_full_notifications').delete().eq('id', id).eq('club_id', clubId);
+}
+
+export async function deleteAllBinFullNotifications(request: Request): Promise<void> {
+  const supabase = createSupabaseServerClient(request);
+
+  await supabase.from('bin_full_notifications').delete().gte('id', 0);
+}

--- a/app/routes/bin.full.$courseSlug.tsx
+++ b/app/routes/bin.full.$courseSlug.tsx
@@ -1,0 +1,64 @@
+import type { ActionArgs, LoaderArgs } from '@remix-run/node';
+import { createCookie, json } from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+
+import BinFullForm from './components/BinFullForm';
+
+import { createBinFullNotification } from '~/models/binFullNotification.server';
+import { getCourseBySlug } from '~/config/courses';
+
+const RATE_LIMIT_MS = 10 * 60 * 1000;
+
+const cookieFor = (slug: string) =>
+  createCookie(`bin_full_rl_${slug}`, {
+    path: '/bin/full',
+    sameSite: 'lax',
+    maxAge: RATE_LIMIT_MS / 1000,
+    httpOnly: true,
+  });
+
+async function readRateLimitedAt(request: Request, slug: string): Promise<number | null> {
+  const cookie = cookieFor(slug);
+  const value = await cookie.parse(request.headers.get('Cookie'));
+  const ts = typeof value === 'number' ? value : null;
+  if (!ts) return null;
+  return Date.now() - ts < RATE_LIMIT_MS ? ts : null;
+}
+
+export const loader = async ({ request, params }: LoaderArgs) => {
+  const course = getCourseBySlug(params.courseSlug!);
+
+  if (!course) {
+    throw new Response('Rataa ei löytynyt', { status: 404 });
+  }
+
+  const recentlySubmitted = (await readRateLimitedAt(request, course.slug)) != null;
+
+  return json({ course, recentlySubmitted });
+};
+
+export async function action({ request, params }: ActionArgs) {
+  const course = getCourseBySlug(params.courseSlug!);
+
+  if (!course) {
+    throw new Response('Rataa ei löytynyt', { status: 404 });
+  }
+
+  const recentlySubmitted = (await readRateLimitedAt(request, course.slug)) != null;
+
+  if (!recentlySubmitted) {
+    await createBinFullNotification({ courseName: course.name });
+  }
+
+  const cookie = cookieFor(course.slug);
+  const headers = new Headers();
+  headers.append('Set-Cookie', await cookie.serialize(Date.now()));
+
+  return json({ success: true }, { headers });
+}
+
+export default function BinFullCourseSlugPage(): JSX.Element {
+  const { course, recentlySubmitted } = useLoaderData<typeof loader>();
+
+  return <BinFullForm course={course} alreadySubmitted={recentlySubmitted} />;
+}

--- a/app/routes/components/BinFullForm.tsx
+++ b/app/routes/components/BinFullForm.tsx
@@ -1,0 +1,47 @@
+import { Form, useActionData } from '@remix-run/react';
+
+import { Button } from '@mui/material';
+
+import H2 from './H2';
+
+import type { Course } from '~/config/courses';
+
+type BinFullFormProps = {
+  course: Course;
+  alreadySubmitted?: boolean;
+};
+
+export default function BinFullForm({ course, alreadySubmitted }: BinFullFormProps): JSX.Element {
+  const actionData = useActionData<{ success?: boolean }>();
+
+  if (actionData?.success || alreadySubmitted) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] px-6">
+        <div className="text-5xl mb-6">&#9989;</div>
+        <H2 className="mb-4">Kiitos ilmoituksesta!</H2>
+        <p className="text-gray-600 text-center text-lg">
+          Ilmoitus täydestä löytökiekkolaatikosta on vastaanotettu.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-6 py-8 max-w-lg mx-auto">
+      <H2 className="mb-2">Löytökiekkolaatikko täynnä?</H2>
+
+      <p className="text-black font-bold mb-4 text-sm">{course.name}</p>
+
+      <p className="text-gray-700 mb-8 text-base leading-relaxed">
+        Onko löytökiekkolaatikko täynnä niin, että kiekkoja ei enää mahdu sisään? Ilmoita siitä painamalla alla olevaa
+        nappia.
+      </p>
+
+      <Form method="post">
+        <Button variant="contained" type="submit" size="large" fullWidth>
+          Laatikko on täynnä
+        </Button>
+      </Form>
+    </div>
+  );
+}

--- a/app/routes/components/admin/BinFullQrPosterButtons.tsx
+++ b/app/routes/components/admin/BinFullQrPosterButtons.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { Button } from '@mui/material';
+import QRCode from 'qrcode';
+
+import type { Course } from '~/config/courses';
+import { getCourseBySlug } from '~/config/courses';
+
+const BIN_FULL_COURSE_SLUGS = ['oittaa'];
+
+async function generateAndDownloadPdf(course: Course) {
+  const { Document, Page, Text, Image, StyleSheet, pdf } = await import('@react-pdf/renderer');
+
+  const styles = StyleSheet.create({
+    page: {
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 32,
+    },
+    logo: {
+      width: 140,
+      height: 100,
+      objectFit: 'contain',
+      marginBottom: 20,
+    },
+    title: {
+      fontSize: 36,
+      fontWeight: 'bold',
+      marginBottom: 8,
+      textAlign: 'center',
+    },
+    subtitle: {
+      fontSize: 18,
+      textAlign: 'center',
+      marginBottom: 24,
+    },
+    qrCode: {
+      width: 280,
+      height: 280,
+      marginBottom: 0,
+    },
+    url: {
+      fontSize: 14,
+      textAlign: 'center',
+      marginBottom: 16,
+      color: '#555555',
+    },
+    courseName: {
+      fontSize: 22,
+      textAlign: 'center',
+    },
+    greeting: {
+      fontSize: 22,
+      textAlign: 'center',
+      marginTop: 24,
+    },
+    clubName: {
+      fontSize: 18,
+      textAlign: 'center',
+      marginTop: 6,
+    },
+  });
+
+  const baseUrl = window.location.origin;
+  const url = `${baseUrl}/bin/full/${course.slug}`;
+
+  const qrDataUrl = await QRCode.toDataURL(url, { width: 600, margin: 1 });
+
+  const logoFile = course.clubId === 1 ? 'ps-logo.png' : 'TT-Logo-transparent.png';
+  const logoUrl = `${baseUrl}/${logoFile}`;
+  const blob = await pdf(
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <Image src={logoUrl} style={styles.logo} />
+        <Text style={styles.title}>Löytökiekkolaatikko täynnä?</Text>
+        <Text style={styles.subtitle}>Voit ilmoittaa täydestä laatikosta alla olevan linkin kautta</Text>
+        <Image src={qrDataUrl} style={styles.qrCode} />
+        <Text style={styles.url}>{url}</Text>
+        <Text style={styles.courseName}>{course.name}</Text>
+        <Text style={styles.greeting}>Kiitos!</Text>
+        <Text style={styles.clubName}>{course.clubName}</Text>
+      </Page>
+    </Document>,
+  ).toBlob();
+
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = objectUrl;
+  a.download = `${course.slug}-bin-full-qr.pdf`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(objectUrl);
+}
+
+export default function BinFullQrPosterButtons() {
+  const [generating, setGenerating] = useState<string | null>(null);
+
+  const applicableCourses = BIN_FULL_COURSE_SLUGS.map(getCourseBySlug).filter((c): c is Course => !!c);
+
+  if (applicableCourses.length === 0) {
+    return null;
+  }
+
+  const handleClick = async (course: Course) => {
+    setGenerating(course.slug);
+    try {
+      await generateAndDownloadPdf(course);
+    } catch (error) {
+      console.error('Failed to generate PDF:', error);
+    } finally {
+      setGenerating(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-6">
+      {applicableCourses.map((course) => (
+        <Button
+          key={course.slug}
+          variant="outlined"
+          size="small"
+          disabled={generating === course.slug}
+          onClick={() => handleClick(course)}
+        >
+          {generating === course.slug ? 'Luodaan...' : `QR (täysi laatikko): ${course.name}`}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/app/routes/notifications.tsx
+++ b/app/routes/notifications.tsx
@@ -12,11 +12,18 @@ import {
   deleteNotification,
   deleteAllNotifications,
 } from '~/models/discFoundNotification.server';
-import type { DiscFoundNotificationDTO } from '~/types';
+import {
+  getBinFullNotifications,
+  markBinFullNotificationAsRead,
+  deleteBinFullNotification,
+  deleteAllBinFullNotifications,
+} from '~/models/binFullNotification.server';
+import type { BinFullNotificationDTO, DiscFoundNotificationDTO } from '~/types';
 import { formatDateTime } from '~/routes/utils';
 
 import H2 from '~/routes/components/H2';
 import QrPosterButtons from '~/routes/components/admin/QrPosterButtons';
+import BinFullQrPosterButtons from '~/routes/components/admin/BinFullQrPosterButtons';
 
 const Card = styled.div`
   border: 1px solid #e0e0e0;
@@ -38,9 +45,12 @@ export const loader = async ({ request }: LoaderArgs) => {
     return redirect('/sign-in');
   }
 
-  const notifications = await getDiscFoundNotifications(request);
+  const [notifications, binFullNotifications] = await Promise.all([
+    getDiscFoundNotifications(request),
+    getBinFullNotifications(request),
+  ]);
 
-  return json({ notifications });
+  return json({ notifications, binFullNotifications });
 };
 
 export async function action({ request }: ActionArgs) {
@@ -50,6 +60,11 @@ export async function action({ request }: ActionArgs) {
 
   if (intent === 'deleteAll') {
     await deleteAllNotifications(request);
+    return json({});
+  }
+
+  if (intent === 'deleteAllBinFull') {
+    await deleteAllBinFullNotifications(request);
     return json({});
   }
 
@@ -63,6 +78,10 @@ export async function action({ request }: ActionArgs) {
     await deleteNotification(id, request);
   } else if (intent === 'markAsRead') {
     await markNotificationAsRead(id, request);
+  } else if (intent === 'deleteBinFull') {
+    await deleteBinFullNotification(id, request);
+  } else if (intent === 'markBinFullAsRead') {
+    await markBinFullNotificationAsRead(id, request);
   }
 
   return json({});
@@ -141,8 +160,51 @@ function NotificationItem({ notification }: { notification: DiscFoundNotificatio
   );
 }
 
+function BinFullNotificationItem({ notification }: { notification: BinFullNotificationDTO }) {
+  const fetcher = useFetcher();
+  const isUnread = !notification.readAt;
+  const CardComponent = isUnread ? UnreadCard : Card;
+
+  return (
+    <CardComponent>
+      <div className="text-sm text-gray-500 mb-2">
+        {formatDateTime(notification.createdAt)}
+        <span className="ml-4">{notification.courseName}</span>
+        {notification.readAt && <span className="ml-4">Luettu: {formatDateTime(notification.readAt)}</span>}
+      </div>
+
+      <div className="flex gap-2 mt-2">
+        {isUnread && (
+          <fetcher.Form method="post">
+            <input type="hidden" name="notificationId" value={notification.id} />
+            <input type="hidden" name="intent" value="markBinFullAsRead" />
+            <Button variant="outlined" size="small" type="submit">
+              Merkitse luetuksi
+            </Button>
+          </fetcher.Form>
+        )}
+
+        <fetcher.Form
+          method="post"
+          onSubmit={(e) => {
+            if (!confirm('Haluatko varmasti poistaa ilmoituksen?')) {
+              e.preventDefault();
+            }
+          }}
+        >
+          <input type="hidden" name="notificationId" value={notification.id} />
+          <input type="hidden" name="intent" value="deleteBinFull" />
+          <Button variant="outlined" size="small" color="error" type="submit">
+            Poista
+          </Button>
+        </fetcher.Form>
+      </div>
+    </CardComponent>
+  );
+}
+
 export default function NotificationsPage(): JSX.Element {
-  const { notifications } = useLoaderData<typeof loader>();
+  const { notifications, binFullNotifications } = useLoaderData<typeof loader>();
   const fetcher = useFetcher();
 
   return (
@@ -173,6 +235,34 @@ export default function NotificationsPage(): JSX.Element {
 
       {notifications.map((notification: DiscFoundNotificationDTO) => (
         <NotificationItem key={notification.id} notification={notification} />
+      ))}
+
+      <H2 className="mt-12 mb-4">Ilmoitukset täysistä löytökiekkolaatikoista</H2>
+
+      <BinFullQrPosterButtons />
+
+      {binFullNotifications.length > 0 && (
+        <div className="mb-4">
+          <fetcher.Form
+            method="post"
+            onSubmit={(e) => {
+              if (!confirm('Haluatko varmasti poistaa kaikki ilmoitukset?')) {
+                e.preventDefault();
+              }
+            }}
+          >
+            <input type="hidden" name="intent" value="deleteAllBinFull" />
+            <Button variant="outlined" size="small" color="error" type="submit">
+              Poista kaikki
+            </Button>
+          </fetcher.Form>
+        </div>
+      )}
+
+      {binFullNotifications.length === 0 && <p className="text-gray-500">Ei ilmoituksia.</p>}
+
+      {binFullNotifications.map((notification: BinFullNotificationDTO) => (
+        <BinFullNotificationItem key={notification.id} notification={notification} />
       ))}
     </div>
   );

--- a/app/types.ts
+++ b/app/types.ts
@@ -79,6 +79,14 @@ export type DiscFoundNotificationDTO = {
   readAt?: string | null;
 };
 
+export type BinFullNotificationDTO = {
+  id?: number;
+  createdAt?: string | null;
+  clubId: number;
+  courseName: string;
+  readAt?: string | null;
+};
+
 export type DbDiscType = {
   id?: number | null;
   internal_disc_id: number;

--- a/prompts/full-bin.md
+++ b/prompts/full-bin.md
@@ -1,0 +1,60 @@
+# Full bin
+
+There is lost and found box for disc golfs on a course that I do not visit as often.
+During the season, the lost and found bin might get full and now new discs fit.
+
+In such case it would be good if the user, who tried to add a new disc to the bin, could easily report
+that the bin is full
+
+I want to be able to print out a paper with a QR code and a suitable title that the user may take a 
+photo with his phone. When the url in the QR code is loaded, the user can click on a button saying
+"Bin is full".
+
+Previously we implemented a similar feature where the user could scan a QR code and report that he had 
+returned a disc. Check that implementation for a reference. I need a similar download feature for the
+pdf file.
+
+## Specs
+- route: bin/full/:course-name
+  - bin/full/oittaa
+  - use puskasoturit logo
+  - currently only one course needs this
+
+
+
+## Claude
+
+⏺ Plan
+
+1. Route: app/routes/bin.full.$courseSlug.tsx → /bin/full/oittaa
+- Puskasoturit logo, Finnish heading ("Löytökiekkolaatikko täynnä?")
+- Single "Laatikko on täynnä" button; on submit writes a row and shows "Kiitos ilmoituksesta!"
+- Mirrors existing notify.$courseSlug.tsx pattern
+
+2. DB + server model: new bin_full_notifications table (id, created_at, club_id, course_name,
+   read_at). New app/models/binFullNotification.server.ts mirroring
+   discFoundNotification.server.ts. No contact fields (spec says just a button).
+
+3. PDF poster: new component for the "bin full" variant with Puskasoturit logo and a matching
+   title (e.g. "Laatikko täynnä?"). Reuses the QR-generation / download flow from the existing
+   QrPosterButtons.tsx.
+
+4. Admin view: add a poster-download button on the existing /notifications page. Reports
+   viewable in a small section on that same page (vs. a separate route).
+
+Questions
+
+1. DB migration — you handle Supabase schema yourself? I'll write the SQL but not apply it.
+2. Spam / rate-limit — accept that anyone with the QR can click freely, or ignore repeat clicks
+   within a short window?
+3. View reports — OK to add a section on /notifications, or prefer a separate route?
+
+Your plan is sound.
+
+Answers to questions:
+
+Q1: A proper migration for this new feature would be nice if it's easy to run
+
+Q2: Some kind of "rate limit" could be added yes
+
+Q3: OK

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,3 @@
+# Supabase
+.branches
+.temp

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,30 @@
+# Supabase migrations
+
+Each file in `migrations/` is a plain SQL script applied in filename order.
+
+## Running migrations
+
+Two options.
+
+### A. Supabase CLI (recommended once linked)
+
+First-time setup:
+
+```bash
+npx supabase login
+npx supabase link --project-ref <your-project-ref>
+```
+
+Then, from the repo root:
+
+```bash
+npx supabase db push
+```
+
+Pushes any un-applied migrations under `supabase/migrations/` to the linked
+remote project.
+
+### B. Paste into the SQL Editor
+
+Open the Supabase dashboard for your project, go to the SQL Editor, and paste
+the contents of the migration file. Run it once.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,108 @@
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "lost-and-found"
+
+[api]
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. public and storage are always included.
+schemas = ["public", "storage", "graphql_public"]
+# Extra schemas to add to the search_path of every request. public is always included.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialise the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://localhost"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+
+[storage]
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+[auth]
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://localhost:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://localhost:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = true
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+
+# Configure one of the supported SMS providers: `twilio`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+
+[analytics]
+enabled = false
+port = 54327
+vector_port = 54328
+# Setup BigQuery project to enable log viewer on local development stack.
+# See: https://supabase.com/docs/guides/getting-started/local-development#enabling-local-logging
+gcp_project_id = ""
+gcp_project_number = ""
+gcp_jwt_path = "supabase/gcloud.json"

--- a/supabase/migrations/20260424000000_bin_full_notifications.sql
+++ b/supabase/migrations/20260424000000_bin_full_notifications.sql
@@ -1,0 +1,36 @@
+-- Bin-full notifications: signaled by a public user scanning a QR code when
+-- the lost-and-found bin on a course is full and no new discs fit.
+
+CREATE TABLE IF NOT EXISTS public.bin_full_notifications (
+  id          BIGSERIAL PRIMARY KEY,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  club_id     BIGINT NOT NULL,
+  course_name TEXT NOT NULL,
+  read_at     TIMESTAMPTZ
+);
+
+ALTER TABLE public.bin_full_notifications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow public insert"
+  ON public.bin_full_notifications
+  FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Allow authenticated select"
+  ON public.bin_full_notifications
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Allow authenticated update"
+  ON public.bin_full_notifications
+  FOR UPDATE
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Allow authenticated delete"
+  ON public.bin_full_notifications
+  FOR DELETE
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
## Summary
- New public route `/bin/full/:courseSlug` (e.g. `/bin/full/oittaa`): single-button "Laatikko on täynnä" form that writes to a new `bin_full_notifications` table
- Admin view on `/notifications`: second section listing bin-full reports with mark-as-read / delete / delete-all, plus a new "QR (täysi laatikko): …" poster button (Puskasoturit logo, A4 PDF, targets `/bin/full/<slug>`)
- Cookie-based rate limit (10 min per course, per browser) shows the confirmation state on repeat visits and skips the duplicate insert
- Includes the Supabase migration (table + RLS: public INSERT, authenticated SELECT/UPDATE/DELETE) plus `supabase init` scaffolding for future migrations

## Test plan
- [ ] Run `supabase/migrations/20260424000000_bin_full_notifications.sql` against the Supabase project (SQL Editor or `supabase db push`)
- [ ] Visit `/bin/full/oittaa` — confirmation screen appears after submit; row lands in `bin_full_notifications` in Supabase
- [ ] Refresh `/bin/full/oittaa` within 10 min — confirmation shown, no new row created
- [ ] Wait 10 min (or clear `bin_full_rl_oittaa` cookie) — button returns, submit creates another row
- [ ] Visit `/bin/full/nonexistent-slug` — 404 page
- [ ] Sign in and visit `/notifications`
  - Click "QR (täysi laatikko): Oittaan frisbeegolfrata" — `oittaa-bin-full-qr.pdf` downloads, single A4 page, Puskasoturit logo + title "Löytökiekkolaatikko täynnä?" + QR pointing at `/bin/full/oittaa`
  - Bin-full section lists all reports with timestamp + course name
  - "Merkitse luetuksi" toggles read state
  - "Poista" removes a single row (with confirm)
  - "Poista kaikki" removes all bin-full rows (with confirm), disc-found section unaffected
- [ ] Existing disc-found notify/QR poster flow still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)