### PR TITLE
fix: exclude discs.syncItem.tsx from route generation

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -17,6 +17,7 @@ export default flatRoutes({
     '**/AdminMenu.tsx',
     '**/DiscSelector.tsx',
     '**/DiscTable.tsx',
+    '**/discs.syncItem.tsx',
     '**/Header.tsx',
     '**/utils.ts',
     '**/components/**',


### PR DESCRIPTION
## Problem

`/discs/sync` crashes (locally and in production) with:

```
TypeError: Cannot read properties of undefined (reading 'id')
    at SyncItem (app/routes/discs.syncItem.tsx:21)
```

## Root cause

`discs.syncItem.tsx` is a **shared component**, rendered as `<SyncItem club={club} />` inside `discs.sync.tsx`. But its dotted filename made `flatRoutes` register it as the route `/discs/syncItem`. React Router 7 wraps every route module's default export with `UNSAFE_withComponentProps`, which **replaces** props passed at the call site with route props — so `club` arrived as `undefined` and `club.id` threw.

This is the same class of issue the RR7 migration already handled for `AdminMenu`, `DiscTable`, `DiscSelector`, `Header`, and `utils` via `ignoredRouteFiles`; `discs.syncItem.tsx` was simply missed.

## Fix

Add `'**/discs.syncItem.tsx'` to `ignoredRouteFiles` so it stays a plain component. It was the only directly-imported shared component still missing from the list.

## Verification

- `react-router typegen` — `/discs/syncItem` no longer generated as a route
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)