### PR TITLE
feat: migrate DiscTable off Emotion (last styled() component)

### DIFF
--- a/app/routes/DiscTable.tsx
+++ b/app/routes/DiscTable.tsx
@@ -1,14 +1,16 @@
 import { useMemo, useState } from 'react';
 
 import 'react-data-grid/lib/styles.css';
+import '~/styles/disc-table.css';
 
 import { Link, useOutletContext } from 'react-router';
 
 import { add, isAfter } from 'date-fns';
 
-import styled from '@emotion/styled';
+import * as stylex from '@stylexjs/stylex';
 
 import { ArrowDownwardIcon, ArrowUpwardIcon, TextsmsIcon, WarningIcon } from '~/routes/components/icons';
+import { space } from '~/styles/tokens.stylex';
 
 import type { RenderSortStatusProps, SortColumn } from 'react-data-grid';
 import DataGrid from 'react-data-grid';
@@ -71,45 +73,25 @@ function formatDate(dateStr: string | undefined): string {
 
   return formattedDate;
 }
-const StyledDataGrid = styled(DataGrid)`
-  block-size: auto;
-  margin-top: 1rem;
-
-  & .rdg-row-even {
-    background: rgb(63, 60, 60);
-  }
-
-  & .rdg-header-row .rdg-cell {
-    transition: background-color 0.15s ease;
-  }
-
-  & .rdg-header-row .rdg-cell:hover {
-    background-color: rgba(255, 255, 255, 0.06);
-  }
-
-  & .rdg-header-row .rdg-cell[aria-sort='ascending'],
-  & .rdg-header-row .rdg-cell[aria-sort='descending'] {
-    background-color: rgba(255, 255, 255, 0.09);
-  }
-`;
-
-const SortIcon = styled('span')`
-  display: inline-flex;
-  align-items: center;
-  margin-inline-start: 0.25rem;
-  color: rgba(255, 255, 255, 0.7);
-
-  & svg {
-    font-size: 1rem;
-  }
-`;
+const styles = stylex.create({
+  sortIcon: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    marginInlineStart: space.xs,
+    color: 'rgba(255, 255, 255, 0.7)',
+  },
+});
 
 function renderSortStatus({ sortDirection }: RenderSortStatusProps): JSX.Element | null {
   if (!sortDirection) {
     return null;
   }
 
-  return <SortIcon>{sortDirection === 'ASC' ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}</SortIcon>;
+  return (
+    <span {...stylex.props(styles.sortIcon)}>
+      {sortDirection === 'ASC' ? <ArrowUpwardIcon /> : <ArrowDownwardIcon />}
+    </span>
+  );
 }
 
 const isInDangerOfBeingDonatedOrSold = (dateStr: string): boolean => {
@@ -207,7 +189,8 @@ export default function DiscTable({ discs }: DiscTableProps): JSX.Element | null
   }, [rows, sortColumns]);
 
   return (
-    <StyledDataGrid
+    <DataGrid
+      className="disc-grid"
       defaultColumnOptions={{
         sortable: true,
         resizable: true,

--- a/app/styles/disc-table.css
+++ b/app/styles/disc-table.css
@@ -1,0 +1,27 @@
+/*
+ * react-data-grid customizations for DiscTable. These target the grid's own
+ * internal classes (.rdg-*) via descendant selectors, which StyleX cannot
+ * express — so they live here as scoped plain CSS (applied via the `disc-grid`
+ * class on the DataGrid root). Migrated from the former emotion styled(DataGrid).
+ */
+.disc-grid {
+  block-size: auto;
+  margin-top: 1rem;
+}
+
+.disc-grid .rdg-row-even {
+  background: rgb(63, 60, 60);
+}
+
+.disc-grid .rdg-header-row .rdg-cell {
+  transition: background-color 0.15s ease;
+}
+
+.disc-grid .rdg-header-row .rdg-cell:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.disc-grid .rdg-header-row .rdg-cell[aria-sort='ascending'],
+.disc-grid .rdg-header-row .rdg-cell[aria-sort='descending'] {
+  background-color: rgba(255, 255, 255, 0.09);
+}


### PR DESCRIPTION
## What
The final `@emotion/styled` *component*. Two different cases:

- **`styled(DataGrid)`** styled react-data-grid's **internal** classes (`.rdg-row-even`, `.rdg-header-row .rdg-cell:hover`, `[aria-sort]`) via descendant selectors — which **StyleX cannot express** (no descendant selectors; can't target a third-party's child classes). Moved to a **scoped plain CSS file** (`app/styles/disc-table.css`, applied via `className="disc-grid"` on the grid). The file lives **outside `app/routes/`** so `flatRoutes` doesn't try to parse it as a route module (it does, and fails, if placed under `routes/`).
- **`SortIcon`** (a `<span>`) → StyleX. Its `& svg { font-size }` rule was dead (the inline icons are fixed-size) and dropped.

After this, **no route/component uses `@emotion/styled`** — only the SSR plumbing (`createEmotionCache`, `entry.client`/`entry.server`) remains.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · `build` ✓ (grid CSS bundled)
- All **4 e2e specs pass** (they wait on the grid → exercise DiscTable on the public home page).
- **Visually confirmed in a browser screenshot**: the table renders with the dark even-row striping + header intact.

## Almost there
Remaining to fully remove Emotion: the **SSR plumbing** — `createEmotionCache.ts`, the `CacheProvider` in `entry.client`/`entry.server`, the `__STYLES__` slot in `root.tsx` — then uninstall `@emotion/*`. After that: **React 18 → 19**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)