### PR TITLE
Support Puskasoturit as a second club

### DIFF
--- a/app/config/clubs.ts
+++ b/app/config/clubs.ts
@@ -1,0 +1,24 @@
+/**
+ * Per-club details that differ between the instances this codebase serves.
+ *
+ * The club itself comes from APP_CLUB_ID; everything here is keyed on it.
+ */
+
+export const PUSKASOTURIT = 1;
+export const TALIN_TALLAAJAT = 2;
+
+const CONTACT_EMAILS: Record<number, string> = {
+  [PUSKASOTURIT]: 'loytokiekot@puskasoturit.com',
+  [TALIN_TALLAAJAT]: 'janimatti.ellonen@gmail.com',
+};
+
+/**
+ * Where a visitor should write about a disc.
+ *
+ * Falls back to Talin Tallaajat's address, which is the one the help text
+ * carried before it was made per-club, so an unknown club still shows a
+ * working contact rather than nothing.
+ */
+export function getClubContactEmail(clubId: number | null): string {
+  return CONTACT_EMAILS[clubId ?? TALIN_TALLAAJAT] ?? CONTACT_EMAILS[TALIN_TALLAAJAT];
+}

--- a/app/config/clubs.ts
+++ b/app/config/clubs.ts
@@ -12,6 +12,20 @@ const CONTACT_EMAILS: Record<number, string> = {
   [TALIN_TALLAAJAT]: 'janimatti.ellonen@gmail.com',
 };
 
+const LOST_DISCS_URLS: Record<number, string> = {
+  [PUSKASOTURIT]: 'https://puskasoturit.com/index.php/loytokiekot/',
+  [TALIN_TALLAAJAT]: 'https://www.tallaajat.org/loytokiekot/',
+};
+
+/**
+ * The club's own lost-and-found page, which the disc list links to for the
+ * fuller story. Null for a club that has none, so the link can be left out
+ * rather than pointing somewhere wrong.
+ */
+export function getClubLostDiscsUrl(clubId: number | null): string | null {
+  return clubId === null ? null : (LOST_DISCS_URLS[clubId] ?? null);
+}
+
 /**
  * Where a visitor should write about a disc.
  *

--- a/app/config/clubs.ts
+++ b/app/config/clubs.ts
@@ -12,6 +12,30 @@ const CONTACT_EMAILS: Record<number, string> = {
   [TALIN_TALLAAJAT]: 'janimatti.ellonen@gmail.com',
 };
 
+/**
+ * The club's images. `favicon` is a small square where the club has one and the
+ * full logo otherwise, since a browser scales it either way.
+ */
+type ClubImages = { logo: string; favicon: string };
+
+const CLUB_IMAGES: Record<number, ClubImages> = {
+  [PUSKASOTURIT]: { logo: '/ps-logo.png', favicon: '/ps-logo.png' },
+  [TALIN_TALLAAJAT]: { logo: '/tt-sini-logo.jpg', favicon: '/tt-sini-logo-32-32.jpg' },
+};
+
+/**
+ * The logo shown beside the page title, and the favicon. Null for a club with
+ * no image on file, so the caller can leave the element out rather than render
+ * one pointing nowhere.
+ */
+export function getClubLogo(clubId: number | null): string | null {
+  return clubId === null ? null : (CLUB_IMAGES[clubId]?.logo ?? null);
+}
+
+export function getClubFavicon(clubId: number | null): string | null {
+  return clubId === null ? null : (CLUB_IMAGES[clubId]?.favicon ?? null);
+}
+
 const LOST_DISCS_URLS: Record<number, string> = {
   [PUSKASOTURIT]: 'https://puskasoturit.com/index.php/loytokiekot/',
   [TALIN_TALLAAJAT]: 'https://www.tallaajat.org/loytokiekot/',

--- a/app/config/courses.ts
+++ b/app/config/courses.ts
@@ -3,14 +3,41 @@ export type Course = {
   name: string;
   clubId: number;
   clubName: string;
+  /**
+   * The value this course carries in the `course` column of `discs`, for the
+   * clubs that record one. It is the short name the Google Sheet has always
+   * used ("Oittaa"), not the long display name above, so a disc added by hand
+   * lands under the same option in the list page's course filter as an
+   * imported one. Absent for clubs that record no course per disc.
+   */
+  discCourseName?: string;
 };
 
 export const courses: Course[] = [
   { slug: 'tali', name: 'Talin frisbeegolfpuisto', clubId: 2, clubName: 'Talin tallaajat ry' },
-  { slug: 'oittaa', name: 'Oittaan frisbeegolfrata', clubId: 1, clubName: 'Puskasoturit ry' },
-  { slug: 'aijanpelto', name: 'Äijänpelto frisbeegolf', clubId: 1, clubName: 'Puskasoturit ry' },
+  { slug: 'oittaa', name: 'Oittaan frisbeegolfrata', clubId: 1, clubName: 'Puskasoturit ry', discCourseName: 'Oittaa' },
+  {
+    slug: 'aijanpelto',
+    name: 'Äijänpelto frisbeegolf',
+    clubId: 1,
+    clubName: 'Puskasoturit ry',
+    discCourseName: 'Äijänpelto',
+  },
 ];
 
 export function getCourseBySlug(slug: string): Course | undefined {
   return courses.find((course) => course.slug === slug);
+}
+
+/**
+ * The course names a disc of this club may be filed under, in the order they
+ * should be offered. Empty for a club that collects from a single course, which
+ * is how the add form knows not to ask for one at all.
+ */
+export function getDiscCourseNames(clubId: number): string[] {
+  const names = courses
+    .filter((course) => course.clubId === clubId && course.discCourseName != null)
+    .map((course) => course.discCourseName!);
+
+  return names.length > 1 ? names : [];
 }

--- a/app/features/discs/list/CourseFilter.tsx
+++ b/app/features/discs/list/CourseFilter.tsx
@@ -1,0 +1,41 @@
+import type { JSX } from 'react';
+
+import * as stylex from '@stylexjs/stylex';
+
+import { color } from '~/styles/tokens.stylex';
+import FormControlLabel from '~/ui/FormControlLabel';
+import { Radio, RadioGroup } from '~/ui/RadioGroup';
+
+// The value the "all courses" option carries. Empty so it can never collide
+// with a real course name coming from the data.
+const ALL_COURSES = '';
+
+type CourseFilterProps = {
+  courses: string[];
+  onChange: (course: string | null) => void;
+};
+
+const styles = stylex.create({
+  label: { display: 'block', fontWeight: 700, marginBottom: '4px', color: color.textSecondary },
+});
+
+export default function CourseFilter({ courses, onChange }: CourseFilterProps): JSX.Element {
+  return (
+    <div>
+      <span {...stylex.props(styles.label)}>Rata</span>
+      <RadioGroup
+        row
+        name="course"
+        onChange={(e) => {
+          const { value } = e.target as HTMLInputElement;
+          onChange(value === ALL_COURSES ? null : value);
+        }}
+      >
+        <FormControlLabel control={<Radio defaultChecked />} value={ALL_COURSES} label="Kaikki radat" />
+        {courses.map((course) => (
+          <FormControlLabel key={course} control={<Radio />} value={course} label={course} />
+        ))}
+      </RadioGroup>
+    </div>
+  );
+}

--- a/app/features/discs/list/DateAndMethodForm.tsx
+++ b/app/features/discs/list/DateAndMethodForm.tsx
@@ -59,12 +59,15 @@ export default function DateAndMethodForm<V extends number>({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-6 py-2">
-      <p className="basis-full text-xs text-gray-600">
+      {/* The form opens inside the dark disc table, so its text has to be
+          light: the gray-600 of a form on a white page all but disappeared
+          against the row behind it. */}
+      <p className="basis-full text-xs text-gray-300">
         {title}: <b>{discName}</b>
       </p>
 
       <div>
-        <label htmlFor={`${idPrefix}-date`} className="block text-xs font-bold text-gray-600 mb-1">
+        <label htmlFor={`${idPrefix}-date`} className="block text-xs font-bold text-gray-300 mb-1">
           {dateLabel}
         </label>
         <input
@@ -73,12 +76,12 @@ export default function DateAndMethodForm<V extends number>({
           required
           value={date}
           onChange={(event) => setDate(event.currentTarget.value)}
-          className="border border-gray-300 rounded px-2 py-1"
+          className="border border-gray-300 rounded px-2 py-1 bg-white text-gray-900"
         />
       </div>
 
       <fieldset>
-        <legend className="text-xs font-bold text-gray-600 mb-1">{methodLabel}</legend>
+        <legend className="text-xs font-bold text-gray-300 mb-1">{methodLabel}</legend>
         <div className="flex items-center gap-4">
           {options.map((option) => (
             <label key={option.value} className="inline-flex items-center gap-1">
@@ -97,7 +100,7 @@ export default function DateAndMethodForm<V extends number>({
             type="button"
             disabled={method === null}
             onClick={() => setMethod(null)}
-            className="text-xs underline text-gray-500 disabled:opacity-40 disabled:no-underline"
+            className="text-xs underline text-gray-300 disabled:opacity-40 disabled:no-underline"
           >
             Tyhjennä
           </button>
@@ -113,12 +116,12 @@ export default function DateAndMethodForm<V extends number>({
           {isSaving ? 'Tallennetaan...' : submitLabel}
         </button>
 
-        <button type="button" onClick={onCancel} className="border border-gray-300 hover:bg-gray-100 rounded px-3 py-1">
+        <button type="button" onClick={onCancel} className="border border-gray-300 hover:bg-white/10 rounded px-3 py-1">
           Peruuta
         </button>
       </div>
 
-      {error && <p className="basis-full text-red-700">{error}</p>}
+      {error && <p className="basis-full text-red-300">{error}</p>}
     </form>
   );
 }

--- a/app/features/discs/list/DiscListIntro.tsx
+++ b/app/features/discs/list/DiscListIntro.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 
-import { TALIN_TALLAAJAT } from '~/config/clubs';
+import { getClubLostDiscsUrl } from '~/config/clubs';
 import { WarningIcon } from '~/ui/icons';
 
 type DiscListIntroProps = {
@@ -10,14 +10,17 @@ type DiscListIntroProps = {
 /**
  * What a club says above its disc list.
  *
- * Only Talin Tallaajat has written one; every other club (and the moment
- * before the club id has loaded) renders nothing. A second club's intro goes
- * here as another branch rather than back into the page.
+ * The text is the same for every club; only the link to the club's own
+ * lost-and-found page differs, and it is left out for a club that has none.
+ * Nothing renders until the club id has loaded, so the intro does not appear
+ * with a missing link and then gain one.
  */
 export default function DiscListIntro({ clubId }: DiscListIntroProps): JSX.Element | null {
-  if (clubId !== TALIN_TALLAAJAT) {
+  if (clubId === null) {
     return null;
   }
+
+  const lostDiscsUrl = getClubLostDiscsUrl(clubId);
 
   return (
     <div className="mt-8 max-w-4xl">
@@ -34,9 +37,11 @@ export default function DiscListIntro({ clubId }: DiscListIntroProps): JSX.Eleme
         vastaa viestiin "Kiekko haettu".
       </p>
 
-      <p>
-        Tarkemmat tiedot seuran <a href="https://www.tallaajat.org/loytokiekot/">löytökiekoista</a>.
-      </p>
+      {lostDiscsUrl && (
+        <p>
+          Tarkemmat tiedot seuran <a href={lostDiscsUrl}>löytökiekoista</a>.
+        </p>
+      )}
 
       <p>Vinkki: taulukon otsikoita painamalla voit järjestää sisällön halutulla tavalla.</p>
 

--- a/app/features/discs/list/DiscListIntro.tsx
+++ b/app/features/discs/list/DiscListIntro.tsx
@@ -32,11 +32,6 @@ export default function DiscListIntro({ clubId }: DiscListIntroProps): JSX.Eleme
 
       <p>Jos kiekosta löytyy selkeästi luettava puhelinnumero, lähetetään siihen viestiä kiekon löytymisestä.</p>
 
-      <p>
-        Jos olet hakenut kopilta kiekkosi, jonka löytymisestä sait viestin puhelinnumerosta, joka päättyy <b>3904</b>,
-        vastaa viestiin "Kiekko haettu".
-      </p>
-
       {lostDiscsUrl && (
         <p>
           Tarkemmat tiedot seuran <a href={lostDiscsUrl}>löytökiekoista</a>.

--- a/app/features/discs/list/DiscListIntro.tsx
+++ b/app/features/discs/list/DiscListIntro.tsx
@@ -1,0 +1,53 @@
+import type { JSX } from 'react';
+
+import { TALIN_TALLAAJAT } from '~/config/clubs';
+import { WarningIcon } from '~/ui/icons';
+
+type DiscListIntroProps = {
+  clubId: number | null;
+};
+
+/**
+ * What a club says above its disc list.
+ *
+ * Only Talin Tallaajat has written one; every other club (and the moment
+ * before the club id has loaded) renders nothing. A second club's intro goes
+ * here as another branch rather than back into the page.
+ */
+export default function DiscListIntro({ clubId }: DiscListIntroProps): JSX.Element | null {
+  if (clubId !== TALIN_TALLAAJAT) {
+    return null;
+  }
+
+  return (
+    <div className="mt-8 max-w-4xl">
+      <p>
+        Tällä sivulla luetellaan vain palauttamattomat kiekot, jotka ovat edelleen seuran hallussa. Kiekon tila (onko
+        palautettu/myyty/lahjoitettu) saattaa olla virheellinen, jolloin listalla voi näkyä kiekko, joka ei enää ole
+        seuralla.
+      </p>
+
+      <p>Jos kiekosta löytyy selkeästi luettava puhelinnumero, lähetetään siihen viestiä kiekon löytymisestä.</p>
+
+      <p>
+        Jos olet hakenut kopilta kiekkosi, jonka löytymisestä sait viestin puhelinnumerosta, joka päättyy <b>3904</b>,
+        vastaa viestiin "Kiekko haettu".
+      </p>
+
+      <p>
+        Tarkemmat tiedot seuran <a href="https://www.tallaajat.org/loytokiekot/">löytökiekoista</a>.
+      </p>
+
+      <p>Vinkki: taulukon otsikoita painamalla voit järjestää sisällön halutulla tavalla.</p>
+
+      <p>
+        <WarningIcon
+          title={'Kiekko on ollut seuran hallussa yli 3kk ja se saatetaan pian myydä tai lahjoittaa'}
+          style={{ color: 'red', marginRight: '0.5rem' }}
+        />
+        Jos lisäyspäivämäärän jälkeen näkyy kyseinen kuvake, on kiekko ollut seuran hallussa yli 3kk ja se saatetaan
+        pian myydä tai lahjoittaa.
+      </p>
+    </div>
+  );
+}

--- a/app/features/discs/list/DiscListPage.tsx
+++ b/app/features/discs/list/DiscListPage.tsx
@@ -86,6 +86,10 @@ export default function DiscListPage(): JSX.Element {
     }
   }, [fetcher.data]);
 
+  // Only Puskasoturit collects from more than one course. Talin Tallaajat
+  // records no course at all, so neither the filter nor the column applies.
+  const isMultiCourseClub = clubId === 1;
+
   const hasDiscs = discs.length > 0;
   // A reload keeps the previous fetcher.data, so "loading with data already on
   // screen" is what separates a refresh from the very first load.
@@ -152,9 +156,11 @@ export default function DiscListPage(): JSX.Element {
 
           <NumberSearch onChange={debouncedHandler} />
 
-          {/* Only clubs whose discs come from more than one course have
-              anything to choose between. */}
-          {distinctCourses.length > 1 && <CourseFilter courses={distinctCourses} onChange={setCourseTerm} />}
+          {/* Nothing to choose between until the loaded discs name more than
+              one course. */}
+          {isMultiCourseClub && distinctCourses.length > 1 && (
+            <CourseFilter courses={distinctCourses} onChange={setCourseTerm} />
+          )}
 
           <Button
             variant="contained"
@@ -179,7 +185,7 @@ export default function DiscListPage(): JSX.Element {
             for the first load only, when there is nothing to show yet. */}
         {hasDiscs && (
           <div aria-busy={isReloading} className={isReloading ? 'opacity-50 transition-opacity' : undefined}>
-            <DiscTable discs={discs} showCourse={clubId === 1} onChanged={() => fetcher.load('/discs/data')} />
+            <DiscTable discs={discs} showCourse={isMultiCourseClub} onChanged={() => fetcher.load('/discs/data')} />
           </div>
         )}
         {isFirstLoad && <CircularProgress style={{ width: '5rem', height: '5rem' }} />}

--- a/app/features/discs/list/DiscListPage.tsx
+++ b/app/features/discs/list/DiscListPage.tsx
@@ -8,12 +8,12 @@ import Collapse from '~/ui/Collapse';
 import Paper from '~/ui/Paper';
 import InfoBox from '~/ui/InfoBox';
 import EmptyingLogItem from '~/ui/EmptyingLogItem';
-import { WarningIcon } from '~/ui/icons';
 import CircularProgress from '~/ui/CircularProgress';
 
 import DiscTable from '~/features/discs/list/DiscTable';
 import type { DiscDTO, EmptyingLogDTO } from '~/types';
 import DiscSelector from '~/features/discs/list/DiscSelector';
+import DiscListIntro from '~/features/discs/list/DiscListIntro';
 import CourseFilter from '~/features/discs/list/CourseFilter';
 import NumberSearch from '~/ui/NumberSearch';
 
@@ -98,37 +98,7 @@ export default function DiscListPage(): JSX.Element {
 
   return (
     <div>
-      {clubId === 2 && (
-        <div className="mt-8 max-w-4xl">
-          <p>
-            Tällä sivulla luetellaan vain palauttamattomat kiekot, jotka ovat edelleen seuran hallussa. Kiekon tila
-            (onko palautettu/myyty/lahjoitettu) saattaa olla virheellinen, jolloin listalla voi näkyä kiekko, joka ei
-            enää ole seuralla.
-          </p>
-
-          <p>Jos kiekosta löytyy selkeästi luettava puhelinnumero, lähetetään siihen viestiä kiekon löytymisestä.</p>
-
-          <p>
-            Jos olet hakenut kopilta kiekkosi, jonka löytymisestä sait viestin puhelinnumerosta, joka päättyy{' '}
-            <b>3904</b>, vastaa viestiin "Kiekko haettu".
-          </p>
-
-          <p>
-            Tarkemmat tiedot seuran <a href="https://www.tallaajat.org/loytokiekot/">löytökiekoista</a>.
-          </p>
-
-          <p>Vinkki: taulukon otsikoita painamalla voit järjestää sisällön halutulla tavalla.</p>
-
-          <p>
-            <WarningIcon
-              title={'Kiekko on ollut seuran hallussa yli 3kk ja se saatetaan pian myydä tai lahjoittaa'}
-              style={{ color: 'red', marginRight: '0.5rem' }}
-            />
-            Jos lisäyspäivämäärän jälkeen näkyy kyseinen kuvake, on kiekko ollut seuran hallussa yli 3kk ja se saatetaan
-            pian myydä tai lahjoittaa.
-          </p>
-        </div>
-      )}
+      <DiscListIntro clubId={clubId} />
       <div className="mt-8">
         {emptyingLogItems.length > 0 && (
           <div>

--- a/app/features/discs/list/DiscListPage.tsx
+++ b/app/features/discs/list/DiscListPage.tsx
@@ -16,6 +16,7 @@ import DiscSelector from '~/features/discs/list/DiscSelector';
 import DiscListIntro from '~/features/discs/list/DiscListIntro';
 import CourseFilter from '~/features/discs/list/CourseFilter';
 import NumberSearch from '~/ui/NumberSearch';
+import { getDiscCourseNames } from '~/config/courses';
 
 export default function DiscListPage(): JSX.Element {
   const fetcher = useFetcher();
@@ -71,7 +72,9 @@ export default function DiscListPage(): JSX.Element {
 
   // Only Puskasoturit collects from more than one course. Talin Tallaajat
   // records no course at all, so neither the filter nor the column applies.
-  const isMultiCourseClub = clubId === 1;
+  // Derived rather than a club id in a literal: the filter, the column and the
+  // add form then agree by construction, all reading the one course list.
+  const isMultiCourseClub = clubId !== null && getDiscCourseNames(clubId).length > 0;
 
   const hasDiscs = discs.length > 0;
   // A reload keeps the previous fetcher.data, so "loading with data already on

--- a/app/features/discs/list/DiscListPage.tsx
+++ b/app/features/discs/list/DiscListPage.tsx
@@ -14,6 +14,7 @@ import CircularProgress from '~/ui/CircularProgress';
 import DiscTable from '~/features/discs/list/DiscTable';
 import type { DiscDTO, EmptyingLogDTO } from '~/types';
 import DiscSelector from '~/features/discs/list/DiscSelector';
+import CourseFilter from '~/features/discs/list/CourseFilter';
 import NumberSearch from '~/ui/NumberSearch';
 
 export default function DiscListPage(): JSX.Element {
@@ -23,10 +24,12 @@ export default function DiscListPage(): JSX.Element {
   const [emptyingLogItems, setEmptyingLogItems] = useState<EmptyingLogDTO[]>([]);
   const [discTerm, setDiscTerm] = useState<string | null>('');
   const [phoneNumberTerm, setPhoneNumberTerm] = useState<string | null>('');
+  const [courseTerm, setCourseTerm] = useState<string | null>(null);
 
   const [clubId, setClubId] = useState<number | null>(null);
 
   const [distinctDiscNames, setDistinctDiscNames] = useState<string[]>([]);
+  const [distinctCourses, setDistinctCourses] = useState<string[]>([]);
 
   const changeHandler = (e: any): void => {
     if (e.target.value.length > 2) {
@@ -53,8 +56,12 @@ export default function DiscListPage(): JSX.Element {
       filtered = filtered.filter((disc: DiscDTO) => disc.ownerPhoneNumber?.endsWith(phoneNumberTerm));
     }
 
+    if (courseTerm) {
+      filtered = filtered.filter((disc: DiscDTO) => disc.course === courseTerm);
+    }
+
     return filtered;
-  }, [fetcher.data, discTerm, phoneNumberTerm]);
+  }, [fetcher.data, discTerm, phoneNumberTerm, courseTerm]);
 
   useEffect(() => {
     fetcher.load('/discs/data');
@@ -68,6 +75,10 @@ export default function DiscListPage(): JSX.Element {
 
     if (fetcher.data?.distinctDiscNames) {
       setDistinctDiscNames(fetcher.data?.distinctDiscNames);
+    }
+
+    if (fetcher.data?.distinctCourses) {
+      setDistinctCourses(fetcher.data?.distinctCourses);
     }
 
     if (fetcher.data?.emptyingLogItems) {
@@ -129,7 +140,9 @@ export default function DiscListPage(): JSX.Element {
         )}
       </div>
       <div className="mt-8">
-        <div className="flex gap-4 items-end">
+        {/* Stacked on a phone: side by side the fields were squeezed to a few
+            characters wide. From `sm` up they sit in a row that wraps. */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end">
           <DiscSelector
             discNames={distinctDiscNames}
             onChange={(selectedItem: string | null) => {
@@ -139,7 +152,16 @@ export default function DiscListPage(): JSX.Element {
 
           <NumberSearch onChange={debouncedHandler} />
 
-          <Button variant="contained" type="submit" onClick={() => showInfoBox(!isInfoBoxVisible)}>
+          {/* Only clubs whose discs come from more than one course have
+              anything to choose between. */}
+          {distinctCourses.length > 1 && <CourseFilter courses={distinctCourses} onChange={setCourseTerm} />}
+
+          <Button
+            variant="contained"
+            type="submit"
+            className="h-10 self-start sm:self-auto"
+            onClick={() => showInfoBox(!isInfoBoxVisible)}
+          >
             Ohjeet
           </Button>
         </div>
@@ -157,7 +179,7 @@ export default function DiscListPage(): JSX.Element {
             for the first load only, when there is nothing to show yet. */}
         {hasDiscs && (
           <div aria-busy={isReloading} className={isReloading ? 'opacity-50 transition-opacity' : undefined}>
-            <DiscTable discs={discs} onChanged={() => fetcher.load('/discs/data')} />
+            <DiscTable discs={discs} showCourse={clubId === 1} onChanged={() => fetcher.load('/discs/data')} />
           </div>
         )}
         {isFirstLoad && <CircularProgress style={{ width: '5rem', height: '5rem' }} />}

--- a/app/features/discs/list/DiscListPage.tsx
+++ b/app/features/discs/list/DiscListPage.tsx
@@ -21,15 +21,16 @@ export default function DiscListPage(): JSX.Element {
   const fetcher = useFetcher();
 
   const [isInfoBoxVisible, showInfoBox] = useState<boolean>(false);
-  const [emptyingLogItems, setEmptyingLogItems] = useState<EmptyingLogDTO[]>([]);
   const [discTerm, setDiscTerm] = useState<string | null>('');
   const [phoneNumberTerm, setPhoneNumberTerm] = useState<string | null>('');
   const [courseTerm, setCourseTerm] = useState<string | null>(null);
 
-  const [clubId, setClubId] = useState<number | null>(null);
-
-  const [distinctDiscNames, setDistinctDiscNames] = useState<string[]>([]);
-  const [distinctCourses, setDistinctCourses] = useState<string[]>([]);
+  // Read straight off the fetcher rather than copied into state by an effect:
+  // the copy bought nothing and cost a second render on every load.
+  const clubId: number | null = fetcher.data?.clubId ?? null;
+  const distinctDiscNames: string[] = fetcher.data?.distinctDiscNames ?? [];
+  const distinctCourses: string[] = fetcher.data?.distinctCourses ?? [];
+  const emptyingLogItems: EmptyingLogDTO[] = fetcher.data?.emptyingLogItems ?? [];
 
   const changeHandler = (e: any): void => {
     if (e.target.value.length > 2) {
@@ -67,24 +68,6 @@ export default function DiscListPage(): JSX.Element {
     fetcher.load('/discs/data');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    if (fetcher.data?.clubId) {
-      setClubId(fetcher.data?.clubId);
-    }
-
-    if (fetcher.data?.distinctDiscNames) {
-      setDistinctDiscNames(fetcher.data?.distinctDiscNames);
-    }
-
-    if (fetcher.data?.distinctCourses) {
-      setDistinctCourses(fetcher.data?.distinctCourses);
-    }
-
-    if (fetcher.data?.emptyingLogItems) {
-      setEmptyingLogItems(fetcher.data?.emptyingLogItems);
-    }
-  }, [fetcher.data]);
 
   // Only Puskasoturit collects from more than one course. Talin Tallaajat
   // records no course at all, so neither the filter nor the column applies.
@@ -145,7 +128,9 @@ export default function DiscListPage(): JSX.Element {
         <div className="mt-4 mb-4">
           {
             <Collapse in={isInfoBoxVisible}>
-              <Paper elevation={3} children={<InfoBox clubId={clubId} onClose={() => showInfoBox(false)} />} />
+              <Paper elevation={3}>
+                <InfoBox clubId={clubId} onClose={() => showInfoBox(false)} />
+              </Paper>
             </Collapse>
           }
         </div>

--- a/app/features/discs/list/DiscListPage.tsx
+++ b/app/features/discs/list/DiscListPage.tsx
@@ -175,7 +175,7 @@ export default function DiscListPage(): JSX.Element {
         <div className="mt-4 mb-4">
           {
             <Collapse in={isInfoBoxVisible}>
-              <Paper elevation={3} children={<InfoBox onClose={() => showInfoBox(false)} />} />
+              <Paper elevation={3} children={<InfoBox clubId={clubId} onClose={() => showInfoBox(false)} />} />
             </Collapse>
           }
         </div>

--- a/app/features/discs/list/DiscSelector.tsx
+++ b/app/features/discs/list/DiscSelector.tsx
@@ -3,7 +3,7 @@ import { useMemo, useRef, useState, type JSX } from 'react';
 import { useCombobox } from 'downshift';
 import * as stylex from '@stylexjs/stylex';
 
-import { color, radius } from '~/styles/tokens.stylex';
+import { color, radius, size } from '~/styles/tokens.stylex';
 
 type DiscSelectorProps = {
   discNames: string[];
@@ -13,11 +13,14 @@ type DiscSelectorProps = {
 const MENU_MAX_HEIGHT = 240;
 
 const styles = stylex.create({
-  root: { width: '300px' },
+  // Full width on a phone, where the filters stack; a fixed 300px once they sit
+  // in a row, where shrinking squeezed the field down to the chevron alone.
+  root: { width: { default: '100%', '@media (min-width: 600px)': '300px' }, flexShrink: 0 },
   label: { display: 'block', fontWeight: 700, marginBottom: '4px', color: color.textSecondary },
   inputWrap: { position: 'relative', display: 'flex', alignItems: 'center' },
   input: {
     width: '100%',
+    height: size.control,
     boxSizing: 'border-box',
     padding: '8px 36px 8px 12px',
     fontFamily: 'inherit',

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -413,6 +413,10 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
 
   const [sorting, setSorting] = useState<SortingState>([{ id: 'addedAt', desc: true }]);
 
+  // TanStack Table returns functions the React Compiler cannot memoize, so it
+  // skips this component. Nothing here is passed to a memoized consumer, and
+  // the alternative is a table library change.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: rows,
     columns,

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -296,6 +296,7 @@ function DeleteButton({ row, onDeleted }: DeleteButtonProps): JSX.Element | null
     <button
       type="button"
       aria-label={`Poista kiekko ${row.discName}`}
+      title="Poista kiekko"
       disabled={isDeleting}
       onClick={handleClick}
       className="inline-flex text-gray-500 hover:text-red-600 disabled:opacity-40"
@@ -382,6 +383,7 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
                       <button
                         type="button"
                         aria-label={`Merkitse kiekko ${row.original.discName} palautetuksi`}
+                        title="Merkitse palautetuksi"
                         aria-expanded={openForm?.externalId === row.original.externalId && openForm.kind === 'return'}
                         onClick={() => toggleForm(row.original.externalId!, 'return')}
                         className="inline-flex text-gray-500 hover:text-green-700"
@@ -392,6 +394,7 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
                       <button
                         type="button"
                         aria-label={`Merkitse kiekko ${row.original.discName} myytäväksi tai lahjoitettavaksi`}
+                        title="Merkitse myytäväksi tai lahjoitettavaksi"
                         aria-expanded={openForm?.externalId === row.original.externalId && openForm.kind === 'disposal'}
                         onClick={() => toggleForm(row.original.externalId!, 'disposal')}
                         className="inline-flex text-gray-500 hover:text-blue-700"

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -38,6 +38,8 @@ type DiscTableProps = {
   discs: DiscDTO[];
   /** Called after a disc has been deleted or marked returned, to reload the list. */
   onChanged?: () => void;
+  /** Only clubs that collect from more than one course record a course per disc. */
+  showCourse?: boolean;
 };
 
 interface Row {
@@ -46,6 +48,7 @@ interface Row {
   discColour: string;
   owner: string;
   ownerPhoneNumber: string;
+  course: string;
   addedAt: string;
   internalDiscId: number | null;
   /** Only present for a signed-in visitor; the admin actions are keyed on it. */
@@ -66,7 +69,8 @@ function getComparator(sortColumn: string): Comparator {
     case 'discName':
     case 'discColour':
     case 'owner':
-    case 'ownerPhoneNumber': {
+    case 'ownerPhoneNumber':
+    case 'course': {
       return (a, b) => a[sortColumn].localeCompare(b[sortColumn]);
     }
     case 'addedAt': {
@@ -160,6 +164,7 @@ function mapToDataRows(discs: DiscDTO[]): Row[] {
     discColour: disc.discColour,
     owner: disc.ownerName ?? '',
     ownerPhoneNumber: disc.ownerPhoneNumber ?? '',
+    course: disc.course ?? '',
     addedAt: disc.addedAt ?? '',
     internalDiscId: disc.internalDiscId,
     externalId: disc.externalId,
@@ -300,7 +305,7 @@ function DeleteButton({ row, onDeleted }: DeleteButtonProps): JSX.Element | null
   );
 }
 
-export default function DiscTable({ discs, onChanged }: DiscTableProps): JSX.Element | null {
+export default function DiscTable({ discs, onChanged, showCourse = false }: DiscTableProps): JSX.Element | null {
   const { session } = useOutletContext<OutletContext>();
   const isLoggedIn = !!session?.user?.id;
 
@@ -343,6 +348,7 @@ export default function DiscTable({ discs, onChanged }: DiscTableProps): JSX.Ele
             ''
           ),
       },
+      ...(showCourse ? [{ accessorKey: 'course', header: 'Rata', sortingFn: sortDiscs } satisfies ColumnDef<Row>] : []),
       {
         accessorKey: 'addedAt',
         header: 'Lisätty',
@@ -402,7 +408,7 @@ export default function DiscTable({ discs, onChanged }: DiscTableProps): JSX.Ele
           ]
         : []),
     ],
-    [isLoggedIn, onChanged, openForm],
+    [isLoggedIn, onChanged, openForm, showCourse],
   );
 
   const [sorting, setSorting] = useState<SortingState>([{ id: 'addedAt', desc: true }]);

--- a/app/features/discs/list/loadDiscListData.server.ts
+++ b/app/features/discs/list/loadDiscListData.server.ts
@@ -1,7 +1,7 @@
 import { getDiscs } from '~/models/discs.server';
 import { getEmptyingLogItemsForClub } from '~/models/emptyingLog.server';
 import { isUserLoggedIn } from '~/models/utils';
-import { getDistinctDiscNames } from '~/utils';
+import { getDistinctCourses, getDistinctDiscNames } from '~/utils';
 
 /** Everything the public disc list renders, for the club this instance serves. */
 export async function loadDiscListData(request: Request) {
@@ -15,5 +15,11 @@ export async function loadDiscListData(request: Request) {
   const isLoggedIn = await isUserLoggedIn(request);
   const data = isLoggedIn ? discs : discs.map((disc) => ({ ...disc, externalId: undefined }));
 
-  return { clubId, data, distinctDiscNames: getDistinctDiscNames(data), emptyingLogItems };
+  return {
+    clubId,
+    data,
+    distinctDiscNames: getDistinctDiscNames(data),
+    distinctCourses: getDistinctCourses(data),
+    emptyingLogItems,
+  };
 }

--- a/app/features/discs/submission/AddDiscsPage.tsx
+++ b/app/features/discs/submission/AddDiscsPage.tsx
@@ -102,6 +102,11 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
   const missingCourseCount = courses.length > 0 ? rows.filter((row) => row.course == null).length : 0;
   const isCourseMissing = missingCourseCount > 0;
 
+  // Offered whenever it would change something: setting a course needs a row
+  // that lacks it or carries another one, clearing needs a row that has one.
+  const isApplyToAllUseful =
+    course === NO_COURSE ? rows.some((row) => row.course != null) : rows.some((row) => row.course !== course);
+
   const isSending = submitState.status === 'sending';
 
   async function handleSave(): Promise<void> {
@@ -158,10 +163,16 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
             <p {...stylex.props(styles.hint)}>Valinta koskee tästä eteenpäin lisättäviä kiekkoja.</p>
 
             {/* The one-click fix when the batch was typed in before the course
-                was chosen, or when it was chosen wrong. */}
-            {rows.length > 0 && course !== NO_COURSE && (
+                was chosen, or when it was chosen wrong. "Ei radan tietoa"
+                clears the batch, which is the way back from applying the wrong
+                course to all of it. */}
+            {isApplyToAllUseful && (
               <button type="button" onClick={applyCourseToAll} {...stylex.props(styles.applyButton)}>
-                Aseta rata &quot;{course}&quot; kaikille riveille
+                {course === NO_COURSE ? (
+                  'Poista rata kaikilta riveiltä'
+                ) : (
+                  <>Aseta rata &quot;{course}&quot; kaikille riveille</>
+                )}
               </button>
             )}
           </div>

--- a/app/features/discs/submission/AddDiscsPage.tsx
+++ b/app/features/discs/submission/AddDiscsPage.tsx
@@ -5,10 +5,25 @@ import * as stylex from '@stylexjs/stylex';
 import { parseDiscText, type ParsedDisc } from '~/features/discs/submission/parser/parseDiscText';
 import { submitDiscs, toSubmission } from '~/features/discs/submission/submitDiscs';
 import { DeleteIcon } from '~/ui/icons';
+import FormControlLabel from '~/ui/FormControlLabel';
+import { Radio, RadioGroup } from '~/ui/RadioGroup';
 import { color, font, radius, space } from '~/styles/tokens.stylex';
 
-export default function AddDiscsPage(): JSX.Element {
+type AddDiscsPageProps = {
+  /** The courses this club files discs under; empty for a single-course club. */
+  courses: string[];
+};
+
+// The value the "no course" option carries. Empty so it can never collide with
+// a real course name.
+const NO_COURSE = '';
+
+export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Element {
   const [rows, setRows] = useState<Row[]>([]);
+  // The course new rows are filed under. Kept across entries, since a batch is
+  // normally one bin's worth. The course is never read out of the typed text:
+  // this selection is its only source.
+  const [course, setCourse] = useState<string>(NO_COURSE);
   const [editing, setEditing] = useState<EditTarget | null>(null);
   // The row whose delete button has been pressed and is awaiting a yes/no.
   const [confirmingDelete, setConfirmingDelete] = useState<number | null>(null);
@@ -47,6 +62,14 @@ export default function AddDiscsPage(): JSX.Element {
     setEditing(null);
   }
 
+  /**
+   * Files every row still waiting to be saved under the selected course. The
+   * one-click fix for a batch typed in before the course was chosen.
+   */
+  function applyCourseToAll(): void {
+    updateRows((current) => current.map((row) => ({ ...row, course: course || null })));
+  }
+
   function remove(rowId: number): void {
     updateRows((current) => current.filter((row) => row.id !== rowId));
     setConfirmingDelete(null);
@@ -66,11 +89,18 @@ export default function AddDiscsPage(): JSX.Element {
       return;
     }
 
-    updateRows((current) => [...current, { id: nextId.current++, input: text, ...parseDiscText(text) }]);
+    updateRows((current) => [
+      ...current,
+      { id: nextId.current++, input: text, course: course || null, ...parseDiscText(text) },
+    ]);
 
     // Clear so the next disc can be typed straight away.
     form.reset();
   }
+
+  // Only worth nagging about for a club that records a course at all.
+  const missingCourseCount = courses.length > 0 ? rows.filter((row) => row.course == null).length : 0;
+  const isCourseMissing = missingCourseCount > 0;
 
   const isSending = submitState.status === 'sending';
 
@@ -115,7 +145,38 @@ export default function AddDiscsPage(): JSX.Element {
           {...stylex.props(styles.input)}
         />
         <p {...stylex.props(styles.hint)}>Paina Enter tunnistaaksesi tiedot.</p>
+
+        {courses.length > 0 && (
+          <div {...stylex.props(styles.courseField)}>
+            <span {...stylex.props(styles.label)}>Rata</span>
+            <RadioGroup row name="course" onChange={(event) => setCourse((event.target as HTMLInputElement).value)}>
+              {courses.map((name) => (
+                <FormControlLabel key={name} control={<Radio />} value={name} label={name} />
+              ))}
+              <FormControlLabel control={<Radio defaultChecked />} value={NO_COURSE} label="Ei radan tietoa" />
+            </RadioGroup>
+            <p {...stylex.props(styles.hint)}>Valinta koskee tästä eteenpäin lisättäviä kiekkoja.</p>
+
+            {/* The one-click fix when the batch was typed in before the course
+                was chosen, or when it was chosen wrong. */}
+            {rows.length > 0 && course !== NO_COURSE && (
+              <button type="button" onClick={applyCourseToAll} {...stylex.props(styles.applyButton)}>
+                Aseta rata &quot;{course}&quot; kaikille riveille
+              </button>
+            )}
+          </div>
+        )}
       </form>
+
+      {/* Subtle rather than blocking: a disc with no course is still worth
+          saving, it just will not show up under a course in the list. */}
+      {isCourseMissing && (
+        <div role="status" {...stylex.props(styles.reminder)}>
+          {missingCourseCount === rows.length
+            ? 'Radaksi ei ole valittu mitään. Valitse rata yltä.'
+            : `${missingCourseCount} kiekolta puuttuu rata. Valitse rata yltä.`}
+        </div>
+      )}
 
       <div {...stylex.props(styles.tableWrap)}>
         <table {...stylex.props(styles.table)}>
@@ -126,6 +187,11 @@ export default function AddDiscsPage(): JSX.Element {
                   {column.header}
                 </th>
               ))}
+              {courses.length > 0 && (
+                <th scope="col" {...stylex.props(styles.th)}>
+                  Rata
+                </th>
+              )}
               <th scope="col" {...stylex.props(styles.th)}>
                 Ohitettu
               </th>
@@ -137,7 +203,7 @@ export default function AddDiscsPage(): JSX.Element {
           <tbody>
             {rows.length === 0 && (
               <tr>
-                <td colSpan={columns.length + 2} {...stylex.props(styles.td, styles.none)}>
+                <td colSpan={columns.length + (courses.length > 0 ? 3 : 2)} {...stylex.props(styles.td, styles.none)}>
                   Ei vielä tunnistettuja kiekkoja.
                 </td>
               </tr>
@@ -169,6 +235,12 @@ export default function AddDiscsPage(): JSX.Element {
                     </td>
                   );
                 })}
+
+                {/* Not editable: the course comes from the radio buttons
+                    above, never from the typed text or from this cell. */}
+                {courses.length > 0 && (
+                  <td {...stylex.props(styles.td, row.course == null && styles.missingCourse)}>{row.course ?? '–'}</td>
+                )}
 
                 {/* What the parser could not place, so a typo or a dropped
                     word is visible rather than silently missing. */}
@@ -298,7 +370,7 @@ function Cell({ value, header, isEditing, onOpen, onCommit, onCancel }: CellProp
 /** The six fields shown in the table, all of them editable by hand. */
 type EditableField = 'discName' | 'plastic' | 'colour' | 'manufacturer' | 'phoneNumber' | 'ownerName';
 
-type Row = ParsedDisc & { id: number; input: string };
+type Row = ParsedDisc & { id: number; input: string; course: string | null };
 
 /** Which cell, if any, is currently open for editing. */
 type EditTarget = { rowId: number; field: EditableField };
@@ -329,6 +401,31 @@ const styles = stylex.create({
   intro: { marginBottom: space.lg, color: color.textSecondary },
   label: { display: 'block', fontWeight: font.weightBold, marginBottom: space.xs, color: color.textSecondary },
   form: { marginBottom: space.lg },
+  courseField: { marginTop: space.md },
+  // Quiet: a note in the margin, not an error box.
+  reminder: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: space.sm,
+    marginBottom: space.md,
+    fontSize: font.sizeSm,
+    color: '#8a6100',
+  },
+  applyButton: {
+    marginTop: space.sm,
+    padding: '6px 12px',
+    fontFamily: 'inherit',
+    fontSize: font.sizeSm,
+    color: color.textSecondary,
+    backgroundColor: { default: color.surface, ':hover': color.surfaceMuted },
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: color.border,
+    borderRadius: radius.sm,
+    cursor: 'pointer',
+  },
+  missingCourse: { color: color.textMuted },
   input: {
     width: '100%',
     maxWidth: '640px',

--- a/app/features/discs/submission/handleCreateRequest.server.ts
+++ b/app/features/discs/submission/handleCreateRequest.server.ts
@@ -1,6 +1,7 @@
 import { requireAdminJson } from '~/lib/api/resourceRoute.server';
 import { parseBatch, toDiscDTO } from '~/features/discs/submission/toDiscDTO';
 import { createDiscs } from '~/models/discs.server';
+import { getDiscCourseNames } from '~/config/courses';
 
 /**
  * Authorises, validates and stores a batch posted to /discs/create.
@@ -15,13 +16,13 @@ export async function handleCreateRequest(request: Request): Promise<Response> {
     return gate.response;
   }
 
-  const batch = parseBatch(gate.body);
+  const clubId = parseInt(process.env.APP_CLUB_ID!, 10);
+
+  const batch = parseBatch(gate.body, getDiscCourseNames(clubId));
 
   if ('error' in batch) {
     return Response.json({ error: batch.error }, { status: 422 });
   }
-
-  const clubId = parseInt(process.env.APP_CLUB_ID!, 10);
 
   try {
     const externalIds = await createDiscs(

--- a/app/features/discs/submission/submitDiscs.test.ts
+++ b/app/features/discs/submission/submitDiscs.test.ts
@@ -5,6 +5,10 @@ import { parseDiscText } from '~/features/discs/submission/parser/parseDiscText'
 import { submitDiscs, toSubmission } from './submitDiscs';
 
 describe('toSubmission', () => {
+  it('keeps the course the row was filed under', () => {
+    expect(toSubmission({ ...parseDiscText('Mako3 keltainen'), course: 'Oittaa' }).course).toBe('Oittaa');
+  });
+
   it('keeps the fields the server needs and drops the rest', () => {
     const parsed = parseDiscText('Star Destroyer punainen 050 123 4567 Steve D.');
 
@@ -15,6 +19,7 @@ describe('toSubmission', () => {
       manufacturer: 'Innova',
       phoneNumber: '0501234567',
       ownerName: 'Steve D.',
+      course: null,
     });
   });
 

--- a/app/features/discs/submission/submitDiscs.ts
+++ b/app/features/discs/submission/submitDiscs.ts
@@ -9,12 +9,14 @@ export type DiscSubmission = {
   manufacturer: string | null;
   phoneNumber: string | null;
   ownerName: string | null;
+  /** The course the disc was found on, or null when the club records none. */
+  course: string | null;
 };
 
 export type SubmitResult = { status: 'success'; savedCount: number } | { status: 'error'; message: string };
 
 /** Narrows a parsed row to the fields the server cares about. */
-export function toSubmission(disc: ParsedDisc): DiscSubmission {
+export function toSubmission(disc: ParsedDisc & { course?: string | null }): DiscSubmission {
   return {
     discName: disc.discName,
     plastic: disc.plastic,
@@ -22,6 +24,7 @@ export function toSubmission(disc: ParsedDisc): DiscSubmission {
     manufacturer: disc.manufacturer,
     phoneNumber: disc.phoneNumber,
     ownerName: disc.ownerName,
+    course: disc.course ?? null,
   };
 }
 

--- a/app/features/discs/submission/toDiscDTO.test.ts
+++ b/app/features/discs/submission/toDiscDTO.test.ts
@@ -5,7 +5,10 @@ import { parseDiscText } from '~/features/discs/submission/parser/parseDiscText'
 import { toSubmission } from './submitDiscs';
 import { MAX_BATCH_SIZE, parseBatch, toDiscDTO, toDiscName } from './toDiscDTO';
 
-const submission = (text: string) => toSubmission(parseDiscText(text));
+const submission = (text: string, course: string | null = null) => toSubmission({ ...parseDiscText(text), course });
+
+/** The courses the club in these tests files discs under. */
+const COURSES = ['Oittaa', 'Äijänpelto'];
 
 describe('toDiscName', () => {
   it('writes the name and plastic the way the sheet does', () => {
@@ -30,6 +33,7 @@ describe('toDiscDTO', () => {
       discManufacturer: 'Innova',
       ownerName: 'Steve D.',
       ownerPhoneNumber: '0501234567',
+      course: null,
       clubId: 2,
     });
   });
@@ -45,17 +49,21 @@ describe('toDiscDTO', () => {
   it('files the disc under the club it was given', () => {
     expect(toDiscDTO(submission('Mako3 keltainen'), 1).clubId).toBe(1);
   });
+
+  it('carries the chosen course through', () => {
+    expect(toDiscDTO(submission('Mako3 keltainen', 'Oittaa'), 1).course).toBe('Oittaa');
+  });
 });
 
 describe('parseBatch', () => {
   it('accepts a well-formed batch', () => {
-    expect(parseBatch({ discs: [submission('Mako3 keltainen')] })).toEqual({
+    expect(parseBatch({ discs: [submission('Mako3 keltainen')] }, COURSES)).toEqual({
       discs: [submission('Mako3 keltainen')],
     });
   });
 
   it('trims values and turns blanks into null', () => {
-    const result = parseBatch({ discs: [{ discName: '  Mako3  ', ownerName: '   ' }] });
+    const result = parseBatch({ discs: [{ discName: '  Mako3  ', ownerName: '   ' }] }, COURSES);
 
     expect(result).toMatchObject({ discs: [{ discName: 'Mako3', ownerName: null }] });
   });
@@ -69,13 +77,20 @@ describe('parseBatch', () => {
     { reason: 'a field that is not a string', body: { discs: [{ discName: 42 }] } },
     { reason: 'a field over the length cap', body: { discs: [{ discName: 'M'.repeat(201) }] } },
     { reason: 'a row with no name or plastic', body: { discs: [{ colour: 'Punainen' }] } },
+    { reason: 'a course this club does not have', body: { discs: [{ discName: 'Mako3', course: 'Tali' }] } },
   ])('rejects $reason', ({ body }) => {
-    expect(parseBatch(body)).toMatchObject({ error: expect.any(String) });
+    expect(parseBatch(body, COURSES)).toMatchObject({ error: expect.any(String) });
+  });
+
+  it('accepts a row with one of the club courses, and one with none', () => {
+    const result = parseBatch({ discs: [submission('Mako3 keltainen', 'Äijänpelto'), submission('Mako3')] }, COURSES);
+
+    expect(result).toMatchObject({ discs: [{ course: 'Äijänpelto' }, { course: null }] });
   });
 
   it('rejects a batch over the size cap', () => {
     const discs = Array.from({ length: MAX_BATCH_SIZE + 1 }, () => submission('Mako3 keltainen'));
 
-    expect(parseBatch({ discs })).toMatchObject({ error: expect.stringContaining('Liian monta') });
+    expect(parseBatch({ discs }, COURSES)).toMatchObject({ error: expect.stringContaining('Liian monta') });
   });
 });

--- a/app/features/discs/submission/toDiscDTO.ts
+++ b/app/features/discs/submission/toDiscDTO.ts
@@ -30,11 +30,12 @@ export function toDiscDTO(disc: DiscSubmission, clubId: number): DiscDTO {
     discManufacturer: disc.manufacturer,
     ownerName: disc.ownerName,
     ownerPhoneNumber: disc.phoneNumber ?? undefined,
+    course: disc.course,
     clubId,
   };
 }
 
-const fields = ['discName', 'plastic', 'colour', 'manufacturer', 'phoneNumber', 'ownerName'] as const;
+const fields = ['discName', 'plastic', 'colour', 'manufacturer', 'phoneNumber', 'ownerName', 'course'] as const;
 
 function readField(row: Record<string, unknown>, field: string): string | null | undefined {
   const value = row[field];
@@ -56,10 +57,15 @@ function readField(row: Record<string, unknown>, field: string): string | null |
  * Validates a batch as it arrives over the wire. The request body is untrusted,
  * so nothing is assumed about its shape.
  *
+ * `allowedCourses` are the course names this club may file a disc under; a row
+ * naming anything else is rejected rather than written to the course column,
+ * where a stray value would become an extra option in the list page's filter.
+ * No course at all is always accepted.
+ *
  * Returns the accepted rows, or a Finnish message ready to show in the error
  * box.
  */
-export function parseBatch(body: unknown): { discs: DiscSubmission[] } | { error: string } {
+export function parseBatch(body: unknown, allowedCourses: string[]): { discs: DiscSubmission[] } | { error: string } {
   if (typeof body !== 'object' || body === null || !Array.isArray((body as { discs?: unknown }).discs)) {
     return { error: 'Virheellinen pyyntö.' };
   }
@@ -91,6 +97,10 @@ export function parseBatch(body: unknown): { discs: DiscSubmission[] } | { error
       }
 
       disc[field] = value;
+    }
+
+    if (disc.course != null && !allowedCourses.includes(disc.course)) {
+      return { error: `Rivi ${index + 1}: tuntematon rata "${disc.course}".` };
     }
 
     // disc_name is what the public list is built around, so a nameless row is

--- a/app/features/messaging/MessagePreview.tsx
+++ b/app/features/messaging/MessagePreview.tsx
@@ -8,16 +8,12 @@ type MessagePreviewProps = {
 };
 export default function MessagePreview({ message }: MessagePreviewProps): JSX.Element {
   return (
-    <Paper
-      className={'mt-8'}
-      elevation={1}
-      children={
-        <div className="p-4">
-          <H3 className="mb-2">Esikatselu</H3>
+    <Paper className={'mt-8'} elevation={1}>
+      <div className="p-4">
+        <H3 className="mb-2">Esikatselu</H3>
 
-          <div dangerouslySetInnerHTML={{ __html: message }} />
-        </div>
-      }
-    />
+        <div dangerouslySetInnerHTML={{ __html: message }} />
+      </div>
+    </Paper>
   );
 }

--- a/app/features/messaging/MessageTemplatesPage.tsx
+++ b/app/features/messaging/MessageTemplatesPage.tsx
@@ -28,8 +28,9 @@ export default function MessageTemplatesPage({ messageTemplates }: Props): JSX.E
               className={messageTemplate.isDefault ? 'mb-8 mt-8' : 'mt-8'}
               style={messageTemplate.isDefault ? { border: 'solid rgba(2, 208, 232, 0.85) 4px' } : undefined}
               elevation={messageTemplate.isDefault ? 7 : 1}
-              children={<MessageTemplateItem messageTemplate={messageTemplate} />}
-            />
+            >
+              <MessageTemplateItem messageTemplate={messageTemplate} />
+            </Paper>
           );
         })}
       </Wrapper>

--- a/app/import/PuskaSoturitImporter.test.ts
+++ b/app/import/PuskaSoturitImporter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSheetDate } from '~/import/PuskaSoturitImporter';
+
+describe('parseSheetDate', () => {
+  it('reads the sheet dd/MM/y format', () => {
+    expect(parseSheetDate('03/01/2026')).toBe('2026-01-03');
+    expect(parseSheetDate('21/07/2026')).toBe('2026-07-21');
+  });
+
+  it('returns null for a cell that is not a date', () => {
+    // One row in the sheet currently reads "9248"; this used to throw and take
+    // the whole import down.
+    expect(parseSheetDate('9248')).toBeNull();
+    expect(parseSheetDate('ei tiedossa')).toBeNull();
+  });
+
+  it('returns null for an empty cell', () => {
+    expect(parseSheetDate('')).toBeNull();
+    expect(parseSheetDate(null)).toBeNull();
+    expect(parseSheetDate(undefined)).toBeNull();
+  });
+});

--- a/app/import/PuskaSoturitImporter.ts
+++ b/app/import/PuskaSoturitImporter.ts
@@ -6,6 +6,21 @@ function isEmpty(str?: string | null): boolean {
   return !str || str.length === 0;
 }
 
+/**
+ * A dd/MM/y date from the sheet as y-MM-dd, or null when the cell holds
+ * something else. One row currently reads "9248", and throwing on it took the
+ * whole import down; callers can now skip or report the row instead.
+ */
+export function parseSheetDate(value?: string | null): string | null {
+  if (isEmpty(value)) {
+    return null;
+  }
+
+  const parsed = parse(value!, 'dd/MM/y', new Date());
+
+  return isNaN(parsed.getTime()) ? null : format(parsed, 'y-MM-dd');
+}
+
 const indexes = {
   DISC_NAME: 0,
   DISC_MANUFACTURER: 1,
@@ -29,6 +44,12 @@ export async function importDiscData(): Promise<DiscDTO[]> {
   const res = await fetch(url);
 
   const data = await res.json();
+
+  // Without this, an API error (a rejected key, say) surfaces further down as
+  // "Cannot read properties of undefined", which says nothing about the cause.
+  if (!data.values) {
+    throw new Error(`Reading the Puskasoturit sheet failed: ${data.error?.message ?? JSON.stringify(data)}`);
+  }
 
   const {
     DISC_NAME,
@@ -57,9 +78,7 @@ export async function importDiscData(): Promise<DiscDTO[]> {
       ownerPhoneNumber: item[OWNER_PHONE_NUMBER],
       additionalInfo: item[ADDITIONAL_INFO],
       //addedAt: '2023-02-023',
-      addedAt: item[ADDED_AT]
-        ? format(parse(item[ADDED_AT] ? item[ADDED_AT] : '', 'dd/MM/y', new Date()), 'y-MM-dd')
-        : null,
+      addedAt: parseSheetDate(item[ADDED_AT]),
       isReturnedToOwner: !isEmpty(item[IS_RETURNED_TO_OWNER]) ? true : false,
       returnedToOwnerText: item[IS_RETURNED_TO_OWNER],
       canBeSoldOrDonated: !isEmpty(item[CAN_BE_SOLD_OR_DONATED]) ? true : false,

--- a/app/import/puskasoturitDiscFields.test.ts
+++ b/app/import/puskasoturitDiscFields.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import { DisposalMethod } from '~/features/discs/disposal/disposalMethod';
+import { ReturnMethod } from '~/features/discs/return/returnMethod';
+import type { DiscDTO } from '~/types';
+import {
+  DISPOSAL_METHOD_DONATED,
+  DISPOSAL_METHOD_SOLD,
+  RETURN_METHOD_BY_MAIL,
+  RETURN_METHOD_PICKED_UP,
+  normalizeCourse,
+  parseDisposalMethod,
+  parseNoteDate,
+  parseReturnMethod,
+  toDiscRow,
+} from '~/import/puskasoturitDiscFields';
+
+// The import script cannot import the enums themselves (see the module docs),
+// so this is what keeps the two copies from drifting apart.
+describe('method numbers', () => {
+  it('match the enums the rest of the app uses', () => {
+    expect(RETURN_METHOD_BY_MAIL).toBe(ReturnMethod.ByMail);
+    expect(RETURN_METHOD_PICKED_UP).toBe(ReturnMethod.PickedUp);
+    expect(DISPOSAL_METHOD_SOLD).toBe(DisposalMethod.Sold);
+    expect(DISPOSAL_METHOD_DONATED).toBe(DisposalMethod.Donated);
+  });
+});
+
+describe('normalizeCourse', () => {
+  it('keeps a correctly spelled course as it is', () => {
+    expect(normalizeCourse('Oittaa')).toBe('Oittaa');
+    expect(normalizeCourse('Äijänpelto')).toBe('Äijänpelto');
+  });
+
+  it('folds the misspellings found in the sheet into one name', () => {
+    expect(normalizeCourse('Oiittaa')).toBe('Oittaa');
+    expect(normalizeCourse('ÄIjänpelto')).toBe('Äijänpelto');
+    expect(normalizeCourse(' oittaa ')).toBe('Oittaa');
+  });
+
+  it('treats a missing or empty course as none', () => {
+    expect(normalizeCourse('')).toBeNull();
+    expect(normalizeCourse('   ')).toBeNull();
+    expect(normalizeCourse(null)).toBeNull();
+    expect(normalizeCourse(undefined)).toBeNull();
+  });
+
+  it('passes an unknown course through rather than dropping it', () => {
+    expect(normalizeCourse('Puolarmaari')).toBe('Puolarmaari');
+  });
+});
+
+describe('parseNoteDate', () => {
+  it('reads the date out of a return note', () => {
+    expect(parseNoteDate('14.5.2026 (Janimatti), noudettu')).toBe('2026-05-14');
+    expect(parseNoteDate('7.5.2026 (Janimatti), postitettu')).toBe('2026-05-07');
+  });
+
+  it('finds a date given in parentheses', () => {
+    expect(parseNoteDate('Viety Äpeen (10.4.2026)')).toBe('2026-04-10');
+  });
+
+  it('rejects a mistyped year instead of guessing at it', () => {
+    expect(parseNoteDate('17.7.10126 (Janimatti), noudettu')).toBeNull();
+  });
+
+  it('rejects a day that does not exist', () => {
+    expect(parseNoteDate('31.2.2026')).toBeNull();
+  });
+
+  it('returns null for a note with no date', () => {
+    expect(parseNoteDate('Palautettu')).toBeNull();
+    expect(parseNoteDate('')).toBeNull();
+    expect(parseNoteDate(null)).toBeNull();
+  });
+});
+
+describe('parseReturnMethod', () => {
+  it('recognises the two methods', () => {
+    expect(parseReturnMethod('14.5.2026 (Janimatti), noudettu')).toBe(RETURN_METHOD_PICKED_UP);
+    expect(parseReturnMethod('7.5.2026 (Janimatti), postitettu')).toBe(RETURN_METHOD_BY_MAIL);
+  });
+
+  it('still recognises the typos in the sheet', () => {
+    expect(parseReturnMethod('6.8.2026 (Janimatti), noudwttu')).toBe(RETURN_METHOD_PICKED_UP);
+    expect(parseReturnMethod('26.8.2026 (Janimatti), kaveri nouti')).toBe(RETURN_METHOD_PICKED_UP);
+  });
+
+  it('leaves a note that names no method unanswered', () => {
+    expect(parseReturnMethod('Palautettu')).toBeNull();
+    expect(parseReturnMethod('Viety Taliin')).toBeNull();
+    expect(parseReturnMethod(null)).toBeNull();
+  });
+});
+
+describe('parseDisposalMethod', () => {
+  it('recognises the two methods', () => {
+    expect(parseDisposalMethod('Myydään')).toBe(DISPOSAL_METHOD_SOLD);
+    expect(parseDisposalMethod('Lahjoitetaan')).toBe(DISPOSAL_METHOD_DONATED);
+    expect(parseDisposalMethod('Lahjoitettu')).toBe(DISPOSAL_METHOD_DONATED);
+  });
+
+  it('still recognises the typo in the sheet', () => {
+    expect(parseDisposalMethod('Muyydään')).toBe(DISPOSAL_METHOD_SOLD);
+  });
+
+  it('treats a discarded disc as neither sold nor donated', () => {
+    expect(parseDisposalMethod('Roskiin, koiran purema')).toBeNull();
+    expect(parseDisposalMethod(null)).toBeNull();
+  });
+});
+
+describe('toDiscRow', () => {
+  const disc: DiscDTO = {
+    discName: 'Destroyer',
+    discManufacturer: 'Innova',
+    discColour: 'punainen',
+    ownerName: 'Matti M.',
+    ownerPhoneNumber: '0401234567',
+    additionalInfo: '',
+    addedAt: '2026-01-03',
+    isReturnedToOwner: true,
+    returnedToOwnerText: '14.5.2026 (Janimatti), noudettu',
+    canBeSoldOrDonated: false,
+    canBeSoldOrDonatedText: '',
+    course: 'Oiittaa',
+    internalDiscId: 3802,
+    clubId: 1,
+  } as DiscDTO;
+
+  it('maps the disc onto the database columns, notes included', () => {
+    const row = toDiscRow(disc);
+
+    expect(row).toMatchObject({
+      internal_disc_id: 3802,
+      club_id: 1,
+      disc_name: 'Destroyer',
+      course: 'Oittaa',
+      added_at: '2026-01-03',
+      is_returned_to_owner: true,
+      returned_to_owner_text: '14.5.2026 (Janimatti), noudettu',
+      returned_to_owner_date: '2026-05-14',
+      return_method: RETURN_METHOD_PICKED_UP,
+      can_be_sold_or_donated: false,
+      can_be_sold_or_donated_text: null,
+      can_be_sold_or_donated_date: null,
+      can_be_sold_or_donated_method: null,
+    });
+  });
+
+  it('gives every disc its own external id', () => {
+    expect(toDiscRow(disc).external_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(toDiscRow(disc).external_id).not.toBe(toDiscRow(disc).external_id);
+  });
+
+  it('turns an internal disc id that arrives as sheet text into a number', () => {
+    expect(toDiscRow({ ...disc, internalDiscId: '3802' as unknown as number }).internal_disc_id).toBe(3802);
+  });
+});

--- a/app/import/puskasoturitDiscFields.ts
+++ b/app/import/puskasoturitDiscFields.ts
@@ -1,0 +1,173 @@
+import type { DiscDTO } from '~/types';
+
+/**
+ * Turns the free-text columns of the Puskasoturit sheet into the typed columns
+ * `discs` grew later (returned_to_owner_date, return_method,
+ * can_be_sold_or_donated_method) and cleans up the course names.
+ *
+ * Everything here is best-effort: a note that does not carry a date or a method
+ * simply yields null, and the original text is stored alongside regardless.
+ *
+ * The two method maps repeat the numbers from
+ * ~/features/discs/return/returnMethod and ~/features/discs/disposal/disposalMethod
+ * rather than importing them, so this module (and the import script that uses
+ * it) stays free of `~/` runtime imports and runs under plain `node`. The
+ * accompanying test asserts the numbers still match those enums.
+ */
+
+/** 0 = postitettu (ByMail), 1 = noudettu (PickedUp). */
+export const RETURN_METHOD_BY_MAIL = 0;
+export const RETURN_METHOD_PICKED_UP = 1;
+
+/** 0 = myydään (Sold), 1 = lahjoitetaan (Donated). */
+export const DISPOSAL_METHOD_SOLD = 0;
+export const DISPOSAL_METHOD_DONATED = 1;
+
+// The sheet is typed by hand, so the same course arrives spelled several ways.
+const COURSE_SPELLINGS: Record<string, string> = {
+  oittaa: 'Oittaa',
+  oiittaa: 'Oittaa',
+  aijanpelto: 'Äijänpelto',
+  äijänpelto: 'Äijänpelto',
+};
+
+/**
+ * The course name as the app should store it, or null when the row has none.
+ * Without this, "Oiittaa" and "ÄIjänpelto" would each become an extra option in
+ * the course filter.
+ */
+export function normalizeCourse(course?: string | null): string | null {
+  const key = course?.trim().toLowerCase();
+
+  if (!key) {
+    return null;
+  }
+
+  return COURSE_SPELLINGS[key] ?? course!.trim();
+}
+
+// "14.5.2026 (Janimatti), noudettu". The lookahead rejects a mistyped year
+// such as "17.7.10126" instead of silently reading it as the year 1012.
+const DATE_PATTERN = /(\d{1,2})\.(\d{1,2})\.(\d{4})(?!\d)/;
+
+/** The date mentioned in a note, as y-MM-dd, or null if there is none. */
+export function parseNoteDate(text?: string | null): string | null {
+  const match = text?.match(DATE_PATTERN);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, day, month, year] = match.map(Number);
+
+  // Rejects both an impossible date and one that says 31.2., which Date would
+  // otherwise roll over into March.
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+    return null;
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * How the disc got back to its owner. Matches the stems rather than the whole
+ * word, so the typos in the sheet ("noudwttu", "kaveri nouti") still land.
+ */
+export function parseReturnMethod(text?: string | null): number | null {
+  if (!text) {
+    return null;
+  }
+
+  if (/noud|nout/i.test(text)) {
+    return RETURN_METHOD_PICKED_UP;
+  }
+
+  if (/postit/i.test(text)) {
+    return RETURN_METHOD_BY_MAIL;
+  }
+
+  return null;
+}
+
+/**
+ * What is to happen to a disc the club is releasing. "Roskiin" (thrown away) is
+ * neither, so it stays null.
+ */
+export function parseDisposalMethod(text?: string | null): number | null {
+  if (!text) {
+    return null;
+  }
+
+  if (/lahjoit/i.test(text)) {
+    return DISPOSAL_METHOD_DONATED;
+  }
+
+  if (/myyd|muyyd/i.test(text)) {
+    return DISPOSAL_METHOD_SOLD;
+  }
+
+  return null;
+}
+
+/** A `discs` row, ready to insert. */
+export type DiscRow = {
+  external_id: string;
+  internal_disc_id: number;
+  club_id: number;
+  disc_name: string;
+  disc_colour: string | null;
+  disc_manufacturer: string | null;
+  owner_name: string | null;
+  owner_phone_number: string | null;
+  added_at: string | null;
+  additional_info: string | null;
+  course: string | null;
+  is_returned_to_owner: boolean;
+  returned_to_owner_text: string | null;
+  returned_to_owner_date: string | null;
+  return_method: number | null;
+  can_be_sold_or_donated: boolean;
+  can_be_sold_or_donated_text: string | null;
+  can_be_sold_or_donated_date: string | null;
+  can_be_sold_or_donated_method: number | null;
+};
+
+function orNull(value?: string | null): string | null {
+  const trimmed = value?.trim();
+
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * The imported disc as a row of the `discs` table, with the free-text notes
+ * also read into the typed columns.
+ *
+ * The external id is generated here rather than left to a column default, so
+ * the app does not depend on one being in place — the same reasoning as in
+ * ~/models/syncDiscs.server.
+ */
+export function toDiscRow(disc: DiscDTO): DiscRow {
+  return {
+    external_id: crypto.randomUUID(),
+    internal_disc_id: Number(disc.internalDiscId),
+    club_id: disc.clubId!,
+    disc_name: disc.discName,
+    disc_colour: orNull(disc.discColour),
+    disc_manufacturer: orNull(disc.discManufacturer),
+    owner_name: orNull(disc.ownerName),
+    owner_phone_number: orNull(disc.ownerPhoneNumber),
+    added_at: disc.addedAt ?? null,
+    additional_info: orNull(disc.additionalInfo),
+    course: normalizeCourse(disc.course),
+    is_returned_to_owner: !!disc.isReturnedToOwner,
+    returned_to_owner_text: orNull(disc.returnedToOwnerText),
+    returned_to_owner_date: parseNoteDate(disc.returnedToOwnerText),
+    return_method: parseReturnMethod(disc.returnedToOwnerText),
+    can_be_sold_or_donated: !!disc.canBeSoldOrDonated,
+    can_be_sold_or_donated_text: orNull(disc.canBeSoldOrDonatedText),
+    can_be_sold_or_donated_date: parseNoteDate(disc.canBeSoldOrDonatedText),
+    can_be_sold_or_donated_method: parseDisposalMethod(disc.canBeSoldOrDonatedText),
+  };
+}

--- a/app/models/DiscMapper.ts
+++ b/app/models/DiscMapper.ts
@@ -38,6 +38,7 @@ export const toDTO = (raw: any): DiscDTO => {
     clubId: raw.club_id,
     course: raw.course,
     notifiedAt: raw.notified_at,
+    archivedAt: raw.archived_at,
   };
 };
 
@@ -67,5 +68,6 @@ export const fromDTO = (discDTO: DiscDTO): DbDiscType => {
     club_id: discDTO.clubId,
     course: discDTO.course,
     notified_at: discDTO.notifiedAt,
+    archived_at: discDTO.archivedAt,
   };
 };

--- a/app/models/discs.server.ts
+++ b/app/models/discs.server.ts
@@ -17,7 +17,7 @@ export async function getDiscs(): Promise<DiscDTO[]> {
   const { data } = await supabase
     .from('discs')
     .select(
-      'external_id, internal_disc_id, disc_name, disc_colour, disc_manufacturer, owner_name, owner_phone_number, owner_club_name, added_at',
+      'external_id, internal_disc_id, disc_name, disc_colour, disc_manufacturer, owner_name, owner_phone_number, owner_club_name, added_at, course',
     )
     .order('disc_name', { ascending: true })
     .eq('is_returned_to_owner', false)

--- a/app/models/discs.server.ts
+++ b/app/models/discs.server.ts
@@ -22,6 +22,9 @@ export async function getDiscs(): Promise<DiscDTO[]> {
     .order('disc_name', { ascending: true })
     .eq('is_returned_to_owner', false)
     .eq('can_be_sold_or_donated', false)
+    // Archived discs are ones the club has stopped listing; they are still in
+    // the table, and still counted in the statistics.
+    .is('archived_at', null)
     .eq('club_id', clubId);
 
   return data

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,6 +19,7 @@ import { createSupabaseServerClientWithHeaders } from '~/models/utils';
 
 import AdminMenu from '~/ui/AdminMenu';
 import Header from '~/ui/Header';
+import { getClubFavicon } from '~/config/clubs';
 // Side-effect import so Vite processes app.css through PostCSS/Tailwind in both
 // dev and build (a `?url` import is served raw in dev, leaving @tailwind
 // directives unexpanded). React Router injects the resulting stylesheet for SSR.
@@ -86,7 +87,7 @@ export default function App() {
     };
   }, [serverAccessToken, supabase, revalidate]);
 
-  const iconUrl = parseInt(env.CLUB_ID, 10) === 2 ? '/tt-sini-logo-32-32.jpg' : '/ps-logo.png';
+  const iconUrl = getClubFavicon(parseInt(env.CLUB_ID, 10));
   const isNotifyPage = location.pathname.startsWith('/notify');
   const isLoggedIn = !!session?.user;
   const showHeader = !isNotifyPage || isLoggedIn;
@@ -97,7 +98,7 @@ export default function App() {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
         <Meta />
-        <link rel="shortcut icon" href={iconUrl} />
+        {iconUrl && <link rel="shortcut icon" href={iconUrl} />}
         <Links />
         {/* StyleX dev CSS endpoint (DEV only). In production the unplugin folds
             StyleX's atomic CSS into the root stylesheet via cssInjectionTarget

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -86,7 +86,7 @@ export default function App() {
     };
   }, [serverAccessToken, supabase, revalidate]);
 
-  const iconUrl = parseInt(env.CLUB_ID, 10) === 2 ? '/tt-sini-logo-32-32.jpg' : '';
+  const iconUrl = parseInt(env.CLUB_ID, 10) === 2 ? '/tt-sini-logo-32-32.jpg' : '/ps-logo.png';
   const isNotifyPage = location.pathname.startsWith('/notify');
   const isLoggedIn = !!session?.user;
   const showHeader = !isNotifyPage || isLoggedIn;

--- a/app/routes/discs.add.tsx
+++ b/app/routes/discs.add.tsx
@@ -1,8 +1,9 @@
 import { type JSX } from 'react';
 
-import { redirect, type LoaderFunctionArgs } from 'react-router';
+import { redirect, useLoaderData, type LoaderFunctionArgs } from 'react-router';
 
 import AddDiscsPage from '~/features/discs/submission/AddDiscsPage';
+import { getDiscCourseNames } from '~/config/courses';
 import { isUserLoggedIn } from '~/models/utils';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -10,9 +11,12 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     return redirect('/sign-in');
   }
 
-  return null;
+  // The courses this club files discs under, so the form can offer them.
+  return { courses: getDiscCourseNames(parseInt(process.env.APP_CLUB_ID!, 10)) };
 };
 
 export default function AddDiscsRoute(): JSX.Element {
-  return <AddDiscsPage />;
+  const data = useLoaderData<typeof loader>();
+
+  return <AddDiscsPage courses={data?.courses ?? []} />;
 }

--- a/app/styles/tokens.stylex.ts
+++ b/app/styles/tokens.stylex.ts
@@ -34,6 +34,12 @@ export const font = stylex.defineVars({
   weightBold: '700',
 });
 
+// Shared control metrics, so a text field, a combobox and a row of radios line
+// up to the same height when they sit side by side in a filter row.
+export const size = stylex.defineVars({
+  control: '40px',
+});
+
 export const radius = stylex.defineVars({
   sm: '4px',
   md: '8px',

--- a/app/types.ts
+++ b/app/types.ts
@@ -59,6 +59,8 @@ export type DiscDTO = {
   ownerClubName?: string | null;
   addedAt?: string;
   course?: string | null;
+  /** When the club stopped listing the disc publicly; null while it is listed. */
+  archivedAt?: string | null;
 };
 
 export type MessageTemplateDTO = {
@@ -124,4 +126,5 @@ export type DbDiscType = {
   club_id: number;
   course?: string | null;
   notified_at?: string | null;
+  archived_at?: string | null;
 };

--- a/app/ui/Header.tsx
+++ b/app/ui/Header.tsx
@@ -16,19 +16,18 @@ const styles = stylex.create({
   },
 });
 
-function getClubLogo(clubId: number): string | undefined {
-  if (clubId === 2) {
-    return '/tt-sini-logo.jpg';
-  }
-
-  return undefined;
-}
+const CLUB_LOGOS: Record<number, string> = {
+  1: '/ps-logo.png',
+  2: '/tt-sini-logo.jpg',
+};
 
 export default function Header({ clubId, clubName }: HeaderProps): JSX.Element {
   const logo = stylex.props(styles.logo);
+  const logoUrl = CLUB_LOGOS[clubId];
+
   return (
     <div className="flex items-center">
-      <img className={`mr-4 ${logo.className ?? ''}`} style={logo.style} src={getClubLogo(clubId)} alt={''} />
+      {logoUrl && <img className={`mr-4 ${logo.className ?? ''}`} style={logo.style} src={logoUrl} alt={''} />}
       <h1 {...stylex.props(styles.h1)}>Löytökiekot - {clubName}</h1>
     </div>
   );

--- a/app/ui/Header.tsx
+++ b/app/ui/Header.tsx
@@ -2,6 +2,8 @@ import * as stylex from '@stylexjs/stylex';
 
 import type { JSX } from 'react';
 
+import { getClubLogo } from '~/config/clubs';
+
 type HeaderProps = {
   clubId: number;
   clubName: string;
@@ -16,14 +18,9 @@ const styles = stylex.create({
   },
 });
 
-const CLUB_LOGOS: Record<number, string> = {
-  1: '/ps-logo.png',
-  2: '/tt-sini-logo.jpg',
-};
-
 export default function Header({ clubId, clubName }: HeaderProps): JSX.Element {
   const logo = stylex.props(styles.logo);
-  const logoUrl = CLUB_LOGOS[clubId];
+  const logoUrl = getClubLogo(clubId);
 
   return (
     <div className="flex items-center">

--- a/app/ui/InfoBox.tsx
+++ b/app/ui/InfoBox.tsx
@@ -79,11 +79,6 @@ export default function InfoBox({ onClose, clubId }: InfoBoxProps): JSX.Element 
         Nimettömän spessukiekkojen takaisin saanti on hieman helpompaa, jos vain osaat kuvaille stämpin ja muut
         yksityiskohdat.
       </p>
-      <p>
-        Haettuasi kiekon kopilta, vastaa tekstiviestiin “Kiekko haettu”, mikäli viesti löydetystä kiekosta on tullut
-        puhelinnumerosta, jonka 4 viimeistä numeroa ovat 3904. Tällöin voimme poistaa kiekkosi listalta, eikä se näy
-        siellä enää virheellisesti.
-      </p>
 
       <p>
         Emme julkaise tällä sivustolla omistajan koko nimeä, koko puhelinnumeroa, PDGA-numeroa, tai muita omistajaa

--- a/app/ui/InfoBox.tsx
+++ b/app/ui/InfoBox.tsx
@@ -1,5 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 
+import { getClubContactEmail } from '~/config/clubs';
 import { font, space } from '~/styles/tokens.stylex';
 
 import type { JSX } from 'react';
@@ -34,8 +35,12 @@ const styles = stylex.create({
 
 type InfoBoxProps = {
   onClose: () => void;
+  /** Decides which club's contact address the text ends on. */
+  clubId: number | null;
 };
-export default function InfoBox({ onClose }: InfoBoxProps): JSX.Element {
+export default function InfoBox({ onClose, clubId }: InfoBoxProps): JSX.Element {
+  const contactEmail = getClubContactEmail(clubId);
+
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
@@ -86,8 +91,7 @@ export default function InfoBox({ onClose }: InfoBoxProps): JSX.Element {
       </p>
 
       <p className="font-bold text-lg">
-        Tiedustelut sähköpostitse osoitteeseen{' '}
-        <a href="mailto:janimatti.ellonen@gmail.com">janimatti.ellonen@gmail.com</a>.
+        Tiedustelut sähköpostitse osoitteeseen <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
       </p>
     </div>
   );

--- a/app/ui/RadioGroup.tsx
+++ b/app/ui/RadioGroup.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react';
 
 import * as stylex from '@stylexjs/stylex';
 
-import { color } from '~/styles/tokens.stylex';
+import { color, size, space } from '~/styles/tokens.stylex';
 
 // Native radios grouped by a shared `name` (provided via context, like MUI's
 // RadioGroup). Selection is handled natively; the group's onChange catches the
@@ -15,6 +15,18 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
   },
+  // Side by side, dropping onto further lines only when the row runs out of
+  // room. nowrap keeps a multi-word option from breaking mid-label first.
+  groupRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    // Matches a text field's height so a filter row lines up.
+    alignItems: 'center',
+    minHeight: size.control,
+    columnGap: space.md,
+    rowGap: space.xs,
+    whiteSpace: 'nowrap',
+  },
   radio: {
     accentColor: color.accent,
     width: '18px',
@@ -25,13 +37,15 @@ const styles = stylex.create({
 
 type RadioGroupProps = {
   name?: string;
+  /** Lay the radios out horizontally, wrapping when they no longer fit. */
+  row?: boolean;
   onChange?: FormEventHandler<HTMLDivElement>;
   children: ReactNode;
 };
 
-export function RadioGroup({ name, onChange, children }: RadioGroupProps): JSX.Element {
+export function RadioGroup({ name, row, onChange, children }: RadioGroupProps): JSX.Element {
   return (
-    <div role="radiogroup" onChange={onChange} {...stylex.props(styles.group)}>
+    <div role="radiogroup" onChange={onChange} {...stylex.props(styles.group, row && styles.groupRow)}>
       <RadioGroupContext.Provider value={{ name }}>{children}</RadioGroupContext.Provider>
     </div>
   );
@@ -39,9 +53,12 @@ export function RadioGroup({ name, onChange, children }: RadioGroupProps): JSX.E
 
 type RadioProps = {
   value?: string;
+  defaultChecked?: boolean;
 };
 
-export function Radio({ value }: RadioProps): JSX.Element {
+export function Radio({ value, defaultChecked }: RadioProps): JSX.Element {
   const { name } = useContext(RadioGroupContext);
-  return <input type="radio" name={name} value={value} {...stylex.props(styles.radio)} />;
+  return (
+    <input type="radio" name={name} value={value} defaultChecked={defaultChecked} {...stylex.props(styles.radio)} />
+  );
 }

--- a/app/ui/TextField.tsx
+++ b/app/ui/TextField.tsx
@@ -2,7 +2,7 @@ import type { ChangeEventHandler, InputHTMLAttributes, JSX } from 'react';
 
 import * as stylex from '@stylexjs/stylex';
 
-import { color, radius } from '~/styles/tokens.stylex';
+import { color, radius, size } from '~/styles/tokens.stylex';
 
 // StyleX text input / textarea. Replaces MUI <TextField> for the app's form
 // fields (which use a separate <Label> above, not MUI's floating label). The
@@ -27,6 +27,8 @@ const styles = stylex.create({
     boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',
     outline: 'none',
   },
+  // Single-line only: a textarea sizes itself from `rows`.
+  input: { height: size.control },
   fullWidth: { width: '100%' },
 });
 
@@ -56,7 +58,7 @@ export default function TextField({
   type,
   ...rest
 }: TextFieldProps): JSX.Element {
-  const sx = stylex.props(styles.base, fullWidth && styles.fullWidth);
+  const sx = stylex.props(styles.base, !multiline && styles.input, fullWidth && styles.fullWidth);
   const merged = [sx.className, className].filter(Boolean).join(' ');
 
   if (multiline) {

--- a/app/utils.test.ts
+++ b/app/utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DiscDTO } from '~/types';
+import { getDistinctCourses } from '~/utils';
+
+function disc(course?: string | null): DiscDTO {
+  return { discName: 'Destroyer', course } as DiscDTO;
+}
+
+describe('getDistinctCourses', () => {
+  it('returns each course once, in Finnish alphabetical order', () => {
+    const discs = [disc('Äijänpelto'), disc('Oittaa'), disc('Äijänpelto')];
+
+    expect(getDistinctCourses(discs)).toEqual(['Oittaa', 'Äijänpelto']);
+  });
+
+  it('leaves out discs with no course recorded', () => {
+    const discs = [disc('Oittaa'), disc(''), disc(null), disc(undefined)];
+
+    expect(getDistinctCourses(discs)).toEqual(['Oittaa']);
+  });
+
+  it('returns nothing for a club that records no course at all', () => {
+    expect(getDistinctCourses([disc(null), disc(null)])).toEqual([]);
+  });
+});

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -17,6 +17,24 @@ export function getDistinctDiscNames(discs: DiscDTO[]): string[] {
   return unique;
 }
 
+/**
+ * The course names actually present in the list, for the course filter. Clubs
+ * with a single course (or none recorded) yield fewer than two names, which is
+ * how the list page knows not to show the filter at all. Discs with no course
+ * recorded are left out of the options and only appear under "all courses".
+ */
+export function getDistinctCourses(discs: DiscDTO[]): string[] {
+  const unique = new Set<string>();
+
+  discs.forEach((disc: DiscDTO) => {
+    if (disc.course) {
+      unique.add(disc.course);
+    }
+  });
+
+  return [...unique].sort((a, b) => a.localeCompare(b, 'fi'));
+}
+
 type GroupedType = {
   [index: string]: string[];
 };

--- a/docs/caching-the-public-disc-list.md
+++ b/docs/caching-the-public-disc-list.md
@@ -1,0 +1,115 @@
+# Caching the public disc list
+
+Status: **proposed, not implemented** (deferred 2026-08-30).
+
+Every front-page visit currently costs a Supabase round trip: `DiscListPage`
+fetches on mount, the loader runs `getDiscs()`, and nothing in the app sets a
+single cache header. The list changes only when an admin marks a disc or an
+import runs, so it is a good candidate for CDN caching.
+
+## The approach
+
+Set `Cache-Control` on the disc-list loader response and let Vercel's Edge
+Network store it. This is plain HTTP caching — available on the Hobby tier,
+not a paid feature, and not Next.js's plan-gated Data Cache.
+
+```ts
+// app/routes/discs.data.tsx
+const payload = await loadDiscListData(request);
+
+return data(payload, {
+  headers: {
+    'Cache-Control': payload.isLoggedIn
+      ? 'private, no-store'
+      : 'public, max-age=0, s-maxage=60, stale-while-revalidate=300',
+  },
+});
+```
+
+`max-age=0` keeps browsers honest while `s-maxage` lets the CDN hold the copy;
+`stale-while-revalidate` refreshes it in the background instead of making a
+visitor wait. `loadDiscListData` would need to return `isLoggedIn`, which it
+already computes.
+
+## The part that will bite
+
+**The same URL returns two different payloads.** `loadDiscListData` strips
+`externalId` for anonymous visitors. Vercel's edge cache does not vary on
+`Cookie`, so an admin would be served the cached anonymous copy and the disc
+table's action buttons would quietly stop rendering. It is not a data leak —
+the anonymous body is a strict subset — but it is a real bug.
+
+Fix by making the URL differ, since the query string is part of the cache key:
+
+```ts
+fetcher.load(isLoggedIn ? '/discs/data?admin=1' : '/discs/data');
+```
+
+`DiscListPage` can read `session` from the outlet context the way `DiscTable`
+already does. The admin variant is `no-store` and never caches.
+
+**Vercel refuses to cache any response carrying `Set-Cookie`.** Today the
+loader has none: `createSupabaseServerClient` (app/models/utils.ts) deliberately
+drops Supabase's cookie writes and `isUserLoggedIn` uses that variant. Switching
+that loader to `createSupabaseServerClientWithHeaders` would silently disable
+caching.
+
+**Staleness.** After an admin marks a disc returned, the public list can lag by
+up to `s-maxage`. 60s is probably fine here; 10–15s still absorbs most repeat
+traffic. Hobby has no cache-purge API, so a bad cached response has to age out —
+an argument for keeping the TTL short while verifying.
+
+## Which URL actually gets cached
+
+Because `app/routes/discs.data.tsx` has a default export, React Router treats it
+as a normal route: `fetcher.load('/discs/data')` really requests
+**`/discs/data.data`** (the single-fetch payload, ~138KB), while a plain GET to
+`/discs/data` renders a full ~200KB HTML document. Both answer 200, so it is
+easy to test the wrong one and conclude caching is broken.
+
+Worth doing as part of this: drop that `export default function DiscsDataRoute()
+{ return null }`. The file then becomes a true resource route — served directly
+at `/discs/data`, no `.data` suffix, no pointless HTML variant — and a simpler
+thing to cache.
+
+## How to verify it works
+
+Locally, only the header itself can be checked (there is no CDN in front of the
+dev server):
+
+```bash
+curl -sI http://localhost:3400/discs/data.data | grep -iE 'cache-control|set-cookie'
+```
+
+On the deployment, the CDN reports its own decision:
+
+```bash
+curl -sI https://<app>/discs/data.data | grep -iE 'x-vercel-cache|age|cache-control'
+```
+
+- `MISS` on the first request, `HIT` on the second — that is the whole test.
+- `age` counting up confirms the stored copy is being served.
+- One `STALE` after `s-maxage` elapses is `stale-while-revalidate` working, not
+  a failure.
+- `BYPASS` means something opted out, usually a `Set-Cookie` or `no-store`.
+
+Test the admin variant explicitly, and confirm the two bodies differ:
+
+```bash
+curl -s 'https://<app>/discs/data.data' | grep -c externalId    # expect 0
+curl -s --cookie '<auth cookie>' 'https://<app>/discs/data.data?admin=1' | grep -c externalId
+```
+
+If an anonymous request ever returns `externalId`, the cache is serving an admin
+response to the public — stop and fix that first.
+
+## Alternatives considered
+
+- **Module-scope cache in the serverless function**, ~30s TTL. Five lines, but
+  survives only as long as an instance and does nothing on a cold start. Worth
+  it alongside the CDN headers, not instead of them.
+- **Move the query into the `_index` loader** so the list is server-rendered and
+  the document itself is cacheable, dropping the extra client round trip. Better
+  for first paint and for search engines, but it is a real refactor of
+  `DiscListPage`, which fetches in a `useEffect` on mount — and the
+  logged-in-variant problem applies to the HTML too.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "typecheck": "react-router typegen && tsc",
     "test:e2e": "playwright test",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "import:puskasoturit": "node --env-file=.env scripts/importPuskasoturitDiscs.ts"
   },
   "dependencies": {
     "@react-pdf/renderer": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:e2e": "playwright test",
     "test": "vitest run",
     "test:watch": "vitest",
-    "import:puskasoturit": "node --env-file=.env scripts/importPuskasoturitDiscs.ts"
+    "import:puskasoturit": "node --env-file=.env scripts/importPuskasoturitDiscs.ts",
+    "archive:discs": "node --env-file=.env scripts/archiveStaleDiscs.ts"
   },
   "dependencies": {
     "@react-pdf/renderer": "^4.5.1",

--- a/prompts/puskasoturit.md
+++ b/prompts/puskasoturit.md
@@ -1,0 +1,30 @@
+# Puskasoturit
+
+I'm planning on using this same project for another club, Puskasoturit (CLUB_ID = 1).
+
+Create a new branch.
+
+First task it see wht there is no logo visible on the frontpage.
+
+If CLUB_ID = 2 then image tt-sini-logo.jpg is used. For CLUB_DI = 2, image ps-logo.png should be used
+
+## Multiple courses
+
+Puskasoturit ry gets lost discs from two courses, Oittaa and Äijänpelto. There should be a course filter 
+(radio buttons + reset option) that allows the user to select the course from which to list found discs.
+
+Also see functions in `app/models/syncDiscs.server.ts` that persists new discs.
+
+Note that some of the functions in `app/models/syncDiscs.server.ts` deletes rows from `discs`.
+
+In this case don't want to delete anything, just add data that has not yet been added and that some data 
+is added to the new columns, if possible. Hint: use the internal_disc_id value to verify that the disc
+has not been previously persisted to database. Note that internal_disc_id is not unique on its own, you 
+need to use club_id along. Same internal_disc_id can be found twice, one with club_id 1 and one with club_id 2.
+
+Create a separate script that fetches the data (maybe using PuskasoturitImporter), formats the data to
+fit the new `discs` columns and persists the data to Supabase. The script must have a dry run flag that 
+displays the data to be saved, without actually trying to save.
+
+This script should be runnable using `npm run ...`.
+

--- a/prompts/puskasoturit.md
+++ b/prompts/puskasoturit.md
@@ -27,3 +27,13 @@ fit the new `discs` columns and persists the data to Supabase. The script must h
 displays the data to be saved, without actually trying to save.
 
 This script should be runnable using `npm run ...`.
+
+## Fixes to new disc form
+
+- use radio buttons instead of select list for course
+- the course is not a value that I enter in the text field. It should be obtained only form the filter
+  selection
+- I often add several discs for either Äijänpelto or Oittaa. If I fail to select a course when I add new
+  discs, show a subtle notice to remind me to choose a course
+- make it possible for me to select course for all discs added by the textfield, that are not yet
+  persisted in one click

--- a/prompts/puskasoturit.md
+++ b/prompts/puskasoturit.md
@@ -10,21 +10,20 @@ If CLUB_ID = 2 then image tt-sini-logo.jpg is used. For CLUB_DI = 2, image ps-lo
 
 ## Multiple courses
 
-Puskasoturit ry gets lost discs from two courses, Oittaa and Äijänpelto. There should be a course filter 
+Puskasoturit ry gets lost discs from two courses, Oittaa and Äijänpelto. There should be a course filter
 (radio buttons + reset option) that allows the user to select the course from which to list found discs.
 
 Also see functions in `app/models/syncDiscs.server.ts` that persists new discs.
 
 Note that some of the functions in `app/models/syncDiscs.server.ts` deletes rows from `discs`.
 
-In this case don't want to delete anything, just add data that has not yet been added and that some data 
+In this case don't want to delete anything, just add data that has not yet been added and that some data
 is added to the new columns, if possible. Hint: use the internal_disc_id value to verify that the disc
-has not been previously persisted to database. Note that internal_disc_id is not unique on its own, you 
+has not been previously persisted to database. Note that internal_disc_id is not unique on its own, you
 need to use club_id along. Same internal_disc_id can be found twice, one with club_id 1 and one with club_id 2.
 
 Create a separate script that fetches the data (maybe using PuskasoturitImporter), formats the data to
-fit the new `discs` columns and persists the data to Supabase. The script must have a dry run flag that 
+fit the new `discs` columns and persists the data to Supabase. The script must have a dry run flag that
 displays the data to be saved, without actually trying to save.
 
 This script should be runnable using `npm run ...`.
-

--- a/prompts/script for importing Puskasoturit sheet data.md
+++ b/prompts/script for importing Puskasoturit sheet data.md
@@ -1,6 +1,6 @@
 # Script for importing Puskasoturit sheet data
 
-While I'm actually abandoning the old way of importing disc data from a google sheet, I want to make a 
+While I'm actually abandoning the old way of importing disc data from a google sheet, I want to make a
 final import from the Puskasoturit google sheet, which hasn't been done in a long time.
 
 I want to have the data for statistical purposes.
@@ -11,6 +11,7 @@ The `discs` table has new columns for determining whether disc was sold and dona
 by mail of pickup. The data in the google sheet is handled in a different way that will need some parsing.
 
 For example a disc that was returned to its owner, has often these notes:
+
 - "18.8.2026 (Janimatti), noudettu"
 - 15.8.2026 (Janimatti), postitettu
 - 26.8.2026 (Janimatti), kaveri nouti
@@ -19,6 +20,7 @@ For example a disc that was returned to its owner, has often these notes:
 Format of these notes: (date of return, name handler [who returned], mail or pickup)
 
 If a disc was sold or donated:
+
 - "Lahjoitetaan"
 - "Myydään"
 
@@ -26,7 +28,3 @@ Format: donated or sold.
 
 As these are not always standardized and we don't have the date when a disc was marked for donation or,
 for sale, we have to parse and at times just leave some of the columns empty.
-
-
-
-

--- a/prompts/script for importing Puskasoturit sheet data.md
+++ b/prompts/script for importing Puskasoturit sheet data.md
@@ -1,0 +1,32 @@
+# Script for importing Puskasoturit sheet data
+
+While I'm actually abandoning the old way of importing disc data from a google sheet, I want to make a 
+final import from the Puskasoturit google sheet, which hasn't been done in a long time.
+
+I want to have the data for statistical purposes.
+
+Previously used script can be found in `app/import/PuskaSoturitImporter.ts`.
+
+The `discs` table has new columns for determining whether disc was sold and donated, was the disc returned
+by mail of pickup. The data in the google sheet is handled in a different way that will need some parsing.
+
+For example a disc that was returned to its owner, has often these notes:
+- "18.8.2026 (Janimatti), noudettu"
+- 15.8.2026 (Janimatti), postitettu
+- 26.8.2026 (Janimatti), kaveri nouti
+- Viety Taliin
+
+Format of these notes: (date of return, name handler [who returned], mail or pickup)
+
+If a disc was sold or donated:
+- "Lahjoitetaan"
+- "Myydään"
+
+Format: donated or sold.
+
+As these are not always standardized and we don't have the date when a disc was marked for donation or,
+for sale, we have to parse and at times just leave some of the columns empty.
+
+
+
+

--- a/scripts/archiveStaleDiscs.ts
+++ b/scripts/archiveStaleDiscs.ts
@@ -1,0 +1,169 @@
+/**
+ * Archives discs the club has stopped listing.
+ *
+ * Sets `archived_at` on unresolved discs added before a cutoff date, so they
+ * drop off the public list without being recorded as returned or sold — see
+ * supabase/migrations/20260830000000_discs_archived_at.sql.
+ *
+ * Run it with:
+ *   npm run archive:discs -- --before=2025-09-01 --dry-run
+ *   npm run archive:discs -- --before=2025-09-01
+ *
+ * Flags:
+ *   --before=YYYY-MM-DD  archive discs added strictly before this date (required)
+ *   --club=<id>          which club (defaults to APP_CLUB_ID)
+ *   --dry-run            print what would be archived, write nothing
+ *
+ * Reversible: `UPDATE discs SET archived_at = NULL WHERE ...` puts them back.
+ *
+ * Writing needs more than the anon key; see createWriteConnection.
+ *
+ * Runs on plain node (>= 22) via its native TypeScript stripping, so nothing in
+ * this file's import graph may use the `~/` alias at runtime.
+ */
+import { createReadConnection, createWriteConnection, requireEnv } from './supabaseClients.ts';
+
+/** Supabase caps a select at 1000 rows. */
+const PAGE_SIZE = 1000;
+
+/** Matches the chunking the import script uses. */
+const UPDATE_CHUNK_SIZE = 100;
+
+type StaleDisc = {
+  external_id: string;
+  internal_disc_id: number | null;
+  disc_name: string;
+  added_at: string | null;
+  course: string | null;
+};
+
+function flag(name: string): string | undefined {
+  return process.argv.find((arg) => arg.startsWith(`--${name}=`))?.split('=')[1];
+}
+
+function requireCutoff(): string {
+  const before = flag('before');
+
+  if (!before || !/^\d{4}-\d{2}-\d{2}$/.test(before)) {
+    throw new Error('Pass the cutoff as --before=YYYY-MM-DD, e.g. --before=2025-09-01.');
+  }
+
+  return before;
+}
+
+/**
+ * Discs that would disappear from the public list: still listed, added before
+ * the cutoff, and neither returned nor released for sale or donation.
+ */
+async function getStaleDiscs(clubId: number, before: string): Promise<StaleDisc[]> {
+  const supabase = createReadConnection();
+  const discs: StaleDisc[] = [];
+
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('discs')
+      .select('external_id, internal_disc_id, disc_name, added_at, course')
+      .eq('club_id', clubId)
+      .eq('is_returned_to_owner', false)
+      .eq('can_be_sold_or_donated', false)
+      .is('archived_at', null)
+      .lt('added_at', before)
+      .order('added_at', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) {
+      throw new Error(`Reading discs failed: ${error.message}`);
+    }
+
+    discs.push(...((data ?? []) as StaleDisc[]));
+
+    if (!data || data.length < PAGE_SIZE) {
+      return discs;
+    }
+  }
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+
+  return chunks;
+}
+
+async function archive(discs: StaleDisc[]): Promise<void> {
+  const supabase = await createWriteConnection();
+  const archivedAt = new Date().toISOString();
+
+  let archived = 0;
+
+  // Addressed by external_id rather than by repeating the filters, so a disc
+  // returned between the read and the write is not archived behind your back.
+  for (const batch of chunk(discs, UPDATE_CHUNK_SIZE)) {
+    const { error } = await supabase
+      .from('discs')
+      .update({ archived_at: archivedAt })
+      .in(
+        'external_id',
+        batch.map((disc) => disc.external_id),
+      );
+
+    if (error) {
+      throw new Error(`Archiving failed after ${archived} discs: ${error.message}`);
+    }
+
+    archived += batch.length;
+    console.log(`  archived ${archived}/${discs.length}`);
+  }
+}
+
+function countByYear(discs: StaleDisc[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+
+  discs.forEach((disc) => {
+    const year = disc.added_at?.slice(0, 4) ?? '(no date)';
+    counts[year] = (counts[year] ?? 0) + 1;
+  });
+
+  return counts;
+}
+
+async function main(): Promise<void> {
+  const isDryRun = process.argv.includes('--dry-run');
+  const before = requireCutoff();
+  const clubId = Number(flag('club') ?? requireEnv('APP_CLUB_ID'));
+
+  console.log(isDryRun ? 'DRY RUN — nothing will be written.\n' : 'Archiving for real.\n');
+  console.log(`Club ${clubId}, discs added before ${before}.`);
+
+  const discs = await getStaleDiscs(clubId, before);
+
+  console.log(`Unresolved discs still listed: ${discs.length}`);
+
+  if (discs.length === 0) {
+    console.log('\nNothing to do.');
+    return;
+  }
+
+  console.log('By year added:', countByYear(discs));
+  console.log('\nDiscs that would be archived:');
+  discs.forEach((disc) =>
+    console.log(`  ${disc.added_at?.slice(0, 10)}  id ${disc.internal_disc_id ?? '-'}  ${disc.disc_name}`),
+  );
+
+  if (isDryRun) {
+    console.log('\nDry run — nothing was written.');
+    return;
+  }
+
+  console.log('');
+  await archive(discs);
+  console.log('\nDone. Clear archived_at to put a disc back on the list.');
+}
+
+main().catch((error: unknown) => {
+  console.error(`\n${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/importPuskasoturitDiscs.ts
+++ b/scripts/importPuskasoturitDiscs.ts
@@ -1,0 +1,161 @@
+/**
+ * Imports the Puskasoturit lost-disc sheet into `discs`, adding only.
+ *
+ * Unlike the sync in app/models/syncDiscs.server.ts, this never deletes: it
+ * reads which (internal_disc_id, club_id) pairs the table already holds and
+ * inserts the rest. internal_disc_id is not unique on its own — the same number
+ * exists once for each club — so the club is always part of the comparison.
+ *
+ * Run it with:
+ *   npm run import:puskasoturit -- --dry-run    # print what would be inserted
+ *   npm run import:puskasoturit                 # actually insert
+ *
+ * Inserting needs write access to `discs`; see createWriteConnection.
+ *
+ * Runs on plain node (>= 22) via its native TypeScript stripping, so nothing in
+ * this file's import graph may use the `~/` alias at runtime.
+ */
+import { importDiscData } from '../app/import/PuskaSoturitImporter.ts';
+import { toDiscRow, type DiscRow } from '../app/import/puskasoturitDiscFields.ts';
+import { createReadConnection, createWriteConnection } from './supabaseClients.ts';
+
+const PUSKASOTURIT_CLUB_ID = 1;
+
+/** Supabase caps a select at 1000 rows, so the existing ids come back in pages. */
+const PAGE_SIZE = 1000;
+
+/** Matches the chunking the in-app sync uses. */
+const INSERT_CHUNK_SIZE = 100;
+
+/** Every internal_disc_id this club already has a row for. */
+async function getPersistedInternalDiscIds(clubId: number): Promise<Set<number>> {
+  const supabase = createReadConnection();
+  const ids = new Set<number>();
+
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('discs')
+      .select('internal_disc_id')
+      .eq('club_id', clubId)
+      // Discs added through the web app have no internal_disc_id and cannot
+      // collide with a sheet row.
+      .not('internal_disc_id', 'is', null)
+      .order('internal_disc_id', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) {
+      throw new Error(`Reading existing discs failed: ${error.message}`);
+    }
+
+    data?.forEach((row) => ids.add(Number(row.internal_disc_id)));
+
+    if (!data || data.length < PAGE_SIZE) {
+      return ids;
+    }
+  }
+}
+
+function chunk(rows: DiscRow[], size: number): DiscRow[][] {
+  const chunks: DiscRow[][] = [];
+
+  for (let i = 0; i < rows.length; i += size) {
+    chunks.push(rows.slice(i, i + size));
+  }
+
+  return chunks;
+}
+
+async function insertRows(rows: DiscRow[]): Promise<void> {
+  const supabase = await createWriteConnection();
+
+  let inserted = 0;
+
+  // Awaited one chunk at a time: a failure then stops the run instead of
+  // leaving the rest to fail unnoticed in the background.
+  for (const batch of chunk(rows, INSERT_CHUNK_SIZE)) {
+    const { error } = await supabase.from('discs').insert(batch);
+
+    if (error) {
+      throw new Error(`Insert failed after ${inserted} discs: ${error.message}`);
+    }
+
+    inserted += batch.length;
+    console.log(`  inserted ${inserted}/${rows.length}`);
+  }
+}
+
+function countBy(rows: DiscRow[], key: (row: DiscRow) => string): Record<string, number> {
+  const counts: Record<string, number> = {};
+
+  rows.forEach((row) => {
+    const value = key(row);
+    counts[value] = (counts[value] ?? 0) + 1;
+  });
+
+  return counts;
+}
+
+function report(rows: DiscRow[]): void {
+  console.log(
+    '\nBy course:',
+    countBy(rows, (row) => row.course ?? '(none)'),
+  );
+  console.log('Returned to owner:', rows.filter((row) => row.is_returned_to_owner).length);
+  console.log('With a parsed return date:', rows.filter((row) => row.returned_to_owner_date).length);
+  console.log('With a parsed return method:', rows.filter((row) => row.return_method !== null).length);
+  console.log('For sale or donation:', rows.filter((row) => row.can_be_sold_or_donated).length);
+  console.log(
+    'With a parsed disposal method:',
+    rows.filter((row) => row.can_be_sold_or_donated_method !== null).length,
+  );
+}
+
+async function main(): Promise<void> {
+  const isDryRun = process.argv.includes('--dry-run');
+
+  console.log(isDryRun ? 'DRY RUN — nothing will be written.\n' : 'Importing for real.\n');
+
+  const discs = await importDiscData();
+  console.log(`Sheet rows with a disc name, a date and an id: ${discs.length}`);
+
+  const persisted = await getPersistedInternalDiscIds(PUSKASOTURIT_CLUB_ID);
+  console.log(`Already in the database for club ${PUSKASOTURIT_CLUB_ID}: ${persisted.size}`);
+
+  const newDiscs = discs.filter((disc) => !persisted.has(Number(disc.internalDiscId)));
+
+  // A row whose date cell the sheet holds as something other than dd/MM/y (one
+  // currently reads "9248"). Rather than insert a disc with no added_at, name
+  // it so the sheet can be corrected and the disc picked up on the next run.
+  const unreadable = newDiscs.filter((disc) => !disc.addedAt);
+
+  if (unreadable.length > 0) {
+    console.log(`\nSkipped ${unreadable.length} disc(s) whose "Lisätty" date could not be read:`);
+    unreadable.forEach((disc) => console.log(`  id ${disc.internalDiscId}: ${disc.discName}`));
+  }
+
+  const rows = newDiscs.filter((disc) => disc.addedAt).map(toDiscRow);
+  console.log(`\nNew discs to insert: ${rows.length}`);
+
+  if (rows.length === 0) {
+    console.log('\nNothing to do.');
+    return;
+  }
+
+  report(rows);
+
+  if (isDryRun) {
+    console.log('\nRows that would be inserted:');
+    rows.forEach((row) => console.log(JSON.stringify(row)));
+    console.log('\nDry run — nothing was written.');
+    return;
+  }
+
+  console.log('');
+  await insertRows(rows);
+  console.log('\nDone.');
+}
+
+main().catch((error: unknown) => {
+  console.error(`\n${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/importPuskasoturitDiscs.ts
+++ b/scripts/importPuskasoturitDiscs.ts
@@ -18,8 +18,7 @@
 import { importDiscData } from '../app/import/PuskaSoturitImporter.ts';
 import { toDiscRow, type DiscRow } from '../app/import/puskasoturitDiscFields.ts';
 import { createReadConnection, createWriteConnection } from './supabaseClients.ts';
-
-const PUSKASOTURIT_CLUB_ID = 1;
+import { PUSKASOTURIT } from '../app/config/clubs.ts';
 
 /** Supabase caps a select at 1000 rows, so the existing ids come back in pages. */
 const PAGE_SIZE = 1000;
@@ -118,8 +117,8 @@ async function main(): Promise<void> {
   const discs = await importDiscData();
   console.log(`Sheet rows with a disc name, a date and an id: ${discs.length}`);
 
-  const persisted = await getPersistedInternalDiscIds(PUSKASOTURIT_CLUB_ID);
-  console.log(`Already in the database for club ${PUSKASOTURIT_CLUB_ID}: ${persisted.size}`);
+  const persisted = await getPersistedInternalDiscIds(PUSKASOTURIT);
+  console.log(`Already in the database for club ${PUSKASOTURIT}: ${persisted.size}`);
 
   const newDiscs = discs.filter((disc) => !persisted.has(Number(disc.internalDiscId)));
 

--- a/scripts/supabaseClients.ts
+++ b/scripts/supabaseClients.ts
@@ -1,0 +1,63 @@
+/**
+ * Supabase clients for the command-line scripts.
+ *
+ * Kept free of `~/` imports so the scripts run under plain node's TypeScript
+ * stripping, the same reason app/import/puskasoturitDiscFields.ts avoids them.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing ${name}. Set it in .env.`);
+  }
+
+  return value;
+}
+
+/** Reading is public, so the anon key is enough for it. */
+export function createReadConnection() {
+  return createClient(requireEnv('SUPABASE_URL'), requireEnv('SUPABASE_KEY'));
+}
+
+/**
+ * A client allowed to write. Row-level security on `discs` only lets
+ * authenticated users insert or update, and the anon key is not one — the app
+ * writes with the signed-in user's session, which a script has to arrange for
+ * itself.
+ *
+ * Either put SUPABASE_SERVICE_ROLE_KEY in .env (it bypasses RLS), or sign in
+ * with an admin account through SUPABASE_EMAIL / SUPABASE_PASSWORD.
+ */
+export async function createWriteConnection() {
+  const url = requireEnv('SUPABASE_URL');
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (serviceRoleKey) {
+    console.log('Writing with the service role key.');
+    return createClient(url, serviceRoleKey);
+  }
+
+  const email = process.env.SUPABASE_EMAIL;
+  const password = process.env.SUPABASE_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error(
+      'Writing needs more than the anon key. Set SUPABASE_SERVICE_ROLE_KEY in .env, ' +
+        'or SUPABASE_EMAIL and SUPABASE_PASSWORD for an admin account.',
+    );
+  }
+
+  const supabase = createClient(url, requireEnv('SUPABASE_KEY'));
+
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    throw new Error(`Signing in as ${email} failed: ${error.message}`);
+  }
+
+  console.log(`Writing as ${email}.`);
+
+  return supabase;
+}

--- a/supabase/migrations/20260830000000_discs_archived_at.sql
+++ b/supabase/migrations/20260830000000_discs_archived_at.sql
@@ -1,0 +1,20 @@
+-- Discs the club has stopped listing, without claiming to know what became of
+-- them.
+--
+-- The public list only shows discs that are neither returned nor released for
+-- sale/donation, which leaves years of unresolved rows on the front page for
+-- ever. Marking those returned or sold would record something that did not
+-- happen; archiving records only what is true — the club no longer lists them.
+--
+-- Nullable and reversible: clearing the column puts a disc back on the list.
+-- Statistics deliberately ignore it (getDiscsForStats reads every row for the
+-- club), so archiving does not rewrite the club's history.
+
+ALTER TABLE public.discs
+  ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+
+-- The public list filters on it on every load.
+CREATE INDEX IF NOT EXISTS discs_archived_at_idx ON public.discs (archived_at);
+
+COMMENT ON COLUMN public.discs.archived_at IS
+  'When the club stopped listing this disc publicly. NULL = still listed. Says nothing about where the disc ended up.';


### PR DESCRIPTION
Everything needed to run this app for Puskasoturit (`APP_CLUB_ID=1`) alongside Talin Tallaajat, plus the disc-list changes that came out of it.

## Front page

- **The logo was missing.** `getClubLogo()` only knew club 2, so club 1 rendered an `<img>` with no `src`. Both clubs now come from a map, and an unknown club gets no image rather than an empty `src`. The favicon had the same gap.
- **Course filter and column.** Puskasoturit collects from Oittaa and Äijänpelto. `getDiscs()` now selects the `course` column (already mapped, never fetched), the list gains a "Rata" radio filter with "Kaikki radat" as the reset, and the table shows the course between the phone number and the added date. Both are gated on the club, and the filter additionally needs more than one course in the loaded data.
- **The filter row was cramped.** It was a single non-wrapping flex line, so the disc selector collapsed to its chevron. It now stacks on a phone and wraps above that, and a `size.control` token gives the text field, combobox and radio row the same height.
- **The intro is shown to both clubs.** It was hidden behind `clubId === 2`; the text reads fine for either club, so only the link to the club's own lost-and-found page differs now. Extracted to `DiscListIntro`, which owns the club check.
- **Per-club contact address** in the Ohjeet box, and the Tali-specific "reply to 3904" instructions are gone from both places.

## Importing the Puskasoturit sheet

`npm run import:puskasoturit -- --dry-run` prints every row it would write; without the flag it inserts.

Unlike `syncAllDiscs` it never deletes: it reads which `(internal_disc_id, club_id)` pairs the table already holds and inserts only the rest. `internal_disc_id` is not unique on its own — the same number exists once per club — so the club is always part of the comparison.

The free-text notes are read into the columns `discs` grew later: `"14.5.2026 (Janimatti), noudettu"` becomes `returned_to_owner_date` plus `return_method`, and `"Lahjoitetaan"` becomes a disposal method. Matching is on stems so the sheet's typos still land, and the course spellings (`Oiittaa`, `ÄIjänpelto`) are folded into one name so the filter does not sprout extra options.

The importer also stops throwing on two inputs that took whole runs down: an API error now says so, and a date cell that is not a date yields null instead of `Invalid time value`.

Writes need more than the anon key, since RLS only lets authenticated users insert: either `SUPABASE_SERVICE_ROLE_KEY`, or `SUPABASE_EMAIL` and `SUPABASE_PASSWORD`.

## Archiving

Years of 2024–2025 discs that were never marked returned or sold sat on the public list for ever. Marking them returned would record something that did not happen, so `discs` gains a nullable `archived_at` recording only what is true: the club stopped listing them.

`getDiscs()` skips archived discs; `getDiscsForStats()` deliberately does not, so the club's history is unchanged. `npm run archive:discs -- --before=YYYY-MM-DD` sets it, with the same `--dry-run` flag. The cutoff is required and validated, and rows are addressed by `external_id` rather than by re-running the filters, so a disc resolved between the read and the write is not archived behind the admin's back. Reversible: clearing `archived_at` puts a disc back on the list.

**The migration in this PR is already applied to the database.**

## Choosing a course when adding discs

A disc added by hand had no course, so it could only ever appear under "Kaikki radat" — the filter above was useless for exactly the discs an admin had just entered.

The add form now offers the club's courses as radio buttons, with "Ei radan tietoa" as the default; the choice sticks between entries, since a batch is normally one bin's worth. The course is never read out of the typed disc text — the radio is its only source, and the table's "Rata" cell is read-only. Two things make a whole batch easy to fix: one click applies the selected course to every row not yet saved, and a subtle line reminds the admin while any row is still without one. Saving without a course is still allowed.

The course names live in `app/config/courses.ts` beside the slugs the QR posters already use, as the short spelling the sheet writes (`Oittaa`, not `Oittaan frisbeegolfrata`) so a hand-added disc lands under the same filter option as an imported one. The server takes the allowed names from `APP_CLUB_ID` rather than from the request and rejects anything else — a free-text course would sprout a stray option in the public filter. A club with a single course (Talin Tallaajat) is not asked at all.

## Also

- Hover titles on the three admin icons in the disc table: "Merkitse palautetuksi", "Merkitse myytäväksi tai lahjoitettavaksi", "Poista kiekko". They had `aria-label`s but nothing on hover.
- The mark forms open inside the dark disc table, where their `gray-600` labels sat at about 1.6:1 against the row. Light text throughout, and the Peruuta button no longer turns light-on-light on hover.
- `docs/caching-the-public-disc-list.md` — a CDN caching design that is deliberately **not implemented**, kept with its traps and verification steps.
- `npm run lint` is now clean (it was 5 warnings, none of them failing the build).

## Testing

22 new unit tests covering the note parsing, course normalisation and row mapping — including one that asserts the script's local method numbers still equal the `ReturnMethod` / `DisposalMethod` enums, since the script cannot import them. The submission tests now cover the course too: that it reaches the DTO, that a course the club does not have is rejected, and that no course at all is accepted. 201 tests, `tsc`, eslint and prettier all pass.

Both scripts were verified against the real sheet and database with `--dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
