### PR TITLE
feat: migrate BarChart/HorizontaBarChart off Emotion to StyleX

### DIFF
--- a/app/routes/components/admin/BarChart.tsx
+++ b/app/routes/components/admin/BarChart.tsx
@@ -1,66 +1,39 @@
 import { useState } from 'react';
 
-import styled from '@emotion/styled';
+import * as stylex from '@stylexjs/stylex';
 
 import H3 from '../H3';
+import { space } from '~/styles/tokens.stylex';
 
-const Outer = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const Wrapper = styled.div`
-  width: 100%;
-  height: 200px;
-  display: flex;
-  align-items: self-end;
-  gap: 1rem;
-`;
-
-const Legend = styled.div`
-  display: flex;
-  gap: 1rem;
-  width: 100%;
-  max-width: 1200px;
-
-  & > div {
-    width: 75px;
-    text-align: center;
-  }
-`;
-
-type BarProps = {
-  height: number;
-  colour: string;
-};
-
-const VerticalBar = styled.div<BarProps>`
-  position: relative;
-  width: 75px;
-  background: pink;
-  ${(props) => {
-    return {
-      background: `${props.colour}`,
-      height: `${props.height}%`,
-    };
-  }}
-
-  &:hover {
-    background: blue;
-  }
-`;
-
-const BarValue = styled.div`
-  top: -25px;
-  color: black;
-  position: absolute;
-  margin: 0 auto;
-  width: 100%;
-
-  & > div {
-    text-align: center;
-  }
-`;
+const styles = stylex.create({
+  outer: { display: 'flex', flexDirection: 'column' },
+  wrapper: { width: '100%', height: '200px', display: 'flex', alignItems: 'self-end', gap: space.md },
+  legend: { display: 'flex', gap: space.md, width: '100%', maxWidth: '1200px' },
+  legendItem: { width: '75px', textAlign: 'center' },
+  // Rendered as a <button> (the bars are clickable) with a button reset.
+  barBase: {
+    position: 'relative',
+    width: '75px',
+    appearance: 'none',
+    borderStyle: 'none',
+    padding: 0,
+    fontFamily: 'inherit',
+    cursor: 'pointer',
+  },
+  // Dynamic per-bar height/colour. Background must be StyleX (not inline style)
+  // so the :hover rule can override it.
+  barDynamic: (height: number, colour: string) => ({ height: `${height}%`, backgroundColor: colour }),
+  barHover: { backgroundColor: { ':hover': 'blue' } },
+  barValue: {
+    position: 'absolute',
+    top: '-25px',
+    width: '100%',
+    marginBlock: 0,
+    marginInline: 'auto',
+    color: 'black',
+  },
+  barValueInner: { textAlign: 'center' },
+});
 
 export type BarValueType = {
   label: string;
@@ -87,36 +60,40 @@ export default function BarChart({ className, data, legendItems, onBarClick, tit
     }
   });
 
+  const outer = stylex.props(styles.outer);
+
   return (
-    <Outer className={className}>
+    <div className={[outer.className, className].filter(Boolean).join(' ')} style={outer.style}>
       <H3>{title}</H3>
-      <Wrapper>
+      <div {...stylex.props(styles.wrapper)}>
         {data.map((item: BarValueType, index: number) => {
           const height = Math.round((item.value / (highest + 30)) * 100);
           return (
-            <VerticalBar
+            <button
               key={index}
-              height={height}
-              colour={index === selectedBar ? 'blue' : 'red'}
-              onClick={(e) => {
+              type="button"
+              {...stylex.props(styles.barBase, styles.barHover, styles.barDynamic(height, index === selectedBar ? 'blue' : 'red'))}
+              onClick={() => {
                 if (onBarClick) {
                   setSelectedBar(index);
                   onBarClick(item.date);
                 }
               }}
             >
-              <BarValue>
-                <div>{item.value}</div>
-              </BarValue>
-            </VerticalBar>
+              <div {...stylex.props(styles.barValue)}>
+                <div {...stylex.props(styles.barValueInner)}>{item.value}</div>
+              </div>
+            </button>
           );
         })}
-      </Wrapper>
-      <Legend>
-        {legendItems.map((item, index: number) => {
-          return <div key={index}>{item}</div>;
-        })}
-      </Legend>
-    </Outer>
+      </div>
+      <div {...stylex.props(styles.legend)}>
+        {legendItems.map((item, index: number) => (
+          <div key={index} {...stylex.props(styles.legendItem)}>
+            {item}
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/app/routes/components/admin/HorizontaBarChart.tsx
+++ b/app/routes/components/admin/HorizontaBarChart.tsx
@@ -1,4 +1,6 @@
-import styled from '@emotion/styled';
+import * as stylex from '@stylexjs/stylex';
+
+import { space } from '~/styles/tokens.stylex';
 
 type Stat = {
   label: string;
@@ -9,44 +11,15 @@ type HorizontalBarChartProps = {
   data: Stat[];
 };
 
-type BarProps = {
-  width: number;
-  colour: string;
-};
+const styles = stylex.create({
+  wrapper: { display: 'flex', justifyContent: 'flex-start' },
+  label: { width: '10rem', marginRight: space.md },
+  barBase: { position: 'relative', height: '25px', marginBottom: space.sm },
+  // Dynamic per-bar width/colour.
+  barDynamic: (width: number, colour: string) => ({ width: `${width}%`, backgroundColor: colour }),
+  barValue: { position: 'absolute', right: '-25px', color: 'black' },
+});
 
-const HorizontalBar = styled.div<BarProps>`
-  position: relative;
-  height: 25px;
-  background: pink;
-  ${(props) => {
-    return {
-      background: `${props.colour}`,
-      width: `${props.width}%`,
-    };
-  }}
-
-  margin-bottom: 0.5rem;
-`;
-
-const BarValue = styled.div`
-  right: -25px;
-  color: black;
-  position: absolute;
-
-  & > div {
-    text-align: center;
-  }
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  justify-content: flex-start;
-`;
-
-const Label = styled.div`
-  width: 10rem;
-  margin-right: 1rem;
-`;
 export default function HorizontalBarChart({ data }: HorizontalBarChartProps): JSX.Element {
   let highest: number = 0;
 
@@ -62,12 +35,12 @@ export default function HorizontalBarChart({ data }: HorizontalBarChartProps): J
         const width = Math.round((item.value / (highest + 30)) * 100);
 
         return (
-          <Wrapper key={index}>
-            <Label>{item.label}</Label>
-            <HorizontalBar width={width} colour={'red'} key={index}>
-              <BarValue>{item.value}</BarValue>
-            </HorizontalBar>
-          </Wrapper>
+          <div key={index} {...stylex.props(styles.wrapper)}>
+            <div {...stylex.props(styles.label)}>{item.label}</div>
+            <div {...stylex.props(styles.barBase, styles.barDynamic(width, 'red'))}>
+              <div {...stylex.props(styles.barValue)}>{item.value}</div>
+            </div>
+          </div>
         );
       })}
     </div>


### PR DESCRIPTION
## What
Migrates both chart components — the trickiest Emotion patterns in the codebase — to StyleX.

- **Dynamic per-bar height/width/colour** → StyleX **dynamic style functions** (`stylex.create({ barDynamic: (h, c) => ({...}) })`). The bar background goes through StyleX (not inline `style`) so the `:hover` rule can actually override it (inline styles win on specificity and would break hover).
- **`VerticalBar &:hover { background: blue }`** → a static `:hover` `backgroundColor` composed with the dynamic default colour.
- **`& > div` descendant selectors** (Legend items, BarValue) → styles applied to the child elements directly (StyleX has no descendant selectors).
- BarChart's clickable bar was an emotion `styled.div` with `onClick`; it's now a real **`<button>`** — keeps lint/a11y green and adds keyboard support for free.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓ — StyleX emits its dynamic-style runtime chunk, confirming the dynamic functions compile.
- Note: the charts live on the **auth-gated `/stats`** page, so they aren't covered by the unauthenticated e2e run. Build-verified; worth a logged-in glance on a preview (bar sizing/colour + hover).

## Progress
Emotion `styled` remaining: **`DiscTable`** — the last one (the react-data-grid hairball). After that: remove the Emotion SSR plumbing + uninstall `@emotion/*`, then React 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)