### PR TITLE
feat: replace @mui/icons-material with inline SVG icons

### DIFF
--- a/app/routes/DiscTable.tsx
+++ b/app/routes/DiscTable.tsx
@@ -7,10 +7,8 @@ import { Link, useOutletContext } from 'react-router';
 import { add, isAfter } from 'date-fns';
 
 import styled from '@emotion/styled';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
-import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import TextsmsIcon from '@mui/icons-material/Textsms';
-import WarningIcon from '@mui/icons-material/Warning';
+
+import { ArrowDownwardIcon, ArrowUpwardIcon, TextsmsIcon, WarningIcon } from '~/routes/components/icons';
 
 import type { RenderSortStatusProps, SortColumn } from 'react-data-grid';
 import DataGrid from 'react-data-grid';
@@ -21,9 +19,6 @@ type DiscTableProps = {
   discs: DiscDTO[];
 };
 
-const StyledWarningIcon = styled(WarningIcon)`
-  color: red;
-`;
 
 interface Row {
   id: number;
@@ -156,8 +151,9 @@ const getColumns = (isLoggedIn: boolean): any => {
           <div className="flex gap-4 items-center">
             {formatDate(props.row.addedAt)}
             {isInDangerOfBeingDonatedOrSold(props.row.addedAt) && (
-              <StyledWarningIcon
-                titleAccess={'Kiekko on ollut seuran hallussa yli 3kk ja se saatetaan pian myydä tai lahjoittaa'}
+              <WarningIcon
+                title={'Kiekko on ollut seuran hallussa yli 3kk ja se saatetaan pian myydä tai lahjoittaa'}
+                style={{ color: 'red' }}
               />
             )}
           </div>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -9,7 +9,7 @@ import Collapse from '@mui/material/Collapse';
 import Paper from '~/routes/components/Paper';
 import InfoBox from '~/routes/components/InfoBox';
 import EmptyingLogItem from '~/routes/components/EmptyingLogItem';
-import WarningIcon from '@mui/icons-material/Warning';
+import { WarningIcon } from '~/routes/components/icons';
 import CircularProgress from '@mui/material/CircularProgress';
 
 import DiscTable from '~/routes/DiscTable';
@@ -27,10 +27,6 @@ const H2 = styled.h2`
   }
 `;
 
-const StyledWarningIcon = styled(WarningIcon)`
-  color: red;
-  margin-right: 0.5rem;
-`;
 
 export default function TestPage(): JSX.Element {
   const fetcher = useFetcher();
@@ -124,8 +120,9 @@ export default function TestPage(): JSX.Element {
           <p>Vinkki: taulukon otsikoita painamalla voit järjestää sisällön halutulla tavalla.</p>
 
           <p>
-            <StyledWarningIcon
-              titleAccess={'Kiekko on ollut seuran hallussa yli 3kk ja se saatetaan pian myydä tai lahjoittaa'}
+            <WarningIcon
+              title={'Kiekko on ollut seuran hallussa yli 3kk ja se saatetaan pian myydä tai lahjoittaa'}
+              style={{ color: 'red', marginRight: '0.5rem' }}
             />
             Jos lisäyspäivämäärän jälkeen näkyy kyseinen kuvake, on kiekko ollut seuran hallussa yli 3kk ja se saatetaan
             pian myydä tai lahjoittaa.

--- a/app/routes/components/icons.tsx
+++ b/app/routes/components/icons.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode, SVGProps } from 'react';
+
+// Inline Material icons (24x24, currentColor) replacing @mui/icons-material.
+// Accept all SVG props (className/style/onClick). Pass `title` for an accessible
+// label (renders <title> + role="img"); otherwise the icon is aria-hidden.
+type IconProps = SVGProps<SVGSVGElement> & { title?: string };
+
+function SvgIcon({ title, children, ...props }: IconProps & { children: ReactNode }): JSX.Element {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      role={title ? 'img' : undefined}
+      aria-hidden={title ? undefined : true}
+      {...props}
+    >
+      {title ? <title>{title}</title> : null}
+      {children}
+    </svg>
+  );
+}
+
+export function WarningIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+    </SvgIcon>
+  );
+}
+
+export function TextsmsIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM9 11H7V9h2v2zm4 0h-2V9h2v2zm4 0h-2V9h2v2z" />
+    </SvgIcon>
+  );
+}
+
+export function ArrowUpwardIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z" />
+    </SvgIcon>
+  );
+}
+
+export function ArrowDownwardIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z" />
+    </SvgIcon>
+  );
+}


### PR DESCRIPTION
## What
Adds `app/routes/components/icons.tsx` exporting `WarningIcon`, `TextsmsIcon`, `ArrowUpwardIcon`, `ArrowDownwardIcon` as inline **24×24 currentColor SVGs** (exact Material path data). They accept all SVG props plus a `title` (renders `<title>` + `role="img"`; otherwise `aria-hidden`).

Migrates the only two consumers:
- `DiscTable` — sort arrows, the SMS icon, and the warning icon.
- `_index` — the warning icon in the legend.

Both dropped the MUI icon imports and the emotion `styled(WarningIcon)` wrappers; the former `color: red` (+ `margin-right` in `_index`) is now an inline `style`, and MUI's `titleAccess` → `title`.

**Removes `@mui/icons-material` usage from the app entirely.**

## Notes
- The `@mui/icons-material/<Icon>` → ESM alias in `vite.config.ts` is now unused but left in place (harmless; it'll be removed with the final MUI cleanup).
- `@emotion/styled` is still used elsewhere in both files (sort/table styles) — imports intact.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓

## Progress
MUI removed: `InputLabel`, `Close`, `Paper`, `Button`, `TextField` (forms), **all icons**. Remaining MUI `@mui/material`: `Select`, `Autocomplete`, `Checkbox`, `Radio`, `FormControlLabel`, `Collapse`, `CircularProgress`, `MenuItem` (+ 2 deferred TextFields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)