### PR TITLE
feat: remove MUI entirely (migrate NumberSearch + drop @mui packages)

### DIFF
--- a/app/routes/components/NumberSearch.tsx
+++ b/app/routes/components/NumberSearch.tsx
@@ -1,12 +1,22 @@
-import TextField from '@mui/material/TextField';
+import type { ChangeEvent } from 'react';
+
+import TextField from '~/routes/components/TextField';
 
 type NumberSearchProps = {
-  onChange: (e: any) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 };
+
 export default function NumberSearch({ onChange }: NumberSearchProps): JSX.Element {
   return (
     <div>
-      <TextField label="Puh nro., 4 viimeistä" variant="outlined" onChange={(e) => onChange(e)} />
+      {/* The MUI floating label served as both label and placeholder; here the
+          placeholder is the visible hint and aria-label gives it an accessible
+          name. */}
+      <TextField
+        placeholder="Puh nro., 4 viimeistä"
+        inputProps={{ 'aria-label': 'Puh nro., 4 viimeistä' }}
+        onChange={onChange}
+      />
     </div>
   );
 }

--- a/e2e/number-search.spec.ts
+++ b/e2e/number-search.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+// NumberSearch is the phone-number search box on the home page (migrated off
+// MUI TextField to the StyleX TextField). Verify it renders with its accessible
+// name and accepts input.
+test('NumberSearch renders and accepts input', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', (m) => m.type() === 'error' && consoleErrors.push(m.text()));
+  page.on('pageerror', (e) => consoleErrors.push(e.message));
+
+  await page.goto('/');
+
+  const search = page.getByRole('textbox', { name: 'Puh nro., 4 viimeistä' });
+  await expect(search).toBeVisible();
+
+  await search.fill('3904');
+  await expect(search).toHaveValue('3904');
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join(' | ')}`).toEqual([]);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
         "@emotion/react": "^11.14.0",
         "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.14.1",
-        "@mui/icons-material": "5.14.3",
-        "@mui/material": "5.14.3",
         "@react-pdf/renderer": "^4.5.1",
         "@react-router/node": "^7.17.0",
         "@stylexjs/stylex": "^0.19.0",
@@ -1493,271 +1491,6 @@
       "integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==",
       "license": "MIT"
     },
-    "node_modules/@mui/base": {
-      "version": "5.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.9.tgz",
-      "integrity": "sha512-gm6gnPnc/lS5Z3neH0iuOrK7IbS02+oh6KsMtXYLhI6bJpHs+PNWFsBmISx7x4FSPVJZvZkb8Bw6pEXpIMFt7Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.3",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/base/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.3.tgz",
-      "integrity": "sha512-QxvrcDqphZoXRjsAmCaQylmWjC/8/qKWwIde1MJMna5YIst3R9O0qhKRPu36/OE2d8AeTbCVjRcRvNqhhW8jyg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      }
-    },
-    "node_modules/@mui/icons-material": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.3.tgz",
-      "integrity": "sha512-XkxWPhageu1OPUm2LWjo5XqeQ0t2xfGe8EiLkRW9oz2LHMMZmijvCxulhgquUVTF1DnoSh+3KoDLSsoAFtVNVw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.6"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@mui/material": "^5.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.3.tgz",
-      "integrity": "sha512-dlu4SOcCp9Cy+wkcfZ/ns9ZkP40nr/WPgqxX0HmrE0o+dkE1ropY9BbHsLrTlYJCko8yzcC8bLghrD4xqZG1og==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/base": "5.0.0-beta.9",
-        "@mui/core-downloads-tracker": "^5.14.3",
-        "@mui/system": "^5.14.3",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.3",
-        "@types/react-transition-group": "^4.4.6",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/material/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.7.tgz",
-      "integrity": "sha512-qbSr+udcij5F9dKhGX7fEdx2drXchq7htLNr2Qg2Ma+WJ6q0ERlEqGSBiPiVDJkptcjeVL4DGmcf1wl5+vD4EA==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/utils": "^5.13.7",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styled-engine": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.13.2.tgz",
-      "integrity": "sha512-VCYCU6xVtXOrIN8lcbuPmoG+u7FYuOERG++fpY74hPpEWkyFQG97F+/XfTQVYzlR2m7nPjnwVUgATcTCMEaMvw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.2",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.3.tgz",
-      "integrity": "sha512-b+C+j9+75+/iIYSa+1S4eCMc9MDNrj9hzWfExJqS2GffuNocRagjBZFyjtMqsLWLxMxQIX8Cg6j0hAioiw+WfQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/private-theming": "^5.13.7",
-        "@mui/styled-engine": "^5.13.2",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.3",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@mui/types": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
-      "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
-      "peerDependencies": {
-        "@types/react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/utils": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.3.tgz",
-      "integrity": "sha512-gZ6Etw+ppO43GYc1HFZSLjwd4DoZoa+RrYTD25wQLfzcSoPjVoC/zZqA2Lkq0zjgwGBQOSxKZI6jfp9uXR+kgw==",
-      "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@types/prop-types": "^15.7.5",
-        "@types/react-is": "^18.2.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -1855,15 +1588,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@react-pdf/fns": {
@@ -3207,7 +2931,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
     },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
@@ -3222,6 +2947,7 @@
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3236,22 +2962,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/react-is": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
-      "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
-      "dependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
-      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4827,15 +4537,6 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/downshift": {
       "version": "9.3.6",
@@ -8455,21 +8156,6 @@
         }
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -11354,128 +11040,6 @@
       "resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
       "integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng=="
     },
-    "@mui/base": {
-      "version": "5.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.9.tgz",
-      "integrity": "sha512-gm6gnPnc/lS5Z3neH0iuOrK7IbS02+oh6KsMtXYLhI6bJpHs+PNWFsBmISx7x4FSPVJZvZkb8Bw6pEXpIMFt7Q==",
-      "requires": {
-        "@babel/runtime": "^7.22.6",
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.3",
-        "@popperjs/core": "^2.11.8",
-        "clsx": "^2.0.0",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      },
-      "dependencies": {
-        "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        }
-      }
-    },
-    "@mui/core-downloads-tracker": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.3.tgz",
-      "integrity": "sha512-QxvrcDqphZoXRjsAmCaQylmWjC/8/qKWwIde1MJMna5YIst3R9O0qhKRPu36/OE2d8AeTbCVjRcRvNqhhW8jyg=="
-    },
-    "@mui/icons-material": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.3.tgz",
-      "integrity": "sha512-XkxWPhageu1OPUm2LWjo5XqeQ0t2xfGe8EiLkRW9oz2LHMMZmijvCxulhgquUVTF1DnoSh+3KoDLSsoAFtVNVw==",
-      "requires": {
-        "@babel/runtime": "^7.22.6"
-      }
-    },
-    "@mui/material": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.3.tgz",
-      "integrity": "sha512-dlu4SOcCp9Cy+wkcfZ/ns9ZkP40nr/WPgqxX0HmrE0o+dkE1ropY9BbHsLrTlYJCko8yzcC8bLghrD4xqZG1og==",
-      "requires": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/base": "5.0.0-beta.9",
-        "@mui/core-downloads-tracker": "^5.14.3",
-        "@mui/system": "^5.14.3",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.3",
-        "@types/react-transition-group": "^4.4.6",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0",
-        "react-transition-group": "^4.4.5"
-      },
-      "dependencies": {
-        "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        }
-      }
-    },
-    "@mui/private-theming": {
-      "version": "5.13.7",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.7.tgz",
-      "integrity": "sha512-qbSr+udcij5F9dKhGX7fEdx2drXchq7htLNr2Qg2Ma+WJ6q0ERlEqGSBiPiVDJkptcjeVL4DGmcf1wl5+vD4EA==",
-      "requires": {
-        "@babel/runtime": "^7.22.5",
-        "@mui/utils": "^5.13.7",
-        "prop-types": "^15.8.1"
-      }
-    },
-    "@mui/styled-engine": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.13.2.tgz",
-      "integrity": "sha512-VCYCU6xVtXOrIN8lcbuPmoG+u7FYuOERG++fpY74hPpEWkyFQG97F+/XfTQVYzlR2m7nPjnwVUgATcTCMEaMvw==",
-      "requires": {
-        "@babel/runtime": "^7.21.0",
-        "@emotion/cache": "^11.11.0",
-        "csstype": "^3.1.2",
-        "prop-types": "^15.8.1"
-      }
-    },
-    "@mui/system": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.3.tgz",
-      "integrity": "sha512-b+C+j9+75+/iIYSa+1S4eCMc9MDNrj9hzWfExJqS2GffuNocRagjBZFyjtMqsLWLxMxQIX8Cg6j0hAioiw+WfQ==",
-      "requires": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/private-theming": "^5.13.7",
-        "@mui/styled-engine": "^5.13.2",
-        "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.3",
-        "clsx": "^2.0.0",
-        "csstype": "^3.1.2",
-        "prop-types": "^15.8.1"
-      },
-      "dependencies": {
-        "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        }
-      }
-    },
-    "@mui/types": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
-      "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
-      "requires": {}
-    },
-    "@mui/utils": {
-      "version": "5.14.3",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.3.tgz",
-      "integrity": "sha512-gZ6Etw+ppO43GYc1HFZSLjwd4DoZoa+RrYTD25wQLfzcSoPjVoC/zZqA2Lkq0zjgwGBQOSxKZI6jfp9uXR+kgw==",
-      "requires": {
-        "@babel/runtime": "^7.22.6",
-        "@types/prop-types": "^15.7.5",
-        "@types/react-is": "^18.2.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^18.2.0"
-      }
-    },
     "@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -11531,11 +11095,6 @@
       "requires": {
         "playwright": "1.61.0"
       }
-    },
-    "@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@react-pdf/fns": {
       "version": "3.1.3",
@@ -12334,7 +11893,8 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
     },
     "@types/qrcode": {
       "version": "1.5.6",
@@ -12348,6 +11908,7 @@
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -12359,22 +11920,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "requires": {}
-    },
-    "@types/react-is": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz",
-      "integrity": "sha512-wyUkmaaSZEzFZivD8F2ftSyAfk6L+DfFliVj/mYdOXbVjRcS87fQJLTnhk6dRZPuJjI+9g6RZJO4PNCngUrmyw==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@types/react-transition-group": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
-      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
-      "requires": {
-        "@types/react": "*"
-      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.61.1",
@@ -13396,15 +12941,6 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true
-    },
-    "dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "requires": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "downshift": {
       "version": "9.3.6",
@@ -15780,17 +15316,6 @@
       "requires": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
-      }
-    },
-    "react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "@emotion/react": "^11.14.0",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.14.1",
-    "@mui/icons-material": "5.14.3",
-    "@mui/material": "5.14.3",
     "@react-pdf/renderer": "^4.5.1",
     "@react-router/node": "^7.17.0",
     "@stylexjs/stylex": "^0.19.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,23 +11,6 @@ export default defineConfig({
     // Vite 8 resolves tsconfig `paths` (the `~/*` -> `./app/*` alias) natively,
     // replacing the former vite-tsconfig-paths plugin.
     tsconfigPaths: true,
-    alias: [
-      // `@mui/icons-material/<Icon>` resolves to a CJS flat file (the icons have
-      // no per-icon package.json, so Vite never picks the ESM build). Vite's dev
-      // SSR module runner serves that raw CJS and fails with "require is not
-      // defined". Redirect single-segment icon imports to the ESM build.
-      {
-        find: /^@mui\/icons-material\/([^/]+)$/,
-        replacement: '@mui/icons-material/esm/$1',
-      },
-    ],
-  },
-  ssr: {
-    // MUI 5 ships without an `exports` map (only legacy `main`/`module`), so its
-    // subpath ESM imports fail when externalized for SSR (a default import
-    // resolves to an object -> "Element type is invalid"). Bundling the whole
-    // @mui scope into the server build lets Vite apply proper CJS/ESM interop.
-    noExternal: [/^@mui\//],
   },
   plugins: [
     stylexUnplugin.vite({


### PR DESCRIPTION
## 🎉 This removes MUI from the app entirely.

### What
- **NumberSearch** (the phone-number search box) was the last MUI usage. Migrated its `TextField` to the StyleX `TextField`; MUI's floating label becomes a `placeholder` + `aria-label` (same visual footprint, accessible name preserved).
- **Uninstalled** `@mui/material` and `@mui/icons-material`.
- **Removed the dead MUI workarounds** in `vite.config.ts` — the `@mui/icons-material` ESM alias and `ssr.noExternal: [/^@mui\//]` (both only existed to make MUI work).
- Added an **e2e test** for NumberSearch (renders with its accessible name, accepts input, no console errors).

**Emotion stays** — still used by `Header`, `AdminMenu`, the charts, `notifications`, and `DiscTable`. It leaves in a later pass.

### Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓ — crucially, the build **succeeds without the MUI packages and without the SSR workarounds**, confirming they were truly dead.
- `test:e2e` ✓ — all 3 specs (DiscSelector open/filter, DiscSelector flip, NumberSearch).
- Visually confirmed NumberSearch renders as a clean StyleX input.

### Diff note
−503 lines in package-lock as the MUI dependency trees drop out.

## After this merges
- **MUI: gone.** Remaining migration: the **Emotion `styled`** components (`Header`, `AdminMenu`, `BarChart`, `HorizontaBarChart`, `notifications`, `DiscTable`), then **React 18 → 19** (now unblocked — MUI was the React-19 blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)