### PR TITLE
fix: bottom-align the home filter row

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -133,7 +133,7 @@ export default function TestPage(): JSX.Element {
         )}
       </div>
       <div className="mt-8">
-        <div className="flex gap-4">
+        <div className="flex gap-4 items-end">
           <DiscSelector
             discNames={distinctDiscNames}
             onChange={(selectedItem: string | null) => {

--- a/e2e/number-search.spec.ts
+++ b/e2e/number-search.spec.ts
@@ -18,3 +18,22 @@ test('NumberSearch renders and accepts input', async ({ page }) => {
 
   expect(consoleErrors, `console errors: ${consoleErrors.join(' | ')}`).toEqual([]);
 });
+
+test('filter row controls are bottom-aligned', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('grid')).toBeVisible({ timeout: 20_000 });
+
+  const combo = page.getByRole('combobox').first(); // DiscSelector input (has a label above)
+  const search = page.getByRole('textbox', { name: 'Puh nro., 4 viimeistä' });
+  const button = page.getByRole('button', { name: 'Ohjeet' });
+
+  const [c, s, b] = await Promise.all([combo.boundingBox(), search.boundingBox(), button.boundingBox()]);
+  if (!c || !s || !b) throw new Error('missing bounding boxes');
+
+  const bottom = (box: { y: number; height: number }) => box.y + box.height;
+  // All three should share roughly the same bottom edge (within a few px).
+  expect(Math.abs(bottom(c) - bottom(s))).toBeLessThanOrEqual(4);
+  expect(Math.abs(bottom(c) - bottom(b))).toBeLessThanOrEqual(4);
+
+  await page.screenshot({ path: 'e2e/__screens__/04-filter-row.png', clip: { x: 0, y: c.y - 60, width: 760, height: 140 } });
+});


### PR DESCRIPTION
## Bug
On the home page, the disc filter, the phone-search box, and the **OHJEET** button weren't vertically aligned (reported with a screenshot).

## Cause
The DiscSelector migration (off MUI Autocomplete's *floating* label) added a visible `<label>` **above** the combobox input. In the `flex` row (default `align-items: stretch`), the label-less search box and button aligned with the DiscSelector's *label* row instead of its input — so they sat too high.

## Fix
Add `items-end` to the row so the three control boxes share a bottom edge; the "Valitse kiekko" label sits above, as expected.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors)
- New e2e regression test: asserts the combobox / search / button **bottom edges align within a few px**. Verified visually (screenshot) — all three now line up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)