### PR TITLE
feat: migrate Label/PaperItem/InfoBox off MUI to StyleX

### DIFF
--- a/app/routes/components/InfoBox.tsx
+++ b/app/routes/components/InfoBox.tsx
@@ -1,31 +1,34 @@
-import styled from '@emotion/styled';
+import * as stylex from '@stylexjs/stylex';
 
-import CloseIcon from '@mui/icons-material/Close';
+import { font, space } from '~/styles/tokens.stylex';
 
-const H3 = styled.h2`
-  font-weight: bold;
-
-  font-size: 1rem;
-
-  @media (min-width: 600px) {
-    font-size: 1.25rem;
-  }
-`;
-
-const Ul = styled.ul`
-  margin-bottom: 1rem;
-`;
-
-const Li = styled.li`
-  list-style: disc;
-  margin-left: 1rem;
-`;
-
-const StyledCloseIcon = styled(CloseIcon)`
-  &:hover {
-    cursor: pointer;
-  }
-`;
+const styles = stylex.create({
+  heading: {
+    fontWeight: font.weightBold,
+    fontSize: {
+      default: font.sizeMd,
+      '@media (min-width: 600px)': font.sizeLg,
+    },
+  },
+  ul: {
+    marginBottom: space.md,
+  },
+  li: {
+    listStyle: 'disc',
+    marginLeft: space.md,
+  },
+  // Replaces the MUI CloseIcon: a bare icon button (also fixes the previous
+  // keyboard-inaccessible clickable icon).
+  closeButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: 0,
+    border: 'none',
+    background: 'none',
+    color: 'inherit',
+    cursor: 'pointer',
+  },
+});
 
 type InfoBoxProps = {
   onClose: () => void;
@@ -34,8 +37,12 @@ export default function InfoBox({ onClose }: InfoBoxProps): JSX.Element {
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
-        <H3>Ohjeet</H3>
-        <StyledCloseIcon onClick={onClose} />
+        <h2 {...stylex.props(styles.heading)}>Ohjeet</h2>
+        <button type="button" onClick={onClose} aria-label="Sulje" {...stylex.props(styles.closeButton)}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+          </svg>
+        </button>
       </div>
 
       <p>
@@ -47,15 +54,15 @@ export default function InfoBox({ onClose }: InfoBoxProps): JSX.Element {
         Jos olet sitä mieltä (tai epäilet), että listalta löytyvä kiekko on sinun, laita mahdollisimman tarkat tiedot
         kiekosta:
       </p>
-      <Ul>
-        <Li>nimi</Li>
-        <Li>väri</Li>
-        <Li>muovi</Li>
-        <Li>kiekosta mahdollisesti löytyvä nimi ja puhelinnumero</Li>
-        <Li>paino</Li>
-        <Li>stämpin väri</Li>
-        <Li>onko ns. spessu (Nate Sexton Firebird, Cloud Breaker, Doom Bird etc)</Li>
-      </Ul>
+      <ul {...stylex.props(styles.ul)}>
+        <li {...stylex.props(styles.li)}>nimi</li>
+        <li {...stylex.props(styles.li)}>väri</li>
+        <li {...stylex.props(styles.li)}>muovi</li>
+        <li {...stylex.props(styles.li)}>kiekosta mahdollisesti löytyvä nimi ja puhelinnumero</li>
+        <li {...stylex.props(styles.li)}>paino</li>
+        <li {...stylex.props(styles.li)}>stämpin väri</li>
+        <li {...stylex.props(styles.li)}>onko ns. spessu (Nate Sexton Firebird, Cloud Breaker, Doom Bird etc)</li>
+      </ul>
       <p>
         Jos kiekosta puuttuu nimi ja puhelinnumero ja kyseessä ns stockikiekko (perus kaupan hyllystä löytyvä
         normikiekko), ovat mahdollisuudet saada kiekko takaisin heikot, ellet tarkkaan tiedä kiekon väriä, muovia,

--- a/app/routes/components/Label.tsx
+++ b/app/routes/components/Label.tsx
@@ -1,17 +1,33 @@
-import styled from '@emotion/styled';
-import InputLabel from '@mui/material/InputLabel';
-import type { InputLabelProps } from '@mui/material/InputLabel';
+import type { LabelHTMLAttributes } from 'react';
 
-const StyledLabel = styled(InputLabel)`
-  font-weight: 700;
-  --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity));
-`;
+import * as stylex from '@stylexjs/stylex';
 
-interface FooProps extends InputLabelProps<'label'> {
+import { color, font } from '~/styles/tokens.stylex';
+
+const styles = stylex.create({
+  // Replaces MUI InputLabel: block label, bold, gray-700 text (the only styles
+  // the previous component actually set; the rest were MUI defaults).
+  label: {
+    display: 'block',
+    fontWeight: font.weightBold,
+    fontSize: font.sizeMd,
+    color: color.textSecondary,
+  },
+});
+
+type LabelProps = LabelHTMLAttributes<HTMLLabelElement> & {
   children: JSX.Element | string;
-}
+};
 
-export default function Label({ children, ...rest }: FooProps): JSX.Element {
-  return <StyledLabel {...rest}>{children}</StyledLabel>;
+export default function Label({ children, className, style, ...rest }: LabelProps): JSX.Element {
+  const props = stylex.props(styles.label);
+  return (
+    <label
+      {...rest}
+      className={[props.className, className].filter(Boolean).join(' ')}
+      style={{ ...props.style, ...style }}
+    >
+      {children}
+    </label>
+  );
 }

--- a/app/routes/components/PaperItem.tsx
+++ b/app/routes/components/PaperItem.tsx
@@ -1,8 +1,25 @@
-import Paper from '@mui/material/Paper';
+import * as stylex from '@stylexjs/stylex';
+
+import { color, radius, space } from '~/styles/tokens.stylex';
+
+const styles = stylex.create({
+  // Replaces MUI <Paper elevation={1}> + the `mt-8 p-4` Tailwind utilities.
+  // Shadow is MUI's exact elevation-1 value; radius is MUI's default (4px).
+  paper: {
+    marginTop: space.xl,
+    padding: space.md,
+    backgroundColor: color.surface,
+    color: color.textPrimary,
+    borderRadius: radius.sm,
+    boxShadow:
+      '0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)',
+  },
+});
 
 type PaperItemProps = {
   children: string | JSX.Element | JSX.Element[];
 };
+
 export default function PaperItem({ children }: PaperItemProps): JSX.Element {
-  return <Paper className={'mt-8 p-4'} elevation={1} children={children} />;
+  return <div {...stylex.props(styles.paper)}>{children}</div>;
 }


### PR DESCRIPTION
## What
First batch that drops **actual MUI components** (not just Emotion), each kept faithful to the current rendering.

- **`Label`** — MUI `InputLabel` → native `<label>` + StyleX (block, bold, gray-700 via `color.textSecondary`, which is exactly `#374151`). All call sites pass only `htmlFor`, so switching the prop contract to label attributes is safe.
- **`PaperItem`** — MUI `<Paper elevation={1}>` + `mt-8 p-4` → styled `<div>`; MUI's **exact** elevation-1 shadow + default 4px radius, spacing via tokens.
- **`InfoBox`** — Emotion `styled` (h2/ul/li) → StyleX; MUI `CloseIcon` → inline Material "close" SVG inside a real `<button>` (also **fixes** the previously keyboard-inaccessible clickable icon).

## Dependency impact
Removes the app's **last** `@mui/material/InputLabel` and `@mui/icons-material/Close` usages. (MUI `Paper` is still imported by `_index`, `message-templates`, `MessagePreview` — future batches.)

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors; warnings 17→16, the clickable-icon a11y issue cleared) · `build` ✓
- All migrated rules land in the global `root-*.css` (lightningcss-minified): PaperItem shadow `0 2px 1px -1px #0003,…` (= MUI elevation 1), `list-style:disc`, gray-700.

## ⚠️ Worth a preview look
These replace MUI components with replicated styling — most visual change so far. Suggest eyeballing a form (`/sign-in` labels), a `PaperItem` (the message-send page), and the InfoBox panel on a preview.

## Progress
Emotion `styled`: H2, H3, Wrapper, InfoBox migrated. MUI components: InputLabel + Close icon fully removed; Button/TextField/Select/Paper/etc. remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)