### PR TITLE
feat: migrate AdminMenu/Header/_index off Emotion to StyleX

### DIFF
--- a/app/routes/AdminMenu.tsx
+++ b/app/routes/AdminMenu.tsx
@@ -1,15 +1,20 @@
-import styled from '@emotion/styled';
+import * as stylex from '@stylexjs/stylex';
 
 import { Link } from 'react-router';
 
-const Li = styled.li`
-  display: inline;
-  margin-right: 1rem;
+import { space } from '~/styles/tokens.stylex';
 
-  & a:hover {
-    text-decoration: underline;
-  }
-`;
+// StyleX has no descendant selectors, so the former `& a:hover { underline }`
+// is applied to the links directly.
+const styles = stylex.create({
+  item: {
+    display: 'inline',
+    marginRight: space.md,
+  },
+  link: {
+    textDecoration: { ':hover': 'underline' },
+  },
+});
 
 export default function AdminMenu({ supabase, user }: any): JSX.Element | null {
   const handleLogout = async () => {
@@ -23,30 +28,42 @@ export default function AdminMenu({ supabase, user }: any): JSX.Element | null {
   return (
     <div>
       <ul>
-        <Li>Kirjautuneena: {user?.email}</Li>
-        <Li>
-          <Link to="/">Kiekot</Link>
-        </Li>
-        <Li>
-          <Link to="/discs/sync">Päivitä kiekkodata</Link>
-        </Li>
-        <Li>
-          <Link to="/emptying-log">Tyhjennysloki</Link>
-        </Li>
-        <Li>
-          <Link to="/message-templates">Viestipohjat</Link>
-        </Li>
-        <Li>
-          <Link to="/stats">Statistiikka</Link>
-        </Li>
-        <Li>
-          <Link to="/notifications">Ilmoitukset</Link>
-        </Li>
-        <Li>
-          <Link to={''} onClick={handleLogout}>
+        <li {...stylex.props(styles.item)}>Kirjautuneena: {user?.email}</li>
+        <li {...stylex.props(styles.item)}>
+          <Link to="/" {...stylex.props(styles.link)}>
+            Kiekot
+          </Link>
+        </li>
+        <li {...stylex.props(styles.item)}>
+          <Link to="/discs/sync" {...stylex.props(styles.link)}>
+            Päivitä kiekkodata
+          </Link>
+        </li>
+        <li {...stylex.props(styles.item)}>
+          <Link to="/emptying-log" {...stylex.props(styles.link)}>
+            Tyhjennysloki
+          </Link>
+        </li>
+        <li {...stylex.props(styles.item)}>
+          <Link to="/message-templates" {...stylex.props(styles.link)}>
+            Viestipohjat
+          </Link>
+        </li>
+        <li {...stylex.props(styles.item)}>
+          <Link to="/stats" {...stylex.props(styles.link)}>
+            Statistiikka
+          </Link>
+        </li>
+        <li {...stylex.props(styles.item)}>
+          <Link to="/notifications" {...stylex.props(styles.link)}>
+            Ilmoitukset
+          </Link>
+        </li>
+        <li {...stylex.props(styles.item)}>
+          <Link to={''} onClick={handleLogout} {...stylex.props(styles.link)}>
             Kirjaudu ulos
           </Link>
-        </Li>
+        </li>
       </ul>
     </div>
   );

--- a/app/routes/Header.tsx
+++ b/app/routes/Header.tsx
@@ -1,26 +1,18 @@
-import styled from '@emotion/styled';
+import * as stylex from '@stylexjs/stylex';
 
 type HeaderProps = {
   clubId: number;
   clubName: string;
 };
 
-const Logo = styled.img`
-  font-weight: bold;
-  width: 50px;
-
-  @media (min-width: 600px) {
-    width: 100px;
-  }
-`;
-
-const H1 = styled.h1`
-  font-size: 1.5rem;
-
-  @media (min-width: 600px) {
-    font-size: 2.25rem;
-  }
-`;
+const styles = stylex.create({
+  logo: {
+    width: { default: '50px', '@media (min-width: 600px)': '100px' },
+  },
+  h1: {
+    fontSize: { default: '1.5rem', '@media (min-width: 600px)': '2.25rem' },
+  },
+});
 
 function getClubLogo(clubId: number): string | undefined {
   if (clubId === 2) {
@@ -29,11 +21,13 @@ function getClubLogo(clubId: number): string | undefined {
 
   return undefined;
 }
+
 export default function Header({ clubId, clubName }: HeaderProps): JSX.Element {
+  const logo = stylex.props(styles.logo);
   return (
     <div className="flex items-center">
-      <Logo className="mr-4" src={getClubLogo(clubId)} alt={''} />
-      <H1>Löytökiekot - {clubName}</H1>
+      <img className={`mr-4 ${logo.className ?? ''}`} style={logo.style} src={getClubLogo(clubId)} alt={''} />
+      <h1 {...stylex.props(styles.h1)}>Löytökiekot - {clubName}</h1>
     </div>
   );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -2,8 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useFetcher } from 'react-router';
 import debounce from 'lodash.debounce';
 
-import styled from '@emotion/styled';
-
+import H2 from '~/routes/components/H2';
 import Button from '~/routes/components/Button';
 import Collapse from '~/routes/components/Collapse';
 import Paper from '~/routes/components/Paper';
@@ -16,16 +15,6 @@ import DiscTable from '~/routes/DiscTable';
 import type { DiscDTO, EmptyingLogDTO } from '~/types';
 import DiscSelector from '~/routes/DiscSelector';
 import NumberSearch from '~/routes/components/NumberSearch';
-
-const H2 = styled.h2`
-  font-weight: bold;
-
-  font-size: 1.25rem;
-
-  @media (min-width: 600px) {
-    font-size: 1.75rem;
-  }
-`;
 
 
 export default function TestPage(): JSX.Element {


### PR DESCRIPTION
## What
First Emotion-removal batch — the three simplest `@emotion/styled` files:

- **`Header`** — `Logo` (img) + `H1` responsive font sizes → StyleX. The logo keeps its `mr-4` Tailwind class via className merge.
- **`AdminMenu`** — the `Li` styled → StyleX `item`. Its former `& a:hover { underline }` **descendant** selector becomes a per-link `:hover` style, since StyleX is atomic and has no descendant selectors. (Same visual result.)
- **`_index`** — deleted its **local duplicate** `H2` styled and reused the shared StyleX `~/routes/components/H2`.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓ — StyleX rules confirmed in the global `root-*.css`.
- All 3 e2e specs pass; home page visually confirmed (Header h1 + the `_index` heading render correctly).
- Note: `AdminMenu` only shows when authenticated, so it isn't exercised by the unauthenticated e2e run — it's a static nav (no logic change), build-verified.

## Progress
Emotion `styled` remaining: `notifications`, `BarChart`, `HorizontaBarChart`, `DiscTable`. Then the Emotion SSR plumbing + uninstall `@emotion/*`, then React 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)