### PR TITLE
feat(DiscSelector): flip the list above the field near viewport bottom

### DIFF
--- a/app/routes/DiscSelector.tsx
+++ b/app/routes/DiscSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import { useCombobox } from 'downshift';
 import * as stylex from '@stylexjs/stylex';
@@ -10,8 +10,10 @@ type DiscSelectorProps = {
   onChange: (e: string | null) => void;
 };
 
+const MENU_MAX_HEIGHT = 240;
+
 const styles = stylex.create({
-  root: { position: 'relative', width: '300px' },
+  root: { width: '300px' },
   label: { display: 'block', fontWeight: 700, marginBottom: '4px', color: color.textSecondary },
   inputWrap: { position: 'relative', display: 'flex', alignItems: 'center' },
   input: {
@@ -55,7 +57,7 @@ const styles = stylex.create({
     margin: 0,
     padding: 0,
     listStyle: 'none',
-    maxHeight: '240px',
+    maxHeight: `${MENU_MAX_HEIGHT}px`,
     overflowY: 'auto',
     backgroundColor: color.surface,
     borderWidth: '1px',
@@ -64,6 +66,8 @@ const styles = stylex.create({
     borderRadius: radius.sm,
     boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)',
   },
+  menuBelow: { top: 'calc(100% + 2px)' },
+  menuAbove: { bottom: 'calc(100% + 2px)' },
   menuClosed: { display: 'none' },
   item: { padding: '8px 12px', cursor: 'pointer' },
   itemHighlighted: { backgroundColor: 'rgba(25,118,210,0.08)' },
@@ -78,6 +82,11 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
     () => discNames.filter((name) => name.toLowerCase().includes(filter.toLowerCase())),
     [discNames, filter],
   );
+
+  // Flip the list above the field when there isn't room below (e.g. near the
+  // bottom of the viewport), matching the previous MUI Autocomplete/Popper.
+  const inputWrapRef = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<'bottom' | 'top'>('bottom');
 
   const {
     isOpen,
@@ -99,6 +108,14 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
       }
       return changes;
     },
+    onIsOpenChange({ isOpen: open }) {
+      if (open && inputWrapRef.current) {
+        const rect = inputWrapRef.current.getBoundingClientRect();
+        const spaceBelow = window.innerHeight - rect.bottom;
+        const spaceAbove = rect.top;
+        setPlacement(spaceBelow < MENU_MAX_HEIGHT && spaceAbove > spaceBelow ? 'top' : 'bottom');
+      }
+    },
     onInputValueChange({ inputValue }) {
       setFilter(inputValue ?? '');
     },
@@ -115,7 +132,7 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
       <label {...getLabelProps()} {...stylex.props(styles.label)}>
         Valitse kiekko
       </label>
-      <div {...stylex.props(styles.inputWrap)}>
+      <div ref={inputWrapRef} {...stylex.props(styles.inputWrap)}>
         {/* Open the full list on focus, matching the previous MUI Autocomplete. */}
         <input {...getInputProps({ onFocus: () => !isOpen && openMenu() })} {...stylex.props(styles.input)} />
         <button type="button" aria-label="Avaa lista" {...getToggleButtonProps()} {...stylex.props(styles.toggle)}>
@@ -130,19 +147,26 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
             <path d="M7 10l5 5 5-5z" />
           </svg>
         </button>
+        <ul
+          {...getMenuProps()}
+          {...stylex.props(
+            styles.menu,
+            placement === 'top' ? styles.menuAbove : styles.menuBelow,
+            !isOpen && styles.menuClosed,
+          )}
+        >
+          {isOpen &&
+            items.map((item, index) => (
+              <li
+                key={`${item}-${index}`}
+                {...getItemProps({ item, index })}
+                {...stylex.props(styles.item, highlightedIndex === index && styles.itemHighlighted)}
+              >
+                {item}
+              </li>
+            ))}
+        </ul>
       </div>
-      <ul {...getMenuProps()} {...stylex.props(styles.menu, !isOpen && styles.menuClosed)}>
-        {isOpen &&
-          items.map((item, index) => (
-            <li
-              key={`${item}-${index}`}
-              {...getItemProps({ item, index })}
-              {...stylex.props(styles.item, highlightedIndex === index && styles.itemHighlighted)}
-            >
-              {item}
-            </li>
-          ))}
-      </ul>
     </div>
   );
 }

--- a/e2e/disc-selector.spec.ts
+++ b/e2e/disc-selector.spec.ts
@@ -43,3 +43,26 @@ test('DiscSelector opens the full list on click and filters on type', async ({ p
 
   expect(consoleErrors, `console errors: ${consoleErrors.join(' | ')}`).toEqual([]);
 });
+
+test('DiscSelector flips the list above the field when near the viewport bottom', async ({ page }) => {
+  await page.setViewportSize({ width: 1000, height: 420 });
+  await page.goto('/');
+  await expect(page.getByRole('grid')).toBeVisible({ timeout: 20_000 });
+
+  const input = page.getByRole('combobox').first();
+  // Pin the field to the bottom of the viewport so there's no room below.
+  await input.evaluate((el) => el.scrollIntoView({ block: 'end' }));
+  await input.click();
+
+  const listbox = page.getByRole('listbox');
+  await expect(listbox).toBeVisible();
+  await expect(page.getByRole('option').first()).toBeVisible();
+
+  const inputBox = await input.boundingBox();
+  const listBox = await listbox.boundingBox();
+  if (!inputBox || !listBox) throw new Error('missing bounding boxes');
+  // The list's bottom edge should sit at/above the input's top edge → rendered upward.
+  expect(listBox.y + listBox.height).toBeLessThanOrEqual(inputBox.y + 1);
+
+  await page.screenshot({ path: 'e2e/__screens__/03-flip-above.png' });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,10 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
-  fullyParallel: true,
+  // Serialize: tests share one dev server; running them in parallel races on
+  // Vite's cold-start route compilation. One retry absorbs first-request lag.
+  workers: 1,
+  retries: 1,
   use: {
     baseURL: 'http://localhost:4321',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
## Why this is a separate PR
The flip work was committed *after* PR #53 had already merged (and auto-deleted its branch), so it never made it into `master` — my push re-created the branch with an orphaned commit. This PR re-lands it cleanly on top of `master`.

## What
- **Flip behaviour**: on open, `DiscSelector` measures the field's position and renders the list **above** it when there's not enough room below (more space above) — matching the previous MUI Autocomplete/Popper. Lightweight hand-rolled flip, no positioning dependency; the menu is anchored inside the relatively-positioned input wrapper.
- **e2e**: adds a test that pins the field to the viewport bottom and asserts the list opens upward (verified visually).
- **e2e hardening**: `workers: 1` + `retries: 1` — the suite shares one dev server, and running `fullyParallel` raced on Vite's cold-start route compilation (intermittent first-test timeout). Verified stable across repeated runs.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓
- `test:e2e` ✓ (both tests, stable across repeated runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)