### PR TITLE
chore: upgrade date-fns 2.30.0 → 4.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@supabase/supabase-js": "^2.108.2",
         "@types/qrcode": "^1.5.6",
         "@vercel/react-router": "^1.3.1",
-        "date-fns": "2.30.0",
+        "date-fns": "^4.4.0",
         "isbot": "^5.1.43",
         "lodash.debounce": "4.0.8",
         "qrcode": "^1.5.4",
@@ -4576,18 +4576,13 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -13029,12 +13024,9 @@
       }
     },
     "date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "requires": {
-        "@babel/runtime": "^7.21.0"
-      }
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="
     },
     "debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@supabase/supabase-js": "^2.108.2",
     "@types/qrcode": "^1.5.6",
     "@vercel/react-router": "^1.3.1",
-    "date-fns": "2.30.0",
+    "date-fns": "^4.4.0",
     "isbot": "^5.1.43",
     "lodash.debounce": "4.0.8",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## What
`date-fns` 2.30.0 → 4.4.0 (across two majors, v3 + v4).

## Surface
Used in 6 files via `format`, `parse`, `add`, `isAfter`, `getMonth`, `getYear`, `isWithinInterval`, `lastDayOfMonth`:
- `app/import/PuskaSoturitImporter.ts`, `app/import/TalinTallaajatImporter.ts`
- `app/routes/utils.ts`, `app/routes/DiscTable.tsx`
- `app/routes/components/admin/stats/stats-utils.ts`, `.../DiscsReturnedToOwner.tsx`

All are stable-signature functions across v2→v4, so **no source changes were needed**. v4's generic `DateArg` typing introduced no type errors.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- Runtime check of every call-site pattern on v4 — all produce identical, correct output:
  - `parse('15/03/2024','dd/MM/y')` → `2024-03-15`; `parse('5.3.2024','d.M.y')` → `2024-03-05`
  - `getMonth`/`getYear` from `parse(...,'d.M.yyyy')`
  - DiscTable bin logic: `add(date, {months:3})` + `isAfter`
  - `lastDayOfMonth` (leap-year Feb 2024 → `2024-02-29`) + `isWithinInterval`

Note: the importers' `format(parse('', ...))` invalid-date path throws in both v2 and v4 identically — pre-existing behaviour, not a regression from this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)