### PR TITLE
feat: replace MUI TextField with a StyleX TextField (form fields)

### DIFF
--- a/app/routes/components/NotifyForm.tsx
+++ b/app/routes/components/NotifyForm.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Form, useActionData } from 'react-router';
 
-import { TextField, Collapse, RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import { Collapse, RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 
 import H2 from './H2';

--- a/app/routes/components/TextField.tsx
+++ b/app/routes/components/TextField.tsx
@@ -1,0 +1,68 @@
+import type { ChangeEventHandler, InputHTMLAttributes } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { color, radius } from '~/styles/tokens.stylex';
+
+// StyleX text input / textarea. Replaces MUI <TextField> for the app's form
+// fields (which use a separate <Label> above, not MUI's floating label). The
+// base style reproduces the Tailwind input look the forms previously applied
+// via className (shadow / border / rounded / padding / gray-700 text), so call
+// sites no longer pass that className.
+const styles = stylex.create({
+  base: {
+    width: 'auto',
+    appearance: 'none',
+    boxSizing: 'border-box',
+    padding: '8px 12px',
+    fontFamily: 'inherit',
+    fontSize: '1rem',
+    lineHeight: 1.25,
+    color: color.textSecondary,
+    backgroundColor: color.surface,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: { default: color.border, ':focus': color.accent },
+    borderRadius: radius.sm,
+    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',
+    outline: 'none',
+  },
+  fullWidth: { width: '100%' },
+});
+
+type TextFieldProps = {
+  multiline?: boolean;
+  rows?: number;
+  fullWidth?: boolean;
+  className?: string;
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
+  id?: string;
+  name?: string;
+  type?: string;
+  value?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  onChange?: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+};
+
+export default function TextField({
+  multiline,
+  rows,
+  fullWidth,
+  className,
+  inputProps,
+  type,
+  ...rest
+}: TextFieldProps): JSX.Element {
+  const sx = stylex.props(styles.base, fullWidth && styles.fullWidth);
+  const merged = [sx.className, className].filter(Boolean).join(' ');
+
+  if (multiline) {
+    // `type` is input-only; not forwarded to <textarea>.
+    return <textarea {...rest} rows={rows} className={merged} style={sx.style} />;
+  }
+
+  return <input {...rest} type={type} {...inputProps} className={merged} style={sx.style} />;
+}

--- a/app/routes/message-template.$id.edit.tsx
+++ b/app/routes/message-template.$id.edit.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { data, redirect } from 'react-router';
-import { Checkbox, FormControlLabel, TextField } from '@mui/material';
+import { Checkbox, FormControlLabel } from '@mui/material';
+import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 
 import { Form, useActionData, useLoaderData } from 'react-router';
@@ -82,9 +83,9 @@ export default function EditMessageTemplate(): JSX.Element {
           <TextField
             name="content"
             id="content"
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
             multiline
             rows={9}
+            fullWidth
             value={message}
             onChange={(e) => {
               setMessage(e.target.value);

--- a/app/routes/message-template.create.tsx
+++ b/app/routes/message-template.create.tsx
@@ -3,7 +3,8 @@ import { Form, useActionData } from 'react-router';
 import type { ActionFunctionArgs } from 'react-router';
 import { data, redirect } from 'react-router';
 
-import { TextField, Checkbox, FormControlLabel } from '@mui/material';
+import { Checkbox, FormControlLabel } from '@mui/material';
+import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 
 import H2 from './components/H2';
@@ -54,13 +55,7 @@ export default function CreateMessageTemplate(): JSX.Element {
       <Form method="post">
         <Wrapper>
           <Label htmlFor="content">Sisältö</Label>
-          <TextField
-            name="content"
-            id="content"
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-            multiline
-            rows={9}
-          />
+          <TextField name="content" id="content" multiline rows={9} fullWidth />
 
           {errors?.content && <p className="text-red-500 text-xs italic">{errors.content}</p>}
         </Wrapper>

--- a/app/routes/message.send.$discId.tsx
+++ b/app/routes/message.send.$discId.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
-import TextField from '@mui/material/TextField';
+import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
@@ -151,12 +151,12 @@ export default function SendNotificationPage(): JSX.Element {
           <Label htmlFor="message">Viesti</Label>
 
           <TextField
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
             id="message"
             onChange={(e) => setMessage(e.target.value)}
             value={message}
             multiline
             rows={9}
+            fullWidth
           />
         </Wrapper>
       </Form>


### PR DESCRIPTION
## What
Adds `app/routes/components/TextField.tsx` (StyleX input/textarea) and migrates the app's form fields off MUI `TextField`.

- Renders `<textarea>` when `multiline` (with `rows`), else `<input>`. Supports `id`/`name`/`type`/`value`/`defaultValue`/`onChange`/`placeholder`/`disabled`/`required`, `inputProps` (spread onto the input), and `fullWidth`.
- The base style **reproduces the Tailwind input look** the forms previously applied via `className` (shadow / border / rounded / 8–12px padding / gray-700 text / focus accent border), so call sites drop that long className and just pass `fullWidth` for the former `w-full`.

Migrated 6 fields: `message.send`, `message-template.create`, `message-template.$id.edit`, `NotifyForm`.

## Deferred (still MUI TextField — intentionally)
- `NumberSearch` — uses MUI's floating `label`, which this component doesn't replicate.
- `DiscSelector` — its TextField is bound to MUI `Autocomplete` (`renderInput={...params}`); it migrates with Autocomplete.

So MUI `TextField` is **not** fully removed yet — those two remain.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- Input style (`appearance:none`, shadow) confirmed in the global `root-*.css`.

## ⚠️ Preview look
Notable visual area: the message textareas (message-send, both message-template forms) and the NotifyForm inputs (name/phone/email/message). NotifyForm fields previously used MUI's outlined look and now use the consistent Tailwind-style input — worth a glance.

## Progress
MUI removed: `InputLabel`, `Close`, `Paper`, `Button`, **TextField (forms)**. Remaining: `Select`, `Autocomplete`, `Checkbox`, `Radio`, `FormControlLabel`, `Collapse`, `CircularProgress`, `MenuItem`, + the 2 deferred TextFields + 4 icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)