### PR TITLE
chore(format): apply prettier across the repo

### DIFF
--- a/app/features/discParser/data/ev-7.json
+++ b/app/features/discParser/data/ev-7.json
@@ -11,15 +11,5 @@
     "OG Premium",
     "OG Soft"
   ],
-  "discNames": [
-    "Agera",
-    "Lid",
-    "Mobius",
-    "Ouro Boros",
-    "Penrose",
-    "Phi",
-    "Telos",
-    "Yang",
-    "Yin"
-  ]
+  "discNames": ["Agera", "Lid", "Mobius", "Ouro Boros", "Penrose", "Phi", "Telos", "Yang", "Yin"]
 }

--- a/app/features/discParser/data/millennium.json
+++ b/app/features/discParser/data/millennium.json
@@ -1,14 +1,6 @@
 {
   "manufacturer": "Millennium",
-  "plastics": [
-    "Standard",
-    "Delta-T",
-    "ET",
-    "SuperSoft",
-    "Quantum",
-    "Sirius",
-    "Lunar"
-  ],
+  "plastics": ["Standard", "Delta-T", "ET", "SuperSoft", "Quantum", "Sirius", "Lunar"],
   "discNames": [
     "Aquarius",
     "Astra",

--- a/app/features/discParser/data/prodigy-disc.json
+++ b/app/features/discParser/data/prodigy-disc.json
@@ -1,19 +1,6 @@
 {
   "manufacturer": "Prodigy",
-  "plastics": [
-    "200",
-    "300",
-    "300 Firm",
-    "300 Soft",
-    "400",
-    "400G",
-    "500",
-    "750",
-    "750G",
-    "AIR",
-    "Glow",
-    "ReBlend"
-  ],
+  "plastics": ["200", "300", "300 Firm", "300 Soft", "400", "400G", "500", "750", "750G", "AIR", "Glow", "ReBlend"],
   "discNames": [
     "A1",
     "A2",

--- a/app/features/discParser/data/rpm-discs.json
+++ b/app/features/discParser/data/rpm-discs.json
@@ -1,15 +1,6 @@
 {
   "manufacturer": "RPM Discs",
-  "plastics": [
-    "Or-ion",
-    "Atomic",
-    "Cosmic",
-    "Glow",
-    "Magma",
-    "Magma Soft",
-    "Platinum",
-    "Strata"
-  ],
+  "plastics": ["Or-ion", "Atomic", "Cosmic", "Glow", "Magma", "Magma Soft", "Platinum", "Strata"],
   "discNames": [
     "Huia",
     "Kahu",

--- a/app/features/discParser/data/thought-space-athletics.json
+++ b/app/features/discParser/data/thought-space-athletics.json
@@ -1,14 +1,6 @@
 {
   "manufacturer": "Thought Space Athletics",
-  "plastics": [
-    "Aura",
-    "Ethos",
-    "Ethereal",
-    "Glow",
-    "Nebula Aura",
-    "Nebula Ethereal",
-    "Nerve"
-  ],
+  "plastics": ["Aura", "Ethos", "Ethereal", "Glow", "Nebula Aura", "Nebula Ethereal", "Nerve"],
   "discNames": [
     "Alter",
     "Animus",

--- a/app/features/discParser/data/wild-discs.json
+++ b/app/features/discParser/data/wild-discs.json
@@ -1,15 +1,6 @@
 {
   "manufacturer": "Wild Discs",
-  "plastics": [
-    "Lava",
-    "Lava Flare",
-    "Landslide",
-    "Meteor",
-    "Nuclear",
-    "Ozone",
-    "Quicksand",
-    "Whirlpool"
-  ],
+  "plastics": ["Lava", "Lava Flare", "Landslide", "Meteor", "Nuclear", "Ozone", "Quicksand", "Whirlpool"],
   "discNames": [
     "Addax",
     "Angler",

--- a/app/routes/Header.tsx
+++ b/app/routes/Header.tsx
@@ -1,6 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type HeaderProps = {
   clubId: number;

--- a/app/routes/bin.full.$courseSlug.tsx
+++ b/app/routes/bin.full.$courseSlug.tsx
@@ -7,7 +7,7 @@ import BinFullForm from './components/BinFullForm';
 import { createBinFullNotification } from '~/models/binFullNotification.server';
 import { getCourseBySlug } from '~/config/courses';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 const RATE_LIMIT_MS = 10 * 60 * 1000;
 

--- a/app/routes/components/BinFullForm.tsx
+++ b/app/routes/components/BinFullForm.tsx
@@ -6,7 +6,7 @@ import H2 from './H2';
 
 import type { Course } from '~/config/courses';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type BinFullFormProps = {
   course: Course;

--- a/app/routes/components/EmptyingLogItem.tsx
+++ b/app/routes/components/EmptyingLogItem.tsx
@@ -1,6 +1,6 @@
 import type { EmptyingLogDTO } from '~/types';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type EmptyingLogItemProps = {
   item: EmptyingLogDTO;

--- a/app/routes/components/H2.tsx
+++ b/app/routes/components/H2.tsx
@@ -2,7 +2,7 @@ import * as stylex from '@stylexjs/stylex';
 
 import { font } from '~/styles/tokens.stylex';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 const styles = stylex.create({
   h2: {

--- a/app/routes/components/H3.tsx
+++ b/app/routes/components/H3.tsx
@@ -2,7 +2,7 @@ import * as stylex from '@stylexjs/stylex';
 
 import { font } from '~/styles/tokens.stylex';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 const styles = stylex.create({
   // Preserves the original markup: this component renders an <h2> element.

--- a/app/routes/components/InfoBox.tsx
+++ b/app/routes/components/InfoBox.tsx
@@ -2,7 +2,7 @@ import * as stylex from '@stylexjs/stylex';
 
 import { font, space } from '~/styles/tokens.stylex';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 const styles = stylex.create({
   heading: {

--- a/app/routes/components/PaperItem.tsx
+++ b/app/routes/components/PaperItem.tsx
@@ -2,7 +2,7 @@ import * as stylex from '@stylexjs/stylex';
 
 import { color, radius, space } from '~/styles/tokens.stylex';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 const styles = stylex.create({
   // Replaces MUI <Paper elevation={1}> + the `mt-8 p-4` Tailwind utilities.
@@ -13,8 +13,7 @@ const styles = stylex.create({
     backgroundColor: color.surface,
     color: color.textPrimary,
     borderRadius: radius.sm,
-    boxShadow:
-      '0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)',
+    boxShadow: '0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)',
   },
 });
 

--- a/app/routes/components/admin/BarChart.tsx
+++ b/app/routes/components/admin/BarChart.tsx
@@ -72,7 +72,11 @@ export default function BarChart({ className, data, legendItems, onBarClick, tit
             <button
               key={index}
               type="button"
-              {...stylex.props(styles.barBase, styles.barHover, styles.barDynamic(height, index === selectedBar ? 'blue' : 'red'))}
+              {...stylex.props(
+                styles.barBase,
+                styles.barHover,
+                styles.barDynamic(height, index === selectedBar ? 'blue' : 'red'),
+              )}
               onClick={() => {
                 if (onBarClick) {
                   setSelectedBar(index);

--- a/app/routes/components/admin/EmptyingLogItem.tsx
+++ b/app/routes/components/admin/EmptyingLogItem.tsx
@@ -1,7 +1,7 @@
 import type { EmptyingLogDTO } from '~/types';
 import Button from '~/routes/components/Button';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type EmptyingLogItemProps = {
   item: EmptyingLogDTO;

--- a/app/routes/components/admin/HorizontaBarChart.tsx
+++ b/app/routes/components/admin/HorizontaBarChart.tsx
@@ -2,7 +2,7 @@ import * as stylex from '@stylexjs/stylex';
 
 import { space } from '~/styles/tokens.stylex';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type Stat = {
   label: string;

--- a/app/routes/components/admin/MessagePreview.tsx
+++ b/app/routes/components/admin/MessagePreview.tsx
@@ -1,7 +1,7 @@
 import H3 from '../H3';
 import Paper from '~/routes/components/Paper';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type MessagePreviewProps = {
   message: string;

--- a/app/routes/components/admin/MessageTemplateItem.tsx
+++ b/app/routes/components/admin/MessageTemplateItem.tsx
@@ -5,7 +5,7 @@ import Button from '~/routes/components/Button';
 import { formatDate } from '~/routes/utils';
 import type { MessageTemplateDTO } from '~/types';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type MessageTemplateProps = {
   messageTemplate: MessageTemplateDTO;
@@ -31,9 +31,7 @@ export default function MessageTemplateItem({ messageTemplate }: MessageTemplate
           <Button name="action" value={'default'} type="submit">
             Merkitse oletukseksi
           </Button>
-          <Button to={`/message-template/${messageTemplate.id}/edit`}>
-            Muokkaa
-          </Button>
+          <Button to={`/message-template/${messageTemplate.id}/edit`}>Muokkaa</Button>
           <Button
             color="error"
             variant="contained"

--- a/app/routes/components/admin/stats/MostLostByDiscName.tsx
+++ b/app/routes/components/admin/stats/MostLostByDiscName.tsx
@@ -4,7 +4,7 @@ import H3 from '../../H3';
 
 import HorizontalBarChart from '~/routes/components/admin/HorizontaBarChart';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type DiscProps = {
   data: DiscDTO[];

--- a/app/routes/discs.sync.tsx
+++ b/app/routes/discs.sync.tsx
@@ -13,7 +13,7 @@ import { isUserLoggedIn } from '~/models/utils';
 
 import H2 from '~/routes/components/H2';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const isLoggedIn = await isUserLoggedIn(request);

--- a/app/routes/discs.syncItem.tsx
+++ b/app/routes/discs.syncItem.tsx
@@ -2,7 +2,7 @@ import Button from '~/routes/components/Button';
 
 import type { ClubDTO } from '~/types';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type SyncItemProps = {
   club: ClubDTO;

--- a/app/routes/emptying-log.tsx
+++ b/app/routes/emptying-log.tsx
@@ -11,7 +11,7 @@ import EmptyingLogItem from '~/routes/components/admin/EmptyingLogItem';
 
 import H2 from '~/routes/components/H2';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const isLoggedIn = await isUserLoggedIn(request);

--- a/app/routes/message-template.create.tsx
+++ b/app/routes/message-template.create.tsx
@@ -14,7 +14,7 @@ import Wrapper from './components/Wrapper';
 
 import { createMessageTemplate } from '~/models/messageTemplate.server';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type MessageTemplateErrors = {
   content?: string | null | undefined;

--- a/app/routes/message-templates.tsx
+++ b/app/routes/message-templates.tsx
@@ -15,7 +15,7 @@ import Wrapper from './components/Wrapper';
 
 import MessageTemplateItem from '~/routes/components/admin/MessageTemplateItem';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();

--- a/app/routes/notifications.tsx
+++ b/app/routes/notifications.tsx
@@ -27,7 +27,7 @@ import H2 from '~/routes/components/H2';
 import QrPosterButtons from '~/routes/components/admin/QrPosterButtons';
 import BinFullQrPosterButtons from '~/routes/components/admin/BinFullQrPosterButtons';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 const styles = stylex.create({
   card: {

--- a/app/routes/notify.$courseSlug.tsx
+++ b/app/routes/notify.$courseSlug.tsx
@@ -6,7 +6,7 @@ import NotifyForm from './components/NotifyForm';
 import { createDiscFoundNotification } from '~/models/discFoundNotification.server';
 import { getCourseBySlug } from '~/config/courses';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const course = getCourseBySlug(params.courseSlug!);

--- a/app/routes/notify._index.tsx
+++ b/app/routes/notify._index.tsx
@@ -4,7 +4,7 @@ import NotifyForm from './components/NotifyForm';
 
 import { createDiscFoundNotification } from '~/models/discFoundNotification.server';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 export async function action({ request }: ActionFunctionArgs) {
   const form = await request.formData();

--- a/app/routes/sign-in.tsx
+++ b/app/routes/sign-in.tsx
@@ -9,7 +9,7 @@ import Button from '~/routes/components/Button';
 
 import Label from './components/Label';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 type LoginErrors = {
   password?: string | null | undefined;

--- a/app/routes/stats.tsx
+++ b/app/routes/stats.tsx
@@ -15,7 +15,7 @@ import H3 from '~/routes/components/H3';
 
 import MostLostByDiscName from '~/routes/components/admin/stats/MostLostByDiscName';
 
-import type { JSX } from "react";
+import type { JSX } from 'react';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const isLoggedIn = await isUserLoggedIn(request);

--- a/e2e/number-search.spec.ts
+++ b/e2e/number-search.spec.ts
@@ -35,5 +35,8 @@ test('filter row controls are bottom-aligned', async ({ page }) => {
   expect(Math.abs(bottom(c) - bottom(s))).toBeLessThanOrEqual(4);
   expect(Math.abs(bottom(c) - bottom(b))).toBeLessThanOrEqual(4);
 
-  await page.screenshot({ path: 'e2e/__screens__/04-filter-row.png', clip: { x: 0, y: c.y - 60, width: 760, height: 140 } });
+  await page.screenshot({
+    path: 'e2e/__screens__/04-filter-row.png',
+    clip: { x: 0, y: c.y - 60, width: 760, height: 140 },
+  });
 });

--- a/prompts/full-bin.md
+++ b/prompts/full-bin.md
@@ -6,27 +6,27 @@ During the season, the lost and found bin might get full and now new discs fit.
 In such case it would be good if the user, who tried to add a new disc to the bin, could easily report
 that the bin is full
 
-I want to be able to print out a paper with a QR code and a suitable title that the user may take a 
+I want to be able to print out a paper with a QR code and a suitable title that the user may take a
 photo with his phone. When the url in the QR code is loaded, the user can click on a button saying
 "Bin is full".
 
-Previously we implemented a similar feature where the user could scan a QR code and report that he had 
+Previously we implemented a similar feature where the user could scan a QR code and report that he had
 returned a disc. Check that implementation for a reference. I need a similar download feature for the
 pdf file.
 
 ## Specs
+
 - route: bin/full/:course-name
   - bin/full/oittaa
   - use puskasoturit logo
   - currently only one course needs this
-
-
 
 ## Claude
 
 ⏺ Plan
 
 1. Route: app/routes/bin.full.$courseSlug.tsx → /bin/full/oittaa
+
 - Puskasoturit logo, Finnish heading ("Löytökiekkolaatikko täynnä?")
 - Single "Laatikko on täynnä" button; on submit writes a row and shows "Kiitos ilmoituksesta!"
 - Mirrors existing notify.$courseSlug.tsx pattern

--- a/prompts/support for adding multiple discs through website.md
+++ b/prompts/support for adding multiple discs through website.md
@@ -1,7 +1,7 @@
 # Support for adding multiple discs through website
 
-Before implementing a single piece of code, readh through this prompt and verify that my thesis is doable 
-without using an external agetic api (OpenAI etc). If ultracode, Fable or some other improved model/technique would 
+Before implementing a single piece of code, readh through this prompt and verify that my thesis is doable
+without using an external agetic api (OpenAI etc). If ultracode, Fable or some other improved model/technique would
 help, suggest what and why.
 
 Also before implementing anything, I'd like to read a plan on how you intend to go on.
@@ -12,6 +12,7 @@ Currently new discs can only be added by first inserting them into a google shee
 and import script, that fetches new rows from the sheet into database.
 
 Below are some data that I need to fill in when adding a new disc:
+
 - disc name (and plastic) of Disc ("Mako3, Star", "FD, C-Line", "Undertaker, Titanium") where names
   are Mako3, FD and Undertaker and plastics are Star, C-Line and Titanium
 - owner name
@@ -19,23 +20,23 @@ Below are some data that I need to fill in when adding a new disc:
 - disc color
 - club
 
-
 So far it has worked, but I'd like to investigate how much work it would take to make it possible
 to add 1 or more discs through the same web app that lists the discs.
 
 Top priority is to make it easy and quick to add multiple discs. Currently I add new discs by inserting data
-in a google sheet document, which is then read by my system: it fetches all new unsynced rows and stores them 
+in a google sheet document, which is then read by my system: it fetches all new unsynced rows and stores them
 into a database. Each row has a row id that is used for determining, if the row has been synced or not.
-The sync id is just a numeric value that increases by 1 each new row (I usually generate the row ids by 
+The sync id is just a numeric value that increases by 1 each new row (I usually generate the row ids by
 selecting a few existing values and then pulling down so that google maps generates them for me)
 
-One thing that slows down entering the data is that I have to manually type in the name of the manufacturer, 
+One thing that slows down entering the data is that I have to manually type in the name of the manufacturer,
 name of the disc, plastic type and colour.
 
-My initial thought is to build a database of manufacturers and what discs and plastics they have and also a list 
+My initial thought is to build a database of manufacturers and what discs and plastics they have and also a list
 colours I often use.
 
 The "New disc form" would have 1 textfield that I can type in texts like:
+
 - "Star Destroyer punainen 050 123 4567 Steve D."
 - "Mako3 keltainen"
 - "S-Line DD3 pinkki Peter D."
@@ -43,12 +44,12 @@ The "New disc form" would have 1 textfield that I can type in texts like:
 The system would analyze the content and try to identify, which parts describe the disc, the plastic, the weight,
 phone number and the owner's name. For example if it finds several numbers separated by single spaces, it should
 assume certain range is a phone number. Certain parts it would just have to check against a set of manufacturers,
-plastics, disc names. 
+plastics, disc names.
 
-I don't want to use any external AI api such as Open AI. I expect a simpler system oif regex and quick lookups 
+I don't want to use any external AI api such as Open AI. I expect a simpler system oif regex and quick lookups
 should work too. We are talking about quite standardized content.
 
-Before starting work with implementing a UI, setup a unit test environment (suggest suitable libraries), create 
+Before starting work with implementing a UI, setup a unit test environment (suggest suitable libraries), create
 tests using "red green refactor" methodology to build and test my thesis.
 
 Check directory (another disc golf related project) "/Users/janimattiellonen/Documents/Development/Frisbeegolf/DiscsForSale/data".
@@ -57,11 +58,13 @@ It has a somewhat comprehensive database of discs and manufacturers.
 From the same project, you can find "app/features/discs/discColors.ts" that contains commonly used colours.
 
 Below you can find more examples text that you can expect the admin user to enter in the textfield:
+
 - "Opto Ballista punainen Pekka P."
 - "Gold Stiletto kellertävä, Liisa"
 - "VIP King ruskea 050 111 9876"
 
 You can actually probably generate your own search texts. Some hints:
+
 - plastic may be omitted
 - disc name may be omitted
 - phone number may be omitted
@@ -72,8 +75,8 @@ You can actually probably generate your own search texts. Some hints:
 - some colours, manufacturers etc may not be found in the database
 - sometimes I may write "Tuntematon Innovan draiveri" which would point at an unknown driver made by Innova
 
-Start with the low hanging fruits and leave the hardest in the end. Analyze my example search texts to figure out, which 
-are easy and which are not. Prioritise them by how easy they most likely are to implement. During the first 
+Start with the low hanging fruits and leave the hardest in the end. Analyze my example search texts to figure out, which
+are easy and which are not. Prioritise them by how easy they most likely are to implement. During the first
 implementation round, stick with the very low hanging fruits.
 
 Run the unit tests and report back on your findings.
@@ -83,12 +86,14 @@ Run the unit tests and report back on your findings.
 Next up, let's create a simple UI prototype that I can use to test identification of entered text.
 
 A simple UI with two components:
+
 - text field for entering disc data
 - a table component that displays the parsed and identified data
 
 When I enter some text and press the Enter key, the identification process begins
 
 The table component contains columns with headers:
+
 - disc name, plastic, colour, manufacturer, phone number, owner name
 
 At this point, nothing in the table component is editable. Nothing is persisted over the network. Data, or parts of
@@ -96,13 +101,13 @@ the data is only added to the table. Columns may be left empty, if no value for 
 
 I can manually reset the page by reloading it, so no reset button is needed.
 
-As no data is sent over the network, no login check is required. Use the route "/demo" for this prototype. 
+As no data is sent over the network, no login check is required. Use the route "/demo" for this prototype.
 
 ## Phase 3 - editable data
 
 I usually enter details of several discs in a row, sometimes up to 30 discs.
 The prototype allows me to fill in quite quickly. Sometimes I do make mistakes. THus, I need to be able to
-quickly fix errors. 
+quickly fix errors.
 
 I want to be able to just click on a specific cell in the table to edit that specific data.
 When I have added all discs and certain that the entered data is correct, I'll submit the data, which
@@ -114,7 +119,6 @@ at this point). The static text is then replaced with the changes I may have mad
 
 This phase requires an in-memory data structure that holds the data displayed in the table.
 
-
 ## Phase 4 - allow removing a row
 
 Add a delete icon after each row. If pressed, ask for confirmation. If given, remove the row.
@@ -122,24 +126,22 @@ Add a delete icon after each row. If pressed, ask for confirmation. If given, re
 ## Phase 5 - persistence prototype
 
 No actual api calls yet. Just about everything else. I want to see what the "interface" looks like.
-Include error handling, displaying of error messages and success messages. 
-Add a submit button that sends data over to the server side. Replace button text with "Lähettää..." 
-during sending. Show a success box when data is successfully persisted. In this phase assume data is successfully 
-persisted. 
-
+Include error handling, displaying of error messages and success messages.
+Add a submit button that sends data over to the server side. Replace button text with "Lähettää..."
+during sending. Show a success box when data is successfully persisted. In this phase assume data is successfully
+persisted.
 
 ## Phase 6 - real persistence
 
-Next up, let's implement disc persistence. I just added a new column to discs: `external_id` (uuid). THis must be 
+Next up, let's implement disc persistence. I just added a new column to discs: `external_id` (uuid). THis must be
 generated and persisted manually.
 
 Note that club id must also be provided so that we can display correct discs on a public list.
 
-
 ## Phase 7 - deleting disc
 
 I want to be able to delete selected discs. I won't use this often but at times I may need to. Add a server-side
-function for deleting a disc. 
+function for deleting a disc.
 
 On the frontpage I have a table listing all the discs. When I'm signed in, an icon is shown in the phone column
 that allows me to send a message to the owner. In similar fashion, add a delete icon. When clicked, display an
@@ -148,23 +150,25 @@ content without page reload to remove the deleted disc. Use the external_id as d
 
 ## Phase 8 - marking disc as returned
 
-The discs table has a column `is_returned_to_owner`. I need a new admin tool to the table that allows me to mark 
-a disc as returned to the owner. Currently I add a manual entry to the google sheet: 
+The discs table has a column `is_returned_to_owner`. I need a new admin tool to the table that allows me to mark
+a disc as returned to the owner. Currently I add a manual entry to the google sheet:
+
 - "29.8.2026 (Janimatti), postitettu"
 - "28.8.2026 (Janimatti), noudettu"
 
-It records the date the disc was returned, who returned and basically whether the disc was sent by mail or the 
+It records the date the disc was returned, who returned and basically whether the disc was sent by mail or the
 owner fetched it in person.
 
 Previously there was another person besides me who handled the list so that's why a name is included in the
 message. Now I only handle these but the message format stuck.
 
-I want to record explicitly how the disc was returned (`return_method`, tinyint, nullable), using a dedicated column 
-in `clubs` table. We can use numerical representatio: (0: BY_MAIL, 1: PICKED_UP, .... ). 
-I also need a new column for the date of return (`returned_to_owner_date`, nullable). I no longer need to record 
+I want to record explicitly how the disc was returned (`return_method`, tinyint, nullable), using a dedicated column
+in `clubs` table. We can use numerical representatio: (0: BY_MAIL, 1: PICKED_UP, .... ).
+I also need a new column for the date of return (`returned_to_owner_date`, nullable). I no longer need to record
 the name of the "handler".
 
 The new admin tool icon should present me with a modal or an inline form with the fields:
+
 - date field
   - returned_to_owner_date
   - current date filled in by default
@@ -179,8 +183,9 @@ The new admin tool icon should present me with a modal or an inline form with th
 
 The discs table contains columns `can_be_sold_or_donated_text` and `can_be_sold_or_donated_date`.
 
-In a similar fashion as in phase 8, I need a new admin tool that I can mark a disc for sale or donation. An 
+In a similar fashion as in phase 8, I need a new admin tool that I can mark a disc for sale or donation. An
 inline form with the fields:
+
 - date field
   - can_be_sold_or_donated_date
   - current date filled in by default
@@ -192,7 +197,7 @@ inline form with the fields:
 
 ## Phase 10 - rename route
 
-Currently /demo is the route for adding new discs. Let's rename it to /discs/add. Also rename the files 
+Currently /demo is the route for adding new discs. Let's rename it to /discs/add. Also rename the files
 and components if needed.
 
-Make sure the route is protected and requires login. 
+Make sure the route is protected and requires login.


### PR DESCRIPTION
## Summary

The working tree had drifted from the repo's prettier config, so running `npm run format` on any feature branch produced churn in ~33 unrelated files. This applies the formatter once so future runs are a no-op.

No behavioral changes — the diff is entirely:
- `import type { JSX } from "react"` → single quotes
- short arrays in `app/features/discParser/data/*.json` collapsed onto one line (they fit in 120 cols)
- markdown reflow in two `prompts/*.md` files

## Test plan

- [ ] `npm run typecheck` passes (verified locally)
- [ ] `npm run format` afterwards reports no changes
- [ ] Review the diff is formatting-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)