### PR TITLE
feat: migrate H3 + Wrapper leaf components to StyleX

### DIFF
--- a/app/routes/components/H3.tsx
+++ b/app/routes/components/H3.tsx
@@ -1,14 +1,17 @@
-import styled from '@emotion/styled';
+import * as stylex from '@stylexjs/stylex';
 
-const Heading2 = styled.h2`
-  font-weight: bold;
+import { font } from '~/styles/tokens.stylex';
 
-  font-size: 1rem;
-
-  @media (min-width: 600px) {
-    font-size: 1.5rem;
-  }
-`;
+const styles = stylex.create({
+  // Preserves the original markup: this component renders an <h2> element.
+  heading: {
+    fontWeight: font.weightBold,
+    fontSize: {
+      default: font.sizeMd,
+      '@media (min-width: 600px)': '1.5rem',
+    },
+  },
+});
 
 type H3Props = {
   children: JSX.Element | string;
@@ -16,5 +19,10 @@ type H3Props = {
 };
 
 export default function H3({ children, className }: H3Props): JSX.Element {
-  return <Heading2 className={className}>{children}</Heading2>;
+  const { className: sxClassName, style } = stylex.props(styles.heading);
+  return (
+    <h2 className={[sxClassName, className].filter(Boolean).join(' ')} style={style}>
+      {children}
+    </h2>
+  );
 }

--- a/app/routes/components/Wrapper.tsx
+++ b/app/routes/components/Wrapper.tsx
@@ -1,16 +1,27 @@
 import type { ReactNode } from 'react';
-import styled from '@emotion/styled';
 
-const Div = styled.div`
-  width: 100%;
-  max-width: 40rem;
-  margin-bottom: 1rem;
-`;
+import * as stylex from '@stylexjs/stylex';
+
+import { space } from '~/styles/tokens.stylex';
+
+const styles = stylex.create({
+  wrapper: {
+    width: '100%',
+    maxWidth: '40rem',
+    marginBottom: space.md,
+  },
+});
 
 type WrapperProps = {
   className?: string;
   children: ReactNode;
 };
+
 export default function Wrapper({ className, children }: WrapperProps): JSX.Element {
-  return <Div className={className}>{children}</Div>;
+  const { className: sxClassName, style } = stylex.props(styles.wrapper);
+  return (
+    <div className={[sxClassName, className].filter(Boolean).join(' ')} style={style}>
+      {children}
+    </div>
+  );
 }


### PR DESCRIPTION
## What
Continues the StyleX migration (after the foundation in #42) with two pure `@emotion/styled` → StyleX conversions.

- **`H3`** — bold weight + responsive font-size; preserves the original `<h2>` markup.
- **`Wrapper`** — width / max-width / margin-bottom (`marginBottom` via the `space.md` token).

Both follow the proven `H2` pattern: merge StyleX's generated `className` with the caller-supplied one so callers' Tailwind utilities keep applying during coexistence. **Exact visual fidelity** — same CSS properties, no value changes.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- Both rules land in the global `root-*.css` (served app-wide via `<Links/>`) — `1.5rem` (H3 media) and `40rem` (Wrapper max-width) confirmed present.
- `@emotion/styled` removed from both files.

## Deferred to a follow-up (MUI-component replacement — needs visual checks)
`Label` (MUI `InputLabel` → native `<label>`; all call sites pass only `htmlFor`, so safe), `PaperItem` (MUI `Paper`), `InfoBox` (MUI `CloseIcon` → inline SVG). These replicate MUI styling, so they warrant their own PR with a preview look.

## Progress
Emotion `styled` components migrated: H2, H3, Wrapper (3 of ~13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)