### PR TITLE
feat: replace MUI Autocomplete with a Downshift combobox (DiscSelector)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ node_modules
 
 .idea
 .DS_Store
+
+# Playwright
+/test-results/
+/playwright-report/
+/e2e/__screens__/
+/.playwright/

--- a/app/routes/DiscSelector.tsx
+++ b/app/routes/DiscSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useCombobox } from 'downshift';
 import * as stylex from '@stylexjs/stylex';
@@ -70,7 +70,14 @@ const styles = stylex.create({
 });
 
 export default function DiscSelector({ discNames, onChange }: DiscSelectorProps): JSX.Element {
-  const [items, setItems] = useState<string[]>(discNames);
+  // Derive the visible items from the *current* discNames prop + filter text.
+  // discNames arrives asynchronously (loaded client-side), so it must not be
+  // frozen into state — that left the list permanently empty.
+  const [filter, setFilter] = useState('');
+  const items = useMemo(
+    () => discNames.filter((name) => name.toLowerCase().includes(filter.toLowerCase())),
+    [discNames, filter],
+  );
 
   const {
     isOpen,
@@ -93,8 +100,7 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
       return changes;
     },
     onInputValueChange({ inputValue }) {
-      const filter = (inputValue ?? '').toLowerCase();
-      setItems(discNames.filter((name) => name.toLowerCase().includes(filter)));
+      setFilter(inputValue ?? '');
     },
     onSelectedItemChange({ selectedItem }) {
       onChange(selectedItem ?? null);

--- a/app/routes/DiscSelector.tsx
+++ b/app/routes/DiscSelector.tsx
@@ -1,25 +1,133 @@
-import TextField from '@mui/material/TextField';
-import Autocomplete from '@mui/material/Autocomplete';
+import { useState } from 'react';
+
+import { useCombobox } from 'downshift';
+import * as stylex from '@stylexjs/stylex';
+
+import { color, radius } from '~/styles/tokens.stylex';
 
 type DiscSelectorProps = {
   discNames: string[];
   onChange: (e: string | null) => void;
 };
+
+const styles = stylex.create({
+  root: { position: 'relative', width: '300px' },
+  label: { display: 'block', fontWeight: 700, marginBottom: '4px', color: color.textSecondary },
+  inputWrap: { position: 'relative', display: 'flex', alignItems: 'center' },
+  input: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '8px 36px 8px 12px',
+    fontFamily: 'inherit',
+    fontSize: '1rem',
+    color: color.textPrimary,
+    backgroundColor: color.surface,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: { default: color.border, ':focus': color.accent },
+    borderRadius: radius.sm,
+    outline: 'none',
+  },
+  toggle: {
+    position: 'absolute',
+    right: '4px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '28px',
+    height: '28px',
+    padding: 0,
+    border: 'none',
+    background: 'none',
+    color: color.textMuted,
+    cursor: 'pointer',
+  },
+  chevron: {
+    transitionProperty: 'transform',
+    transitionDuration: '150ms',
+  },
+  chevronOpen: { transform: 'rotate(180deg)' },
+  menu: {
+    position: 'absolute',
+    zIndex: 10,
+    left: 0,
+    right: 0,
+    margin: 0,
+    padding: 0,
+    listStyle: 'none',
+    maxHeight: '240px',
+    overflowY: 'auto',
+    backgroundColor: color.surface,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: color.border,
+    borderRadius: radius.sm,
+    boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)',
+  },
+  menuClosed: { display: 'none' },
+  item: { padding: '8px 12px', cursor: 'pointer' },
+  itemHighlighted: { backgroundColor: 'rgba(25,118,210,0.08)' },
+});
+
 export default function DiscSelector({ discNames, onChange }: DiscSelectorProps): JSX.Element {
-  const options = discNames.map((discName) => {
-    return discName;
+  const [items, setItems] = useState<string[]>(discNames);
+
+  const {
+    isOpen,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    getToggleButtonProps,
+    getItemProps,
+    highlightedIndex,
+    openMenu,
+  } = useCombobox({
+    items,
+    onInputValueChange({ inputValue }) {
+      const filter = (inputValue ?? '').toLowerCase();
+      setItems(discNames.filter((name) => name.toLowerCase().includes(filter)));
+    },
+    onSelectedItemChange({ selectedItem }) {
+      onChange(selectedItem ?? null);
+    },
   });
 
   return (
-    <Autocomplete
-      disablePortal
-      id="combo-box-demo"
-      options={options}
-      sx={{ width: 300 }}
-      renderInput={(params) => <TextField {...params} label="Valitse kiekko" />}
-      onChange={(event: any, newValue: string | null) => {
-        onChange(newValue);
-      }}
-    />
+    <div {...stylex.props(styles.root)}>
+      {/* getLabelProps() supplies htmlFor matching the input's id — the
+          association is real but invisible to the static lint rule. */}
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label {...getLabelProps()} {...stylex.props(styles.label)}>
+        Valitse kiekko
+      </label>
+      <div {...stylex.props(styles.inputWrap)}>
+        {/* Open the full list on focus, matching the previous MUI Autocomplete. */}
+        <input {...getInputProps({ onFocus: () => !isOpen && openMenu() })} {...stylex.props(styles.input)} />
+        <button type="button" aria-label="Avaa lista" {...getToggleButtonProps()} {...stylex.props(styles.toggle)}>
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            {...stylex.props(styles.chevron, isOpen && styles.chevronOpen)}
+          >
+            <path d="M7 10l5 5 5-5z" />
+          </svg>
+        </button>
+      </div>
+      <ul {...getMenuProps()} {...stylex.props(styles.menu, !isOpen && styles.menuClosed)}>
+        {isOpen &&
+          items.map((item, index) => (
+            <li
+              key={`${item}-${index}`}
+              {...getItemProps({ item, index })}
+              {...stylex.props(styles.item, highlightedIndex === index && styles.itemHighlighted)}
+            >
+              {item}
+            </li>
+          ))}
+      </ul>
+    </div>
   );
 }

--- a/app/routes/DiscSelector.tsx
+++ b/app/routes/DiscSelector.tsx
@@ -83,6 +83,15 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
     openMenu,
   } = useCombobox({
     items,
+    // Clicking the input always OPENS the list (never toggles it closed), so a
+    // click reliably shows all options — matching the previous MUI Autocomplete.
+    // The chevron toggle and blur still close it.
+    stateReducer(state, { type, changes }) {
+      if (type === useCombobox.stateChangeTypes.InputClick) {
+        return { ...changes, isOpen: true };
+      }
+      return changes;
+    },
     onInputValueChange({ inputValue }) {
       const filter = (inputValue ?? '').toLowerCase();
       setItems(discNames.filter((name) => name.toLowerCase().includes(filter)));

--- a/e2e/disc-selector.spec.ts
+++ b/e2e/disc-selector.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+// Verifies the Downshift-based DiscSelector on the home page:
+//  - clicking the field opens the full disc-name list (the regression we fixed)
+//  - typing filters the list
+// Data-agnostic: it reads the actual options rather than hard-coding disc names.
+test('DiscSelector opens the full list on click and filters on type', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', (m) => m.type() === 'error' && consoleErrors.push(m.text()));
+  page.on('pageerror', (e) => consoleErrors.push(e.message));
+
+  await page.goto('/');
+
+  // Disc names load client-side (fetcher.load('/foo')); wait for the disc grid
+  // to render so the combobox has data before we open it.
+  await expect(page.getByRole('grid')).toBeVisible({ timeout: 20_000 });
+
+  const input = page.getByRole('combobox').first();
+  await expect(input).toBeVisible();
+
+  // Click → full list opens.
+  await input.click();
+  const options = page.getByRole('option');
+  await expect(options.first()).toBeVisible();
+  const fullCount = await options.count();
+  expect(fullCount).toBeGreaterThan(0);
+  await page.screenshot({ path: 'e2e/__screens__/01-open-on-click.png' });
+
+  // Type a substring taken from a real option → list filters down.
+  const firstText = (await options.first().innerText()).trim();
+  const fragment = firstText.slice(0, 2).toLowerCase();
+  await input.fill(fragment);
+  await expect(options.first()).toBeVisible();
+  const filteredCount = await options.count();
+  expect(filteredCount).toBeLessThanOrEqual(fullCount);
+
+  // Every remaining option should contain the typed fragment.
+  const texts = await options.allInnerTexts();
+  for (const t of texts) {
+    expect(t.toLowerCase()).toContain(fragment);
+  }
+  await page.screenshot({ path: 'e2e/__screens__/02-filtered.png' });
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join(' | ')}`).toEqual([]);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/qrcode": "^1.5.6",
         "@vercel/react-router": "^1.3.1",
         "date-fns": "^4.4.0",
+        "downshift": "^9.3.6",
         "isbot": "^5.1.43",
         "lodash.debounce": "4.0.8",
         "qrcode": "^1.5.4",
@@ -483,12 +484,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.11"
-      },
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1533,11 +1532,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@mui/base/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.14.3",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.3.tgz",
@@ -1623,11 +1617,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/@mui/material/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/private-theming": {
       "version": "5.13.7",
@@ -1767,11 +1756,6 @@
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0"
       }
-    },
-    "node_modules/@mui/utils/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
@@ -4466,6 +4450,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4828,6 +4818,22 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/downshift": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.6.tgz",
+      "integrity": "sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -8348,6 +8354,12 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -8461,11 +8473,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -10702,12 +10709,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
-      "requires": {
-        "regenerator-runtime": "^0.13.11"
-      }
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="
     },
     "@babel/template": {
       "version": "7.29.7",
@@ -11305,11 +11309,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
           "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
     },
@@ -11349,11 +11348,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
           "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        },
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
     },
@@ -11416,13 +11410,6 @@
         "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
         "react-is": "^18.2.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "18.2.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
-        }
       }
     },
     "@napi-rs/wasm-runtime": {
@@ -13094,6 +13081,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -13339,6 +13331,18 @@
       "requires": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "downshift": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.6.tgz",
+      "integrity": "sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==",
+      "requires": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
       }
     },
     "dunder-proto": {
@@ -15661,6 +15665,11 @@
         "scheduler": "^0.23.2"
       }
     },
+    "react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
     "react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -15742,11 +15751,6 @@
         "get-proto": "^1.0.1",
         "which-builtin-type": "^1.2.1"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.61.0",
         "@react-router/dev": "^7.17.0",
         "@react-router/fs-routes": "^7.17.0",
         "@react-router/serve": "^7.17.0",
@@ -1838,6 +1839,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -8006,6 +8023,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/png-js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
@@ -11458,6 +11522,15 @@
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
       "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="
+    },
+    "@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.61.0"
+      }
     },
     "@popperjs/core": {
       "version": "2.11.8",
@@ -15458,6 +15531,31 @@
           "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
         }
       }
+    },
+    "playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.61.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true
     },
     "png-js": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format:check": "prettier --check .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -37,6 +38,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.61.0",
     "@react-router/dev": "^7.17.0",
     "@react-router/fs-routes": "^7.17.0",
     "@react-router/serve": "^7.17.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/qrcode": "^1.5.6",
     "@vercel/react-router": "^1.3.1",
     "date-fns": "^4.4.0",
+    "downshift": "^9.3.6",
     "isbot": "^5.1.43",
     "lodash.debounce": "4.0.8",
     "qrcode": "^1.5.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E config. Boots the React Router dev server on a dedicated port (avoids the
+// default 3400 colliding with a running dev server) and runs Chromium.
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  fullyParallel: true,
+  use: {
+    baseURL: 'http://localhost:4321',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npx react-router dev --port 4321',
+    url: 'http://localhost:4321',
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## What
Rebuilds `DiscSelector` on **Downshift** (`useCombobox`), styled entirely with **StyleX**, removing `@mui/material/Autocomplete` (and its MUI `TextField`). **`Autocomplete` is now gone from the app.**

Chosen after [researching headless combobox libraries](#) — Radix has no combobox primitive; Downshift is the smallest-surface, actively-maintained (v9.3.6, released 2026-06-04; ~46 open issues) hooks-only option, ideal for "headless behaviour + StyleX visuals."

## Behaviour — honours the previous MUI Autocomplete
- **Full disc-name list opens on focus** (matched on request), and a **dropdown chevron** toggles it.
- Typing filters the list; single selection calls `onChange(value | null)`.
- StyleX styles the input, dropdown menu, highlighted item, and the toggle (chevron rotates when open).

## Notes
- `downshift ^9.3.6` — hooks-only, peer `react >=16.12`, SSR-safe (uses `useId`).
- `getLabelProps()` wires `htmlFor`↔`id`; the resulting `jsx-a11y/label-has-associated-control` false positive (association via spread) is disabled with an explanatory comment.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` (Vite 8) ✓
- **SSR**: `/` → 200; combobox + toggle render in server HTML; **no hydration warnings**.
- ⚠️ **Interaction** (filter / select / keyboard nav) confirmed working in a quick local test; worth a final pass on the Vercel preview.

## Progress
Remaining MUI after this + the open Select PR (#52): just `TextField` in `NumberSearch` (MUI floating-label search box). That's the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)