### PR TITLE
feat: replace MUI Collapse with a StyleX grid-based Collapse

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -5,7 +5,7 @@ import debounce from 'lodash.debounce';
 import styled from '@emotion/styled';
 
 import Button from '~/routes/components/Button';
-import Collapse from '@mui/material/Collapse';
+import Collapse from '~/routes/components/Collapse';
 import Paper from '~/routes/components/Paper';
 import InfoBox from '~/routes/components/InfoBox';
 import EmptyingLogItem from '~/routes/components/EmptyingLogItem';

--- a/app/routes/components/Collapse.tsx
+++ b/app/routes/components/Collapse.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+// StyleX replacement for MUI <Collapse in={...}>. Animates to content height
+// via the grid-template-rows 0fr<->1fr technique — smooth, no height
+// measurement, SSR-safe. Children stay mounted (clipped) when collapsed, like
+// MUI.
+const styles = stylex.create({
+  root: {
+    display: 'grid',
+    gridTemplateRows: '0fr',
+    transitionProperty: 'grid-template-rows',
+    transitionDuration: '300ms',
+    transitionTimingFunction: 'ease',
+  },
+  open: {
+    gridTemplateRows: '1fr',
+  },
+  inner: {
+    overflow: 'hidden',
+    minHeight: 0,
+  },
+});
+
+type CollapseProps = {
+  in?: boolean;
+  children: ReactNode;
+};
+
+export default function Collapse({ in: inProp = false, children }: CollapseProps): JSX.Element {
+  return (
+    <div {...stylex.props(styles.root, inProp && styles.open)}>
+      <div {...stylex.props(styles.inner)}>{children}</div>
+    </div>
+  );
+}

--- a/app/routes/components/NotifyForm.tsx
+++ b/app/routes/components/NotifyForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Form, useActionData } from 'react-router';
 
-import { Collapse } from '@mui/material';
+import Collapse from '~/routes/components/Collapse';
 import { RadioGroup, Radio } from '~/routes/components/RadioGroup';
 import FormControlLabel from '~/routes/components/FormControlLabel';
 import TextField from '~/routes/components/TextField';


### PR DESCRIPTION
## What
Adds `app/routes/components/Collapse.tsx` — a height-animated collapse using the modern **`grid-template-rows: 0fr ↔ 1fr`** technique. It animates smoothly to content height with **no JS measurement, no refs, and no SSR/hydration issues** (unlike MUI's measured-height approach). Children stay mounted (clipped) when collapsed, matching MUI; same `in` prop.

Migrated both usages: `_index` (instructions panel) and `NotifyForm` (details toggle). This also removes the **last bare `@mui/material` barrel import**.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- `grid-template-rows:0fr` / `1fr` confirmed in the global `root-*.css`.

## Note
Browser support for animating `grid-template-rows` is all modern evergreens (Chrome 107+, FF 116+, Safari 16+) — fine for this app. Worth a glance: expand the instructions panel on `/` and the "Lisätiedot" details in NotifyForm.

## Progress
Remaining `@mui/material` (all subpath imports now): `Select` + `MenuItem` (message.send), `Autocomplete` + `TextField` (DiscSelector), `TextField` (NumberSearch). i.e. the hard trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)