### PR TITLE
feat: replace MUI Button with a StyleX Button

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,7 +4,7 @@ import debounce from 'lodash.debounce';
 
 import styled from '@emotion/styled';
 
-import Button from '@mui/material/Button';
+import Button from '~/routes/components/Button';
 import Collapse from '@mui/material/Collapse';
 import Paper from '~/routes/components/Paper';
 import InfoBox from '~/routes/components/InfoBox';

--- a/app/routes/components/BinFullForm.tsx
+++ b/app/routes/components/BinFullForm.tsx
@@ -1,6 +1,6 @@
 import { Form, useActionData } from 'react-router';
 
-import { Button } from '@mui/material';
+import Button from '~/routes/components/Button';
 
 import H2 from './H2';
 

--- a/app/routes/components/Button.tsx
+++ b/app/routes/components/Button.tsx
@@ -1,0 +1,161 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+import { Link } from 'react-router';
+import * as stylex from '@stylexjs/stylex';
+
+import { color, radius } from '~/styles/tokens.stylex';
+
+type Variant = 'contained' | 'outlined' | 'text';
+type ButtonColor = 'primary' | 'error';
+type Size = 'small' | 'medium' | 'large';
+
+// StyleX replacement for MUI <Button>, faithful to the variants/colors/sizes the
+// app uses. Tokens: color.accent = MUI primary (#1976d2), color.danger = MUI
+// error (#d32f2f).
+const styles = stylex.create({
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    boxSizing: 'border-box',
+    minWidth: '64px',
+    border: 'none',
+    borderRadius: radius.sm,
+    fontFamily: 'inherit',
+    fontWeight: 500,
+    lineHeight: 1.75,
+    letterSpacing: '0.02857em',
+    textTransform: 'uppercase',
+    textDecoration: 'none',
+    cursor: 'pointer',
+    transition: 'background-color 0.2s, box-shadow 0.2s, border-color 0.2s',
+  },
+
+  small: { padding: '4px 10px', fontSize: '0.8125rem' },
+  medium: { padding: '6px 16px', fontSize: '0.875rem' },
+  large: { padding: '8px 22px', fontSize: '0.9375rem' },
+
+  fullWidth: { width: '100%' },
+
+  // contained
+  containedPrimary: {
+    color: color.onAccent,
+    backgroundColor: { default: color.accent, ':hover': color.accentHover },
+    boxShadow: {
+      default: '0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)',
+      ':hover': '0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)',
+    },
+  },
+  containedError: {
+    color: color.onAccent,
+    backgroundColor: { default: color.danger, ':hover': '#c62828' },
+    boxShadow: {
+      default: '0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)',
+      ':hover': '0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)',
+    },
+  },
+
+  // outlined
+  outlinedPrimary: {
+    color: color.accent,
+    backgroundColor: { default: 'transparent', ':hover': 'rgba(25,118,210,0.04)' },
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: { default: 'rgba(25,118,210,0.5)', ':hover': color.accent },
+  },
+  outlinedError: {
+    color: color.danger,
+    backgroundColor: { default: 'transparent', ':hover': 'rgba(211,47,47,0.04)' },
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: { default: 'rgba(211,47,47,0.5)', ':hover': color.danger },
+  },
+
+  // text
+  textPrimary: {
+    color: color.accent,
+    backgroundColor: { default: 'transparent', ':hover': 'rgba(25,118,210,0.04)' },
+  },
+  textError: {
+    color: color.danger,
+    backgroundColor: { default: 'transparent', ':hover': 'rgba(211,47,47,0.04)' },
+  },
+
+  disabled: {
+    color: 'rgba(0,0,0,0.26)',
+    backgroundColor: 'rgba(0,0,0,0.12)',
+    boxShadow: 'none',
+    borderColor: 'rgba(0,0,0,0.12)',
+    cursor: 'default',
+    pointerEvents: 'none',
+  },
+});
+
+const sizeStyle = {
+  small: styles.small,
+  medium: styles.medium,
+  large: styles.large,
+} as const;
+
+const variantStyle = {
+  contained: { primary: styles.containedPrimary, error: styles.containedError },
+  outlined: { primary: styles.outlinedPrimary, error: styles.outlinedError },
+  text: { primary: styles.textPrimary, error: styles.textError },
+} as const;
+
+type ButtonProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'color'> & {
+  variant?: Variant;
+  color?: ButtonColor;
+  size?: Size;
+  fullWidth?: boolean;
+  // When set, renders a React Router <Link> styled as a button (replaces the
+  // former MUI `component={Link}` polymorphism).
+  to?: string;
+  children: ReactNode;
+};
+
+export default function Button({
+  variant = 'text',
+  color: buttonColor = 'primary',
+  size = 'medium',
+  fullWidth,
+  to,
+  disabled,
+  className,
+  style,
+  children,
+  ...rest
+}: ButtonProps): JSX.Element {
+  const sx = stylex.props(
+    styles.base,
+    sizeStyle[size],
+    variantStyle[variant][buttonColor],
+    fullWidth && styles.fullWidth,
+    disabled && styles.disabled,
+  );
+  const merged = [sx.className, className].filter(Boolean).join(' ');
+  const mergedStyle = { ...sx.style, ...style };
+
+  if (to) {
+    // External schemes (sms:, mailto:, tel:, http:) must be plain anchors;
+    // React Router <Link> is only for in-app navigation.
+    if (/^[a-z][a-z0-9+.-]*:/i.test(to)) {
+      return (
+        <a href={to} className={merged} style={mergedStyle}>
+          {children}
+        </a>
+      );
+    }
+    return (
+      <Link to={to} className={merged} style={mergedStyle}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <button {...rest} disabled={disabled} className={merged} style={mergedStyle}>
+      {children}
+    </button>
+  );
+}

--- a/app/routes/components/NotifyForm.tsx
+++ b/app/routes/components/NotifyForm.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Form, useActionData } from 'react-router';
 
-import { TextField, Button, Collapse, RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import { TextField, Collapse, RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import Button from '~/routes/components/Button';
 
 import H2 from './H2';
 import Wrapper from './Wrapper';
@@ -29,7 +30,7 @@ export default function NotifyForm({ course }: NotifyFormProps): JSX.Element {
           variant="outlined"
           size="large"
           fullWidth
-          sx={{ maxWidth: '20rem' }}
+          style={{ maxWidth: '20rem' }}
           onClick={() => window.location.reload()}
         >
           Lähetä uusi ilmoitus

--- a/app/routes/components/admin/BinFullQrPosterButtons.tsx
+++ b/app/routes/components/admin/BinFullQrPosterButtons.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@mui/material';
+import Button from '~/routes/components/Button';
 import QRCode from 'qrcode';
 
 import type { Course } from '~/config/courses';

--- a/app/routes/components/admin/EmptyingLogItem.tsx
+++ b/app/routes/components/admin/EmptyingLogItem.tsx
@@ -1,5 +1,5 @@
 import type { EmptyingLogDTO } from '~/types';
-import Button from '@mui/material/Button';
+import Button from '~/routes/components/Button';
 
 type EmptyingLogItemProps = {
   item: EmptyingLogDTO;

--- a/app/routes/components/admin/MessageTemplateItem.tsx
+++ b/app/routes/components/admin/MessageTemplateItem.tsx
@@ -1,6 +1,6 @@
-import { useFetcher, Link } from 'react-router';
+import { useFetcher } from 'react-router';
 
-import Button from '@mui/material/Button';
+import Button from '~/routes/components/Button';
 
 import { formatDate } from '~/routes/utils';
 import type { MessageTemplateDTO } from '~/types';
@@ -29,7 +29,7 @@ export default function MessageTemplateItem({ messageTemplate }: MessageTemplate
           <Button name="action" value={'default'} type="submit">
             Merkitse oletukseksi
           </Button>
-          <Button component={Link} to={`/message-template/${messageTemplate.id}/edit`}>
+          <Button to={`/message-template/${messageTemplate.id}/edit`}>
             Muokkaa
           </Button>
           <Button

--- a/app/routes/components/admin/QrPosterButtons.tsx
+++ b/app/routes/components/admin/QrPosterButtons.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@mui/material';
+import Button from '~/routes/components/Button';
 import QRCode from 'qrcode';
 
 import type { Course } from '~/config/courses';

--- a/app/routes/discs.syncItem.tsx
+++ b/app/routes/discs.syncItem.tsx
@@ -1,4 +1,4 @@
-import Button from '@mui/material/Button';
+import Button from '~/routes/components/Button';
 
 import type { ClubDTO } from '~/types';
 

--- a/app/routes/message-template.$id.edit.tsx
+++ b/app/routes/message-template.$id.edit.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { data, redirect } from 'react-router';
-import { Button, Checkbox, FormControlLabel, TextField } from '@mui/material';
+import { Checkbox, FormControlLabel, TextField } from '@mui/material';
+import Button from '~/routes/components/Button';
 
-import { Form, Link, useActionData, useLoaderData } from 'react-router';
+import { Form, useActionData, useLoaderData } from 'react-router';
 
 import { getMessageTemplate, editMessageTemplate } from '~/models/messageTemplate.server';
 
@@ -110,7 +111,7 @@ export default function EditMessageTemplate(): JSX.Element {
         </Wrapper>
 
         <div className="flex justify-start gap-4">
-          <Button color="error" variant="contained" component={Link} to={`/message-templates`}>
+          <Button color="error" variant="contained" to={`/message-templates`}>
             Peru
           </Button>
 

--- a/app/routes/message-template.create.tsx
+++ b/app/routes/message-template.create.tsx
@@ -3,7 +3,8 @@ import { Form, useActionData } from 'react-router';
 import type { ActionFunctionArgs } from 'react-router';
 import { data, redirect } from 'react-router';
 
-import { TextField, Checkbox, Button, FormControlLabel } from '@mui/material';
+import { TextField, Checkbox, FormControlLabel } from '@mui/material';
+import Button from '~/routes/components/Button';
 
 import H2 from './components/H2';
 import Label from './components/Label';

--- a/app/routes/message-templates.tsx
+++ b/app/routes/message-templates.tsx
@@ -1,9 +1,9 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { redirect } from 'react-router';
-import { Link, useLoaderData } from 'react-router';
+import { useLoaderData } from 'react-router';
 
 import Paper from '~/routes/components/Paper';
-import Button from '@mui/material/Button';
+import Button from '~/routes/components/Button';
 
 import { getMessageTemplates, deleteMessageTemplate, markAsDefault } from '~/models/messageTemplate.server';
 
@@ -48,7 +48,7 @@ export default function MessageTemplatesPage(): JSX.Element {
     <div>
       <H2 className="mt-8 mb-4">Viestipohjat</H2>
 
-      <Button component={Link} to="/message-template/create" variant="contained">
+      <Button to="/message-template/create" variant="contained">
         Luo uusi viestipohja
       </Button>
 

--- a/app/routes/message.send.$discId.tsx
+++ b/app/routes/message.send.$discId.tsx
@@ -1,11 +1,11 @@
-import { Form, Link, useFetcher, useLoaderData, useParams } from 'react-router';
+import { Form, useFetcher, useLoaderData, useParams } from 'react-router';
 
 import { useState, useEffect } from 'react';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
-import Button from '@mui/material/Button';
+import Button from '~/routes/components/Button';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { redirect } from 'react-router';
@@ -161,12 +161,12 @@ export default function SendNotificationPage(): JSX.Element {
         </Wrapper>
       </Form>
       <div className="flex justify-start gap-4">
-        <Button color="error" variant="contained" component={Link} to={`/`}>
+        <Button color="error" variant="contained" to={`/`}>
           Peru
         </Button>
         <Button
           variant="contained"
-          component={Link}
+         
           to={`sms:${phoneNumber}&body=${convertLineBreaks(replaceTokensWithValues(message, data))}`}
         >
           Lähetä tekstiviesti

--- a/app/routes/notifications.tsx
+++ b/app/routes/notifications.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'react-router';
 import { useLoaderData, useFetcher } from 'react-router';
 
 import styled from '@emotion/styled';
-import { Button } from '@mui/material';
+import Button from '~/routes/components/Button';
 
 import { isUserLoggedIn } from '~/models/utils';
 import {

--- a/app/routes/sign-in.tsx
+++ b/app/routes/sign-in.tsx
@@ -5,7 +5,7 @@ import { data, redirect } from 'react-router';
 
 import { createSupabaseServerClientWithHeaders } from '~/models/utils';
 
-import { Button } from '@mui/material';
+import Button from '~/routes/components/Button';
 
 import Label from './components/Label';
 


### PR DESCRIPTION
## What
Adds `app/routes/components/Button.tsx` — a faithful StyleX replacement for MUI `<Button>` — and migrates **all ~28 call sites across 14 files**. Removes `@mui/material/Button` from the app entirely.

## Coverage (everything the app actually uses)
- **variants:** contained / outlined / text · **colors:** primary / error · **sizes:** small / medium / large · `fullWidth`, `disabled`, form attrs (`type`/`name`/`value`/`onClick`).
- MUI-exact **primary `#1976d2`** / **error `#d32f2f`**, elevation shadows + hover states, uppercase + 500 weight + 4px radius.
- **Polymorphism:** replaces MUI `component={Link}` with a `to` prop. Internal paths render a React Router `<Link>`; **external schemes (`sms:`, `mailto:`, …) render a plain `<a>`** — the old code routed an `sms:` link through `<Link>`, which this does more correctly.
- `sx` overrides → `style` (merged after the StyleX style). Removed unused `Link` imports left behind by the `component={Link}` → `to` change.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- Button styles confirmed in the global `root-*.css` (uppercase base, primary/error colors).

## ⚠️ Worth a careful preview look
Buttons are everywhere — this is the most visible change yet. Suggest checking: a contained submit (`/sign-in`), the error/cancel buttons + the `sms:` "Lähetä tekstiviesti" link (message-send page), the outlined small buttons (`/notifications`), and the fullWidth large button (NotifyForm/BinFullForm).

## Progress
MUI components removed: `InputLabel`, `Close`, `Paper`, **`Button`**. Remaining: `TextField`, `Select`, `Autocomplete`, `Checkbox`, `Radio`, `FormControlLabel`, `Collapse`, `CircularProgress`, `MenuItem` + 4 icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)