### PR TITLE
docs(prompts): add the main menu cleanup prompt

### DIFF
--- a/prompts/main menu cleanup.md
+++ b/prompts/main menu cleanup.md
@@ -1,0 +1,7 @@
+# Main menu cleanup
+
+Create new branch.
+
+- Convert "Kirjaudu ulos" into a button with ButtonColor red.
+- Remove "Kirjautuneena: xxxx@yyy.com"
+- stylish the main menu a bit so that it pops out a little. Subtle visuals


### PR DESCRIPTION
## Summary

Adds `prompts/main menu cleanup.md`, the prompt notes behind #67, alongside the other prompt files already tracked in `prompts/`.

## Test plan

- [ ] Docs only — no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)