### PR TITLE
feat: replace MUI Select/MenuItem with a native StyleX Select

### DIFF
--- a/app/routes/components/Select.tsx
+++ b/app/routes/components/Select.tsx
@@ -1,0 +1,54 @@
+import type { ChangeEventHandler, ReactNode } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { color, radius } from '~/styles/tokens.stylex';
+
+// StyleX wrappers over native <select>/<option>, replacing MUI Select/MenuItem.
+// Keeps the browser's native dropdown (and arrow); just themes the box.
+const styles = stylex.create({
+  select: {
+    padding: '8px 12px',
+    fontFamily: 'inherit',
+    fontSize: '1rem',
+    color: color.textPrimary,
+    backgroundColor: color.surface,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: { default: color.border, ':focus': color.accent },
+    borderRadius: radius.sm,
+    cursor: 'pointer',
+    outline: 'none',
+  },
+  fullWidth: { width: '100%' },
+});
+
+type SelectProps = {
+  id?: string;
+  name?: string;
+  value?: string;
+  defaultValue?: string;
+  disabled?: boolean;
+  fullWidth?: boolean;
+  className?: string;
+  onChange?: ChangeEventHandler<HTMLSelectElement>;
+  children: ReactNode;
+};
+
+export default function Select({ fullWidth, className, children, ...rest }: SelectProps): JSX.Element {
+  const sx = stylex.props(styles.select, fullWidth && styles.fullWidth);
+  return (
+    <select {...rest} className={[sx.className, className].filter(Boolean).join(' ')} style={sx.style}>
+      {children}
+    </select>
+  );
+}
+
+type MenuItemProps = {
+  value?: string | number;
+  children: ReactNode;
+};
+
+export function MenuItem({ value, children }: MenuItemProps): JSX.Element {
+  return <option value={value}>{children}</option>;
+}

--- a/app/routes/message.send.$discId.tsx
+++ b/app/routes/message.send.$discId.tsx
@@ -1,9 +1,7 @@
 import { Form, useFetcher, useLoaderData, useParams } from 'react-router';
 
 import { useState, useEffect } from 'react';
-import type { SelectChangeEvent } from '@mui/material/Select';
-import Select from '@mui/material/Select';
-import MenuItem from '@mui/material/MenuItem';
+import Select, { MenuItem } from '~/routes/components/Select';
 import TextField from '~/routes/components/TextField';
 import Button from '~/routes/components/Button';
 
@@ -123,10 +121,10 @@ export default function SendNotificationPage(): JSX.Element {
           <Label htmlFor="message-template">Viestipohja</Label>
 
           <Select
-            className="[width:100%]"
+            fullWidth
             value={selected.toString()}
             id="message-template"
-            onChange={(e: SelectChangeEvent) => {
+            onChange={(e) => {
               const messageTemplate = messageTemplates.find(
                 (item: MessageTemplateDTO) => item.id === parseInt(e.target.value, 10),
               );


### PR DESCRIPTION
## What
Adds `app/routes/components/Select.tsx` — native `<select>`/`<option>` wrappers (`Select` + `MenuItem`) themed with StyleX, keeping the browser's native dropdown + arrow. Supports `id`/`name`/`value`/`defaultValue`/`onChange`/`disabled`/`fullWidth`.

Migrated the message-template dropdown in `message.send`:
- Dropped the MUI `SelectChangeEvent` type — the handler now takes a native `ChangeEvent<HTMLSelectElement>` (`e.target.value` is already a string, so the `parseInt` logic is unchanged).
- Replaced the `className="[width:100%]"` with the `fullWidth` prop.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- No MUI `Select`/`MenuItem` refs remain.

## Note
The dropdown is now a native themed `<select>` (native option list/arrow) instead of MUI's custom popover menu — functionally identical, visually simpler. Worth a glance on the message-send page's "Viestipohja" dropdown.

## Progress
Remaining MUI: **`Autocomplete` + `TextField` (DiscSelector)** and **`TextField` (NumberSearch)** — the typeahead. This is the last piece and the one needing the **Radix-vs-custom combobox decision**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)