### PR TITLE
fix(DiscSelector): allow deselecting a disc to reset the filter

### DIFF
--- a/app/routes/DiscSelector.tsx
+++ b/app/routes/DiscSelector.tsx
@@ -30,6 +30,8 @@ const styles = stylex.create({
     borderRadius: radius.sm,
     outline: 'none',
   },
+  // Reserve room for both the clear (×) and chevron buttons when a value is set.
+  inputWithClear: { paddingRight: '64px' },
   toggle: {
     position: 'absolute',
     right: '4px',
@@ -44,6 +46,7 @@ const styles = stylex.create({
     color: color.textMuted,
     cursor: 'pointer',
   },
+  clearOffset: { right: '32px' },
   chevron: {
     transitionProperty: 'transform',
     transitionDuration: '150ms',
@@ -97,6 +100,8 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
     getItemProps,
     highlightedIndex,
     openMenu,
+    selectItem,
+    reset,
   } = useCombobox({
     items,
     // Clicking the input always OPENS the list (never toggles it closed), so a
@@ -118,6 +123,12 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
     },
     onInputValueChange({ inputValue }) {
       setFilter(inputValue ?? '');
+      // Emptying the field clears the selection so the parent filter resets.
+      // Otherwise downshift keeps the previous selectedItem (and restores it on
+      // blur), leaving the disc impossible to deselect.
+      if (!inputValue) {
+        selectItem(null);
+      }
     },
     onSelectedItemChange({ selectedItem }) {
       onChange(selectedItem ?? null);
@@ -134,7 +145,25 @@ export default function DiscSelector({ discNames, onChange }: DiscSelectorProps)
       </label>
       <div ref={inputWrapRef} {...stylex.props(styles.inputWrap)}>
         {/* Open the full list on focus, matching the previous MUI Autocomplete. */}
-        <input {...getInputProps({ onFocus: () => !isOpen && openMenu() })} {...stylex.props(styles.input)} />
+        <input
+          {...getInputProps({ onFocus: () => !isOpen && openMenu() })}
+          {...stylex.props(styles.input, filter.length > 0 && styles.inputWithClear)}
+        />
+        {filter.length > 0 && (
+          <button
+            type="button"
+            aria-label="Tyhjennä valinta"
+            // Prevent the input from blurring so downshift doesn't restore the
+            // value before reset() runs.
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => reset()}
+            {...stylex.props(styles.toggle, styles.clearOffset)}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M18.3 5.71 12 12.01l-6.3-6.3-1.41 1.41 6.3 6.3-6.3 6.3 1.41 1.41 6.3-6.3 6.3 6.3 1.41-1.41-6.3-6.3 6.3-6.3z" />
+            </svg>
+          </button>
+        )}
         <button type="button" aria-label="Avaa lista" {...getToggleButtonProps()} {...stylex.props(styles.toggle)}>
           <svg
             width="20"


### PR DESCRIPTION
## Summary

Fixes a bug where selecting a disc in the filter could not be undone — the table stayed filtered and there was no way to reset it.

**Root cause:** `DiscSelector` notified the parent only via `onSelectedItemChange`. Clearing the input fired `onInputValueChange` (local filter only), never `onChange(null)`, so the parent's `discTerm` stayed set. downshift also restored the previous value on blur.

**Changes:**
- Emptying the input now calls `selectItem(null)`, clearing downshift's selection and notifying the parent (`onChange(null)`).
- Added a clear (×) button, shown when a value is set, that resets the combobox — matching the previous MUI Autocomplete. `onMouseDown` is prevented so the input keeps focus and the value isn't restored before `reset()` runs.
- Input gains extra right padding when the × is visible so a long disc name doesn't underlap the buttons.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Select a disc → table filters; click × → table shows all discs again
- [ ] Select a disc → clear the input text → table resets and the value does not reappear on blur
- [ ] Clearing the disc filter leaves an active phone-number search intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)