### PR TITLE
feat: replace MUI CircularProgress with a StyleX spinner

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -10,7 +10,7 @@ import Paper from '~/routes/components/Paper';
 import InfoBox from '~/routes/components/InfoBox';
 import EmptyingLogItem from '~/routes/components/EmptyingLogItem';
 import { WarningIcon } from '~/routes/components/icons';
-import CircularProgress from '@mui/material/CircularProgress';
+import CircularProgress from '~/routes/components/CircularProgress';
 
 import DiscTable from '~/routes/DiscTable';
 import type { DiscDTO, EmptyingLogDTO } from '~/types';

--- a/app/routes/components/CircularProgress.tsx
+++ b/app/routes/components/CircularProgress.tsx
@@ -1,0 +1,45 @@
+import type { CSSProperties } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { color } from '~/styles/tokens.stylex';
+
+// StyleX loading spinner replacing MUI <CircularProgress>: a rotating ring.
+const spin = stylex.keyframes({
+  to: { transform: 'rotate(360deg)' },
+});
+
+const styles = stylex.create({
+  spinner: {
+    display: 'inline-block',
+    boxSizing: 'border-box',
+    width: '40px',
+    height: '40px',
+    borderRadius: '50%',
+    borderWidth: '4px',
+    borderStyle: 'solid',
+    borderColor: 'rgba(0,0,0,0.1)',
+    borderTopColor: color.accent,
+    animationName: spin,
+    animationDuration: '0.8s',
+    animationIterationCount: 'infinite',
+    animationTimingFunction: 'linear',
+  },
+});
+
+type CircularProgressProps = {
+  className?: string;
+  style?: CSSProperties;
+};
+
+export default function CircularProgress({ className, style }: CircularProgressProps): JSX.Element {
+  const sx = stylex.props(styles.spinner);
+  return (
+    <span
+      role="progressbar"
+      aria-label="Ladataan"
+      className={[sx.className, className].filter(Boolean).join(' ')}
+      style={{ ...sx.style, ...style }}
+    />
+  );
+}


### PR DESCRIPTION
## What
Adds `app/routes/components/CircularProgress.tsx` — a rotating-ring loading spinner built with `stylex.keyframes` (`role="progressbar"`, accepts `className`/`style`). Migrates the single usage in `_index` (the sync loading indicator, `5rem`).

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- Spinner `@keyframes` + `rotate(360deg)` confirmed in the global `root-*.css`.

## Note
Visually a rotating ring rather than MUI's SVG arc — recognizable as a spinner; worth a glance during a sync (the `/` page while data loads).

## Progress
Remaining `@mui/material`: `Select`, `Autocomplete`, `Collapse`, `MenuItem` (+ 2 deferred TextFields). `CircularProgress` done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)