### PR TITLE
feat(discs): record private notes typed after a pipe

### DIFF
--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -26,6 +26,7 @@ import {
   ArrowUpwardIcon,
   CheckCircleIcon,
   DeleteIcon,
+  InfoIcon,
   SellIcon,
   TextsmsIcon,
   WarningIcon,
@@ -53,6 +54,8 @@ interface Row {
   internalDiscId: number | null;
   /** Only present for a signed-in visitor; the admin actions are keyed on it. */
   externalId?: string;
+  /** Club-internal notes. The loader only sends these to a signed-in visitor. */
+  additionalInfo?: string;
 }
 
 type OutletContext = {
@@ -168,13 +171,30 @@ function mapToDataRows(discs: DiscDTO[]): Row[] {
     addedAt: disc.addedAt ?? '',
     internalDiscId: disc.internalDiscId,
     externalId: disc.externalId,
+    additionalInfo: disc.additionalInfo,
   }));
 }
 
 /** Which of the two marks is open on a row. */
 type MarkKind = 'return' | 'disposal';
 
-type OpenForm = { externalId: string; kind: MarkKind };
+/** What the row expanded under a disc is showing: a mark form, or its notes. */
+type PanelKind = MarkKind | 'info';
+
+type OpenPanel = { externalId: string; kind: PanelKind };
+
+/**
+ * The club-internal notes on a disc, shown under it rather than in a column of
+ * their own: they are free text, and most discs have none.
+ */
+function AdditionalInfoPanel({ row }: { row: Row }): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs uppercase tracking-wide text-gray-400">Lisätiedot – {row.discName}</span>
+      <span className="whitespace-pre-wrap">{row.additionalInfo}</span>
+    </div>
+  );
+}
 
 type MarkFormProps = {
   row: Row;
@@ -299,7 +319,7 @@ function DeleteButton({ row, onDeleted }: DeleteButtonProps): JSX.Element | null
       title="Poista kiekko"
       disabled={isDeleting}
       onClick={handleClick}
-      className="inline-flex text-gray-500 hover:text-red-600 disabled:opacity-40"
+      className="inline-flex text-red-400 hover:text-red-300 disabled:opacity-40"
     >
       <DeleteIcon width={18} height={18} />
     </button>
@@ -310,11 +330,11 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
   const { session } = useOutletContext<OutletContext>();
   const isLoggedIn = !!session?.user?.id;
 
-  // Which disc has one of the mark forms open, and which one.
-  const [openForm, setOpenForm] = useState<OpenForm | null>(null);
+  // Which disc has a panel open under it, and what that panel is showing.
+  const [openForm, setOpenForm] = useState<OpenPanel | null>(null);
 
-  /** Opens the given mark on the given disc, or closes it if already open. */
-  const toggleForm = (externalId: string, kind: MarkKind): void =>
+  /** Opens the given panel on the given disc, or closes it if already open. */
+  const toggleForm = (externalId: string, kind: PanelKind): void =>
     setOpenForm((current) =>
       current?.externalId === externalId && current.kind === kind ? null : { externalId, kind },
     );
@@ -386,7 +406,7 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
                         title="Merkitse palautetuksi"
                         aria-expanded={openForm?.externalId === row.original.externalId && openForm.kind === 'return'}
                         onClick={() => toggleForm(row.original.externalId!, 'return')}
-                        className="inline-flex text-gray-500 hover:text-green-700"
+                        className="inline-flex text-green-400 hover:text-green-300"
                       >
                         <CheckCircleIcon width={18} height={18} />
                       </button>
@@ -397,9 +417,24 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
                         title="Merkitse myytäväksi tai lahjoitettavaksi"
                         aria-expanded={openForm?.externalId === row.original.externalId && openForm.kind === 'disposal'}
                         onClick={() => toggleForm(row.original.externalId!, 'disposal')}
-                        className="inline-flex text-gray-500 hover:text-blue-700"
+                        className="inline-flex text-sky-400 hover:text-sky-300"
                       >
                         <SellIcon width={18} height={18} />
+                      </button>
+
+                      {/* Most discs carry no notes, so this one is often
+                          disabled — which is why the icons around it are
+                          coloured rather than grey. */}
+                      <button
+                        type="button"
+                        aria-label={`Näytä kiekon ${row.original.discName} lisätiedot`}
+                        title={row.original.additionalInfo ? 'Näytä lisätiedot' : 'Kiekolla ei ole lisätietoja'}
+                        disabled={!row.original.additionalInfo}
+                        aria-expanded={openForm?.externalId === row.original.externalId && openForm.kind === 'info'}
+                        onClick={() => toggleForm(row.original.externalId!, 'info')}
+                        className="inline-flex text-amber-400 hover:text-amber-300 disabled:text-gray-500 disabled:hover:text-gray-500 disabled:cursor-not-allowed"
+                      >
+                        <InfoIcon width={18} height={18} />
                       </button>
                     </>
                   )}
@@ -500,21 +535,25 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
                 })}
               </tr>
 
-              {/* A mark form opens as a row of its own, under the disc it
-                  belongs to, rather than as a modal. */}
+              {/* A mark form, or a disc's notes, opens as a row of its own
+                  under the disc it belongs to, rather than as a modal. */}
               {open && (
                 <tr {...stylex.props(index % 2 === 1 && styles.rowEven)}>
                   <td colSpan={row.getVisibleCells().length} {...stylex.props(styles.td)}>
-                    <MarkForm
-                      row={row.original}
-                      externalId={open.externalId}
-                      kind={open.kind}
-                      onCancel={() => setOpenForm(null)}
-                      onDone={() => {
-                        setOpenForm(null);
-                        onChanged?.();
-                      }}
-                    />
+                    {open.kind === 'info' ? (
+                      <AdditionalInfoPanel row={row.original} />
+                    ) : (
+                      <MarkForm
+                        row={row.original}
+                        externalId={open.externalId}
+                        kind={open.kind}
+                        onCancel={() => setOpenForm(null)}
+                        onDone={() => {
+                          setOpenForm(null);
+                          onChanged?.();
+                        }}
+                      />
+                    )}
                   </td>
                 </tr>
               )}

--- a/app/features/discs/list/loadDiscListData.server.ts
+++ b/app/features/discs/list/loadDiscListData.server.ts
@@ -8,11 +8,14 @@ export async function loadDiscListData(request: Request) {
   const clubId = parseInt(process.env.APP_CLUB_ID!, 10);
 
   const emptyingLogItems = await getEmptyingLogItemsForClub(clubId, request);
-  const discs = await getDiscs();
 
-  // The external id is only needed for the admin actions in the table, so it is
-  // kept out of the payload anonymous visitors receive.
+  // The external id is only needed for the admin actions in the table, and the
+  // notes in additional_info are club-internal, so both are kept out of the
+  // payload anonymous visitors receive. Checked before the query, so the notes
+  // are never even read for an anonymous visitor.
   const isLoggedIn = await isUserLoggedIn(request);
+
+  const discs = await getDiscs(isLoggedIn);
   const data = isLoggedIn ? discs : discs.map((disc) => ({ ...disc, externalId: undefined }));
 
   return {

--- a/app/features/discs/submission/AddDiscsPage.tsx
+++ b/app/features/discs/submission/AddDiscsPage.tsx
@@ -146,10 +146,13 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
           name="discText"
           type="text"
           autoComplete="off"
-          placeholder="Esim. Star Destroyer punainen 050 123 4567 Steve D."
+          placeholder="Esim. Star Destroyer punainen 050 123 4567 Steve D. | PDGA 12345, 175 g"
           {...stylex.props(styles.input)}
         />
-        <p {...stylex.props(styles.hint)}>Paina Enter tunnistaaksesi tiedot.</p>
+        <p {...stylex.props(styles.hint)}>
+          Paina Enter tunnistaaksesi tiedot. Pystyviivan (|) jälkeen kirjoitettu teksti tallennetaan lisätietoina, eikä
+          sitä näytetä julkisella listalla.
+        </p>
 
         {courses.length > 0 && (
           <div {...stylex.props(styles.courseField)}>
@@ -378,8 +381,15 @@ function Cell({ value, header, isEditing, onOpen, onCommit, onCancel }: CellProp
   );
 }
 
-/** The six fields shown in the table, all of them editable by hand. */
-type EditableField = 'discName' | 'plastic' | 'colour' | 'manufacturer' | 'phoneNumber' | 'ownerName';
+/** The fields shown in the table, all of them editable by hand. */
+type EditableField =
+  | 'discName'
+  | 'plastic'
+  | 'colour'
+  | 'manufacturer'
+  | 'phoneNumber'
+  | 'ownerName'
+  | 'additionalInfo';
 
 type Row = ParsedDisc & { id: number; input: string; course: string | null };
 
@@ -403,6 +413,7 @@ const columns: { header: string; field: EditableField }[] = [
   { header: 'Valmistaja', field: 'manufacturer' },
   { header: 'Puhelinnumero', field: 'phoneNumber' },
   { header: 'Omistaja', field: 'ownerName' },
+  { header: 'Lisätiedot', field: 'additionalInfo' },
 ];
 
 const styles = stylex.create({

--- a/app/features/discs/submission/parser/parseDiscText.test.ts
+++ b/app/features/discs/submission/parser/parseDiscText.test.ts
@@ -77,6 +77,53 @@ describe('parseDiscText — the examples from the brief', () => {
   });
 });
 
+describe('parseDiscText — the note after a pipe', () => {
+  it('stores everything after the pipe as additional info', () => {
+    expect(parseDiscText('Star Destroyer punainen | PDGA 12345, 175 g, sininen stamppi').additionalInfo).toBe(
+      'PDGA 12345, 175 g, sininen stamppi',
+    );
+  });
+
+  it('still parses the disc from the part before the pipe', () => {
+    expect(fields('Star Destroyer punainen 050 123 4567 Steve D. | PDGA 12345')).toEqual({
+      discName: 'Destroyer',
+      plastic: 'Star',
+      manufacturer: 'Innova',
+      colour: 'Punainen',
+      ownerName: 'Steve D.',
+      phoneNumber: '0501234567',
+    });
+  });
+
+  it('never lets the note reach the disc fields, even when it names a colour', () => {
+    const parsed = parseDiscText('Mako3 keltainen | musta stamppi, Innova');
+
+    expect(parsed.colour).toBe('Keltainen');
+    expect(parsed.ownerName).toBeNull();
+    expect(parsed.unmatched).toEqual([]);
+    expect(parsed.additionalInfo).toBe('musta stamppi, Innova');
+  });
+
+  it('reports no note when there is no pipe', () => {
+    expect(parseDiscText('Mako3 keltainen').additionalInfo).toBeNull();
+  });
+
+  it('reports no note when nothing but blanks follow the pipe', () => {
+    expect(parseDiscText('Mako3 keltainen |   ').additionalInfo).toBeNull();
+  });
+
+  it('keeps a later pipe as part of the note', () => {
+    expect(parseDiscText('Mako3 keltainen | 175 g | tarkista').additionalInfo).toBe('175 g | tarkista');
+  });
+
+  it('parses a disc with nothing but a note', () => {
+    const parsed = parseDiscText('Mako3 | 175 g');
+
+    expect(parsed.discName).toBe('Mako3');
+    expect(parsed.additionalInfo).toBe('175 g');
+  });
+});
+
 describe('parseDiscText — plain colours', () => {
   it.each([
     ['musta', 'Musta'],

--- a/app/features/discs/submission/parser/parseDiscText.ts
+++ b/app/features/discs/submission/parser/parseDiscText.ts
@@ -22,6 +22,8 @@ export type ParsedDisc = {
   colour: string | null;
   ownerName: string | null;
   phoneNumber: string | null;
+  /** Private notes typed after a '|'; never shown to anonymous visitors. */
+  additionalInfo: string | null;
   /** Words the parser could not place anywhere. */
   unmatched: string[];
   confidence: { manufacturer: Confidence };
@@ -278,9 +280,32 @@ function valueOf(entries: DictionaryEntry[] | null): string | null {
   return entries ? entries[0].value : null;
 }
 
+/**
+ * Splits the typed line at the first '|': what precedes it describes the disc,
+ * what follows it is a free-text note about it (PDGA number, weight, stamp
+ * colour). The note is kept verbatim — it is never tokenized or matched against
+ * the catalogue, so a word like "punainen" in a note cannot end up as the
+ * disc's colour.
+ *
+ * A later '|' is part of the note, so a note may itself contain one.
+ */
+export function splitAdditionalInfo(input: string): { discText: string; additionalInfo: string | null } {
+  const pipe = input.indexOf('|');
+
+  if (pipe === -1) {
+    return { discText: input, additionalInfo: null };
+  }
+
+  const note = input.slice(pipe + 1).trim();
+
+  return { discText: input.slice(0, pipe), additionalInfo: note.length > 0 ? note : null };
+}
+
 export function parseDiscText(input: string, dictionary: Dictionary = defaultDictionary): ParsedDisc {
-  const phone = findPhoneNumber(input);
-  const tokens = tokenize(stripPhoneNumber(input, phone));
+  const { discText, additionalInfo } = splitAdditionalInfo(input);
+
+  const phone = findPhoneNumber(discText);
+  const tokens = tokenize(stripPhoneNumber(discText, phone));
 
   const spans = segment(tokens, dictionary);
   const unknown = extractUnknownDisc(spans);
@@ -301,6 +326,7 @@ export function parseDiscText(input: string, dictionary: Dictionary = defaultDic
     colour: valueOf(slots[COLOUR]),
     ownerName,
     phoneNumber: phone ? phone.value : null,
+    additionalInfo,
     unmatched,
     confidence: { manufacturer: confidence },
   };

--- a/app/features/discs/submission/submitDiscs.test.ts
+++ b/app/features/discs/submission/submitDiscs.test.ts
@@ -20,7 +20,14 @@ describe('toSubmission', () => {
       phoneNumber: '0501234567',
       ownerName: 'Steve D.',
       course: null,
+      additionalInfo: null,
     });
+  });
+
+  it('carries the note typed after the pipe', () => {
+    expect(toSubmission(parseDiscText('Star Destroyer punainen | PDGA 12345, 175 g')).additionalInfo).toBe(
+      'PDGA 12345, 175 g',
+    );
   });
 
   it('passes unidentified fields through as null', () => {

--- a/app/features/discs/submission/submitDiscs.ts
+++ b/app/features/discs/submission/submitDiscs.ts
@@ -11,6 +11,8 @@ export type DiscSubmission = {
   ownerName: string | null;
   /** The course the disc was found on, or null when the club records none. */
   course: string | null;
+  /** Club-internal notes; never sent to anonymous visitors. */
+  additionalInfo: string | null;
 };
 
 export type SubmitResult = { status: 'success'; savedCount: number } | { status: 'error'; message: string };
@@ -25,6 +27,7 @@ export function toSubmission(disc: ParsedDisc & { course?: string | null }): Dis
     phoneNumber: disc.phoneNumber,
     ownerName: disc.ownerName,
     course: disc.course ?? null,
+    additionalInfo: disc.additionalInfo,
   };
 }
 

--- a/app/features/discs/submission/toDiscDTO.test.ts
+++ b/app/features/discs/submission/toDiscDTO.test.ts
@@ -34,8 +34,13 @@ describe('toDiscDTO', () => {
       ownerName: 'Steve D.',
       ownerPhoneNumber: '0501234567',
       course: null,
+      additionalInfo: undefined,
       clubId: 2,
     });
+  });
+
+  it('carries the note through to the persisted field', () => {
+    expect(toDiscDTO(submission('Mako3 keltainen | PDGA 12345'), 2).additionalInfo).toBe('PDGA 12345');
   });
 
   it('leaves the identifiers to the model', () => {
@@ -78,8 +83,20 @@ describe('parseBatch', () => {
     { reason: 'a field over the length cap', body: { discs: [{ discName: 'M'.repeat(201) }] } },
     { reason: 'a row with no name or plastic', body: { discs: [{ colour: 'Punainen' }] } },
     { reason: 'a course this club does not have', body: { discs: [{ discName: 'Mako3', course: 'Tali' }] } },
+    {
+      reason: 'a note over its own, longer cap',
+      body: { discs: [{ discName: 'Mako3', additionalInfo: 'x'.repeat(501) }] },
+    },
   ])('rejects $reason', ({ body }) => {
     expect(parseBatch(body, COURSES)).toMatchObject({ error: expect.any(String) });
+  });
+
+  it('accepts a note longer than the cap the other fields have', () => {
+    const note = 'x'.repeat(300);
+
+    expect(parseBatch({ discs: [{ discName: 'Mako3', additionalInfo: note }] }, COURSES)).toMatchObject({
+      discs: [{ additionalInfo: note }],
+    });
   });
 
   it('accepts a row with one of the club courses, and one with none', () => {

--- a/app/features/discs/submission/toDiscDTO.ts
+++ b/app/features/discs/submission/toDiscDTO.ts
@@ -7,6 +7,10 @@ export const MAX_BATCH_SIZE = 100;
 
 const MAX_FIELD_LENGTH = 200;
 
+// The note is free text rather than one catalogue value, so it is allowed to
+// run longer than a disc name or a colour.
+const MAX_ADDITIONAL_INFO_LENGTH = 500;
+
 /**
  * Joins the disc name and the plastic the way the Google Sheet has always
  * written them: "Destroyer, Star". Existing rows use that shape, so the public
@@ -31,11 +35,21 @@ export function toDiscDTO(disc: DiscSubmission, clubId: number): DiscDTO {
     ownerName: disc.ownerName,
     ownerPhoneNumber: disc.phoneNumber ?? undefined,
     course: disc.course,
+    additionalInfo: disc.additionalInfo ?? undefined,
     clubId,
   };
 }
 
-const fields = ['discName', 'plastic', 'colour', 'manufacturer', 'phoneNumber', 'ownerName', 'course'] as const;
+const fields = [
+  'discName',
+  'plastic',
+  'colour',
+  'manufacturer',
+  'phoneNumber',
+  'ownerName',
+  'course',
+  'additionalInfo',
+] as const;
 
 function readField(row: Record<string, unknown>, field: string): string | null | undefined {
   const value = row[field];
@@ -44,7 +58,9 @@ function readField(row: Record<string, unknown>, field: string): string | null |
     return null;
   }
 
-  if (typeof value !== 'string' || value.length > MAX_FIELD_LENGTH) {
+  const maxLength = field === 'additionalInfo' ? MAX_ADDITIONAL_INFO_LENGTH : MAX_FIELD_LENGTH;
+
+  if (typeof value !== 'string' || value.length > maxLength) {
     return undefined;
   }
 

--- a/app/models/discs.server.ts
+++ b/app/models/discs.server.ts
@@ -9,16 +9,26 @@ import { fromDTO, toDTO } from '~/models/DiscMapper';
 import type { DiscDisposalDetails } from '~/features/discs/disposal/discDisposal';
 import type { DiscReturnDetails } from '~/features/discs/return/discReturn';
 
-export async function getDiscs(): Promise<DiscDTO[]> {
+/** The columns the public disc list is built from. Safe for anyone to see. */
+const PUBLIC_DISC_COLUMNS =
+  'external_id, internal_disc_id, disc_name, disc_colour, disc_manufacturer, owner_name, owner_phone_number, owner_club_name, added_at, course';
+
+/**
+ * The discs this club is currently listing.
+ *
+ * `additional_info` holds club-internal notes about a disc, so it is left out
+ * of the SELECT unless the caller has established that a user is signed in —
+ * kept out of the query rather than stripped afterwards, so it can never reach
+ * the response by way of a forgotten mapping.
+ */
+export async function getDiscs(includeAdditionalInfo = false): Promise<DiscDTO[]> {
   const clubId = process.env.APP_CLUB_ID;
 
   const supabase = createConnection();
 
   const { data } = await supabase
     .from('discs')
-    .select(
-      'external_id, internal_disc_id, disc_name, disc_colour, disc_manufacturer, owner_name, owner_phone_number, owner_club_name, added_at, course',
-    )
+    .select(includeAdditionalInfo ? `${PUBLIC_DISC_COLUMNS}, additional_info` : PUBLIC_DISC_COLUMNS)
     .order('disc_name', { ascending: true })
     .eq('is_returned_to_owner', false)
     .eq('can_be_sold_or_donated', false)

--- a/app/ui/icons.tsx
+++ b/app/ui/icons.tsx
@@ -54,6 +54,14 @@ export function SellIcon(props: IconProps): JSX.Element {
   );
 }
 
+export function InfoIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
+    </SvgIcon>
+  );
+}
+
 export function DeleteIcon(props: IconProps): JSX.Element {
   return (
     <SvgIcon {...props}>

--- a/prompts/support for adding multiple discs through website.md
+++ b/prompts/support for adding multiple discs through website.md
@@ -201,3 +201,25 @@ Currently /demo is the route for adding new discs. Let's rename it to /discs/add
 and components if needed.
 
 Make sure the route is protected and requires login.
+
+## Phase 11 - allow additional information
+
+Create a new branch.
+
+The `discs` table contains `additional_info` column that can be used for storing private and misc info
+that can be found on the disc (PDG number, weight, stamp colour etc).
+
+I want to be able to provide such information using the same textfield.
+
+All text in the textfield followed by a '|' is 5o be identified as content to be stored in
+`additional_info`. Note that `additional_info` is never shown for unsigned people and must never be
+returned by the query and the response.
+
+For autheticated users, display a (i) icon in the admin tools columns, which open an inline row with the contents of
+`additional_info`. If the row contains no data for `additional_info`, then disable the (i) icon.
+
+This requirement forces the other the admin tool icons to have a different color, as the current gray
+color might be suitable to indicate a disabled icon.
+
+Remember to edit the query and the response that are used for authenticated users to include
+`additional_info`.


### PR DESCRIPTION
Phase 11. Lets an admin record club-internal notes about a disc — PDGA number, weight, stamp colour — through the same text field used to add discs, without those notes ever reaching the public list.

## Summary

- **Parsing** — `splitAdditionalInfo` splits the typed line at the first `|`. What precedes it goes through the existing disc parsing; what follows is kept verbatim as the note. The note is never tokenized or matched against the catalogue, so a word like "punainen" or "Innova" inside a note cannot end up as the disc's colour or manufacturer. A second `|` stays part of the note; a blank note becomes `null`.
- **Submission** — `additionalInfo` threads through `DiscSubmission` → `toSubmission` → `toDiscDTO` → the existing `fromDTO` mapping onto `additional_info`. Validation accepts it as a normal field but with its own 500-character cap; the other fields keep 200, since a note is free text rather than one catalogue value.
- **Add-discs page** — an editable "Lisätiedot" column, and the hint and placeholder document the `|`.
- **Query and response** — `getDiscs(includeAdditionalInfo)` adds `additional_info` to the SELECT only when asked, and `loadDiscListData` resolves `isUserLoggedIn` *before* the query. For an anonymous visitor the column is never read at all, rather than read and then stripped.
- **List table** — an (i) button in the admin actions column toggles an inline row under the disc showing its notes, reusing the same expanded-row mechanism as the existing mark forms (`MarkKind` widened to `PanelKind`). It is `disabled` on a disc with no notes.
- **Icon colours** — since grey now reads as "disabled", the other action icons take a hue of their own against the dark table: returned green-400, sell/donate sky-400, info amber-400, delete red-400, each hovering one step lighter.

## Notes

- No migration: `additional_info` already exists on the `discs` table.
- Nothing writes notes onto sheet-imported discs; this covers discs added through the text field.

## Test plan

- `npx vitest run` — 212 pass, 10 of them new: the pipe split, a note that names a colour not contaminating the disc fields, a blank note, a second pipe, the longer length cap, and the DTO mapping.
- `npm run typecheck`, `npm run build`, `npx eslint app` — all clean.
- Manual, signed in: add a disc with `Star Destroyer punainen | PDGA 12345, 175 g`, confirm the note lands in the Lisätiedot column and the disc fields are unaffected; on the list, confirm the (i) opens the note inline and is disabled on a disc without one.
- Manual, signed out: confirm the list loader's response carries no `additionalInfo` for any disc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)