### PR TITLE
feat: replace MUI Checkbox/Radio/FormControlLabel with StyleX components

### DIFF
--- a/app/routes/components/Checkbox.tsx
+++ b/app/routes/components/Checkbox.tsx
@@ -1,0 +1,35 @@
+import type { ChangeEventHandler } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { color } from '~/styles/tokens.stylex';
+
+// Native checkbox themed with accent-color. Replaces MUI <Checkbox>.
+const styles = stylex.create({
+  checkbox: {
+    accentColor: color.accent,
+    width: '18px',
+    height: '18px',
+    cursor: 'pointer',
+  },
+});
+
+type CheckboxProps = {
+  name?: string;
+  value?: string | boolean;
+  checked?: boolean;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+};
+
+export default function Checkbox({ name, value, checked, onChange }: CheckboxProps): JSX.Element {
+  return (
+    <input
+      type="checkbox"
+      name={name}
+      value={value === undefined ? undefined : String(value)}
+      checked={checked}
+      onChange={onChange}
+      {...stylex.props(styles.checkbox)}
+    />
+  );
+}

--- a/app/routes/components/FormControlLabel.tsx
+++ b/app/routes/components/FormControlLabel.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement, ReactNode } from 'react';
+import { cloneElement } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { space } from '~/styles/tokens.stylex';
+
+// Pairs a control (Checkbox/Radio) with a label. When `value` is set (radio
+// case), it is injected into the control — mirroring MUI's FormControlLabel.
+const styles = stylex.create({
+  label: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: space.sm,
+    cursor: 'pointer',
+  },
+});
+
+type FormControlLabelProps = {
+  control: ReactElement<{ value?: string }>;
+  label: ReactNode;
+  value?: string;
+};
+
+export default function FormControlLabel({ control, label, value }: FormControlLabelProps): JSX.Element {
+  const renderedControl = value !== undefined ? cloneElement(control, { value }) : control;
+  return (
+    <label {...stylex.props(styles.label)}>
+      {renderedControl}
+      <span>{label}</span>
+    </label>
+  );
+}

--- a/app/routes/components/NotifyForm.tsx
+++ b/app/routes/components/NotifyForm.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import { Form, useActionData } from 'react-router';
 
-import { Collapse, RadioGroup, FormControlLabel, Radio } from '@mui/material';
+import { Collapse } from '@mui/material';
+import { RadioGroup, Radio } from '~/routes/components/RadioGroup';
+import FormControlLabel from '~/routes/components/FormControlLabel';
 import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 

--- a/app/routes/components/RadioGroup.tsx
+++ b/app/routes/components/RadioGroup.tsx
@@ -1,0 +1,47 @@
+import type { FormEventHandler, ReactNode } from 'react';
+import { createContext, useContext } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { color } from '~/styles/tokens.stylex';
+
+// Native radios grouped by a shared `name` (provided via context, like MUI's
+// RadioGroup). Selection is handled natively; the group's onChange catches the
+// bubbling change from any child radio.
+const RadioGroupContext = createContext<{ name?: string }>({});
+
+const styles = stylex.create({
+  group: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  radio: {
+    accentColor: color.accent,
+    width: '18px',
+    height: '18px',
+    cursor: 'pointer',
+  },
+});
+
+type RadioGroupProps = {
+  name?: string;
+  onChange?: FormEventHandler<HTMLDivElement>;
+  children: ReactNode;
+};
+
+export function RadioGroup({ name, onChange, children }: RadioGroupProps): JSX.Element {
+  return (
+    <div role="radiogroup" onChange={onChange} {...stylex.props(styles.group)}>
+      <RadioGroupContext.Provider value={{ name }}>{children}</RadioGroupContext.Provider>
+    </div>
+  );
+}
+
+type RadioProps = {
+  value?: string;
+};
+
+export function Radio({ value }: RadioProps): JSX.Element {
+  const { name } = useContext(RadioGroupContext);
+  return <input type="radio" name={name} value={value} {...stylex.props(styles.radio)} />;
+}

--- a/app/routes/message-template.$id.edit.tsx
+++ b/app/routes/message-template.$id.edit.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { data, redirect } from 'react-router';
-import { Checkbox, FormControlLabel } from '@mui/material';
+import Checkbox from '~/routes/components/Checkbox';
+import FormControlLabel from '~/routes/components/FormControlLabel';
 import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 

--- a/app/routes/message-template.create.tsx
+++ b/app/routes/message-template.create.tsx
@@ -3,7 +3,8 @@ import { Form, useActionData } from 'react-router';
 import type { ActionFunctionArgs } from 'react-router';
 import { data, redirect } from 'react-router';
 
-import { Checkbox, FormControlLabel } from '@mui/material';
+import Checkbox from '~/routes/components/Checkbox';
+import FormControlLabel from '~/routes/components/FormControlLabel';
 import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 


### PR DESCRIPTION
## What
Replaces the MUI form-control cluster with native controls themed via `accent-color`:

- **`Checkbox`** — native checkbox; `name`/`value`/`checked`/`onChange`. Controlled in the edit form, uncontrolled in create (both work natively).
- **`RadioGroup` + `Radio`** — native radios grouped by a shared `name` provided via React context (mirroring MUI's RadioGroup). Selection is native; the group's `onChange` catches the bubbling change.
- **`FormControlLabel`** — `<label>` pairing a control with text; injects `value` into the control when set (the radio case), like MUI.

Migrated: `message-template.create`, `message-template.$id.edit`, `NotifyForm`.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- `accent-color` (control theming) and the label `inline-flex` layout confirmed in the global `root-*.css`.

## ⚠️ Preview look
Checkboxes/radios now render as native (accent-colored) controls instead of MUI's custom SVG ones — a visible style change. Check: the "Oletusviestipohja" checkbox (message-template create/edit) and the course radio list (NotifyForm).

## Progress
Remaining `@mui/material`: `Select`, `Autocomplete`, `Collapse`, `CircularProgress`, `MenuItem` (+ 2 deferred TextFields: NumberSearch, DiscSelector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)