### PR TITLE
feat: add sort direction indicators to disc table

### DIFF
--- a/app/routes/DiscTable.tsx
+++ b/app/routes/DiscTable.tsx
@@ -7,10 +7,12 @@ import { Link, useOutletContext } from '@remix-run/react';
 import { add, isAfter } from 'date-fns';
 
 import styled from '@emotion/styled';
-import WarningIcon from '@mui/icons-material/Warning';
+import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
+import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import TextsmsIcon from '@mui/icons-material/Textsms';
+import WarningIcon from '@mui/icons-material/Warning';
 
-import type { SortColumn } from 'react-data-grid';
+import type { RenderSortStatusProps, SortColumn } from 'react-data-grid';
 import DataGrid from 'react-data-grid';
 
 import type { DiscDTO } from '~/types';
@@ -81,7 +83,39 @@ const StyledDataGrid = styled(DataGrid)`
   & .rdg-row-even {
     background: rgb(63, 60, 60);
   }
+
+  & .rdg-header-row .rdg-cell {
+    transition: background-color 0.15s ease;
+  }
+
+  & .rdg-header-row .rdg-cell:hover {
+    background-color: rgba(255, 255, 255, 0.06);
+  }
+
+  & .rdg-header-row .rdg-cell[aria-sort='ascending'],
+  & .rdg-header-row .rdg-cell[aria-sort='descending'] {
+    background-color: rgba(255, 255, 255, 0.09);
+  }
 `;
+
+const SortIcon = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  margin-inline-start: 0.25rem;
+  color: rgba(255, 255, 255, 0.7);
+
+  & svg {
+    font-size: 1rem;
+  }
+`;
+
+function renderSortStatus({ sortDirection }: RenderSortStatusProps): JSX.Element | null {
+  if (!sortDirection) {
+    return null;
+  }
+
+  return <SortIcon>{sortDirection === 'ASC' ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}</SortIcon>;
+}
 
 const isInDangerOfBeingDonatedOrSold = (dateStr: string): boolean => {
   const date = add(new Date(dateStr), { months: 3 });
@@ -186,6 +220,7 @@ export default function DiscTable({ discs }: DiscTableProps): JSX.Element | null
       columns={getColumns(isLoggedIn())}
       sortColumns={sortColumns}
       onSortColumnsChange={setSortColumns}
+      renderers={{ renderSortStatus }}
     />
   );
 }

--- a/prompts/support for adding multiple discs through website.md
+++ b/prompts/support for adding multiple discs through website.md
@@ -1,0 +1,23 @@
+# Support for adding multiple discs through website
+
+Currently new discs can only be added by first inserting them into a google sheet and then running
+and import script, that fetches new rows from the sheet into database.
+
+So far it has worked, but I'd like to investigate how much work it would take to make it possible
+to add 1 or more discs through the same web app that lists the discs.
+
+Top priority is to make it easy and quick to add multiple discs at once, in a similar way as how a 
+google sheet works. That is, not by submitting a form multiple times.
+
+The tool would need to mimic a spreadsheet.
+
+In addition to be able to quickly add multiple discs, I also need a way to modify details of multiple 
+discs.
+
+Below are some data that I need to fill in when adding a new disc:
+- disc name (and plastic) of Disc ("Mako3, Star", "FD, C-Line", "Undertaker, Titanium") where names
+  are Mako3, FD and Undertaker and plastics are Star, C-Line and Titanium
+- owner name
+- owner phonenumber
+- disc color
+- club


### PR DESCRIPTION
## Summary
- Add ascending/descending arrow icons to sorted columns in the disc table via a custom `renderSortStatus` renderer
- Add hover and active-sort background styling to the data grid header cells for clearer interaction feedback
- Add a prompt note for upcoming multi-disc website support

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Sort a column in the disc table and confirm the arrow icon reflects the direction
- [ ] Hover header cells and confirm the highlight appears; sorted column shows the active background

🤖 Generated with [Claude Code](https://claude.com/claude-code)