### PR TITLE
feat: replace MUI Paper with a StyleX Paper component

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
-import Paper from '@mui/material/Paper';
+import Paper from '~/routes/components/Paper';
 import InfoBox from '~/routes/components/InfoBox';
 import EmptyingLogItem from '~/routes/components/EmptyingLogItem';
 import WarningIcon from '@mui/icons-material/Warning';

--- a/app/routes/components/Paper.tsx
+++ b/app/routes/components/Paper.tsx
@@ -1,0 +1,45 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { color, radius } from '~/styles/tokens.stylex';
+
+// StyleX replacement for MUI <Paper>. Shadows are MUI's exact elevation values;
+// radius matches MUI's default (4px). Only the elevations actually used in the
+// app are provided.
+const styles = stylex.create({
+  base: {
+    backgroundColor: color.surface,
+    color: color.textPrimary,
+    borderRadius: radius.sm,
+  },
+  e1: {
+    boxShadow: '0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)',
+  },
+  e3: {
+    boxShadow: '0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)',
+  },
+  e7: {
+    boxShadow: '0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)',
+  },
+});
+
+const shadowByElevation = { 1: styles.e1, 3: styles.e3, 7: styles.e7 };
+
+type Elevation = keyof typeof shadowByElevation;
+
+type PaperProps = {
+  elevation?: Elevation;
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+};
+
+export default function Paper({ elevation = 1, className, style, children }: PaperProps): JSX.Element {
+  const props = stylex.props(styles.base, shadowByElevation[elevation]);
+  return (
+    <div className={[props.className, className].filter(Boolean).join(' ')} style={{ ...props.style, ...style }}>
+      {children}
+    </div>
+  );
+}

--- a/app/routes/components/admin/MessagePreview.tsx
+++ b/app/routes/components/admin/MessagePreview.tsx
@@ -1,5 +1,5 @@
 import H3 from '../H3';
-import Paper from '@mui/material/Paper';
+import Paper from '~/routes/components/Paper';
 
 type MessagePreviewProps = {
   message: string;

--- a/app/routes/message-templates.tsx
+++ b/app/routes/message-templates.tsx
@@ -2,7 +2,7 @@ import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { redirect } from 'react-router';
 import { Link, useLoaderData } from 'react-router';
 
-import Paper from '@mui/material/Paper';
+import Paper from '~/routes/components/Paper';
 import Button from '@mui/material/Button';
 
 import { getMessageTemplates, deleteMessageTemplate, markAsDefault } from '~/models/messageTemplate.server';
@@ -58,7 +58,7 @@ export default function MessageTemplatesPage(): JSX.Element {
             <Paper
               key={messageTemplate.id}
               className={messageTemplate.isDefault ? 'mb-8 mt-8' : 'mt-8'}
-              sx={messageTemplate.isDefault ? { border: 'solid rgba(2, 208, 232, 0.85) 4px' } : {}}
+              style={messageTemplate.isDefault ? { border: 'solid rgba(2, 208, 232, 0.85) 4px' } : undefined}
               elevation={messageTemplate.isDefault ? 7 : 1}
               children={<MessageTemplateItem messageTemplate={messageTemplate} />}
             />


### PR DESCRIPTION
## What
Adds `app/routes/components/Paper.tsx` — a near drop-in for MUI `<Paper>` built on StyleX (MUI's **exact** elevation shadows for 1/3/7, the only elevations used; default 4px radius). Migrates the 3 remaining MUI Paper usages to it.

- `_index` (`elevation={3}`), `MessagePreview` (`elevation={1}`), `message-templates` (`elevation={1|7}` + a border on the default template — `sx` → `style`).
- **Removes `@mui/material/Paper` from the app entirely.**

API: `elevation?: 1|3|7`, `className`, `style`, `children`. `className` is merged with StyleX's generated class so callers' Tailwind utilities (`mt-8`, `mb-8`) still apply.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- elevation-3 (`0 3px 3px -2px #0003,…`) and elevation-7 (`…0 2px 16px 1px…`) shadows confirmed in the global `root-*.css`, matching MUI's values (lightningcss-minified).

## Note
`PaperItem` keeps its own inline elevation-1 shadow — it could later delegate to this `Paper` to dedupe, but I left it to keep this diff focused on removing the MUI dependency.

## Progress
MUI components removed so far: `InputLabel`, `Close` icon, **`Paper`**. Remaining: `Button`, `TextField`, `Select`, `Autocomplete`, `Checkbox`, `Radio`, `FormControlLabel`, `Collapse`, `CircularProgress`, `MenuItem` + 4 icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)