### PR TITLE
feat(discs): keep unsaved rows, and fix a course from the list

### DIFF
--- a/app/features/discs/courseChange/discCourse.ts
+++ b/app/features/discs/courseChange/discCourse.ts
@@ -1,0 +1,12 @@
+/** What is recorded when a disc is filed under a course. */
+export type DiscCourseDetails = {
+  /**
+   * The course the disc was found on, or null to clear it. Null is a real
+   * choice rather than "unanswered": it is how a disc filed under the wrong
+   * course is put back to having none.
+   */
+  course: string | null;
+};
+
+/** The same, addressed to one disc — what the route receives. */
+export type DiscCourseInput = DiscCourseDetails & { externalId: string };

--- a/app/features/discs/courseChange/handleCourseRequest.server.ts
+++ b/app/features/discs/courseChange/handleCourseRequest.server.ts
@@ -1,0 +1,53 @@
+import { getDiscCourseNames } from '~/config/courses';
+import { markRefusal, requireAdminJson } from '~/lib/api/resourceRoute.server';
+import { isExternalId } from '~/lib/api/validate';
+import { setDiscCourse } from '~/models/discs.server';
+
+/**
+ * Authorises, validates and applies a course change posted to /discs/course.
+ *
+ * The course is checked against the ones this club actually collects from,
+ * rather than written through as typed: a stray value would become an extra
+ * option in the list page's course filter, which is the same reason the add
+ * form validates it.
+ */
+export async function handleCourseRequest(request: Request): Promise<Response> {
+  const gate = await requireAdminJson(request);
+
+  if ('response' in gate) {
+    return gate.response;
+  }
+
+  const { externalId, course } = (gate.body ?? {}) as Record<string, unknown>;
+
+  if (!isExternalId(externalId)) {
+    return Response.json({ error: 'Virheellinen kiekon tunniste.' }, { status: 422 });
+  }
+
+  // Null is the deliberate "no course" choice, so it skips the list check.
+  if (course !== null && typeof course !== 'string') {
+    return Response.json({ error: 'Virheellinen rata.' }, { status: 422 });
+  }
+
+  const allowedCourses = getDiscCourseNames(parseInt(process.env.APP_CLUB_ID!, 10));
+
+  if (course !== null && !allowedCourses.includes(course)) {
+    return Response.json({ error: `Tuntematon rata "${course}".` }, { status: 422 });
+  }
+
+  try {
+    const outcome = await setDiscCourse(externalId, course, request);
+
+    const refusal = markRefusal(outcome);
+
+    if (refusal) {
+      return refusal;
+    }
+
+    return Response.json({ marked: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Radan tallennus epäonnistui.';
+
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/features/discs/courseChange/setDiscCourse.test.ts
+++ b/app/features/discs/courseChange/setDiscCourse.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { setDiscCourse } from './setDiscCourse';
+
+const input = { externalId: '3f8a1c2e-5b6d-4a7f-9c0e-1d2b3a4c5d6e', course: 'Oittaa' };
+
+function stubFetch(response: Partial<Response> & { json?: () => Promise<unknown> }) {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, ...response });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('setDiscCourse', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts the course to the resource route', async () => {
+    const fetchMock = stubFetch({});
+
+    expect(await setDiscCourse(input)).toEqual({ status: 'success' });
+    expect(fetchMock).toHaveBeenCalledWith('/discs/course', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+  });
+
+  it('sends a cleared course as null', async () => {
+    const fetchMock = stubFetch({});
+
+    await setDiscCourse({ ...input, course: null });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({ course: null });
+  });
+
+  it("passes the route's own message through", async () => {
+    stubFetch({ ok: false, status: 422, json: async () => ({ error: 'Tuntematon rata "Tali".' }) });
+
+    expect(await setDiscCourse(input)).toEqual({ status: 'error', message: 'Tuntematon rata "Tali".' });
+  });
+
+  it('reports a transport failure rather than throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    expect(await setDiscCourse(input)).toMatchObject({ status: 'error' });
+  });
+});

--- a/app/features/discs/courseChange/setDiscCourse.ts
+++ b/app/features/discs/courseChange/setDiscCourse.ts
@@ -1,0 +1,22 @@
+import { type ActionResult, postJson } from '~/lib/api/postJson';
+
+import type { DiscCourseInput } from './discCourse';
+
+/** The resource route that records the course. */
+const COURSE_URL = '/discs/course';
+
+const GENERIC_ERROR = 'Radan tallennus epäonnistui. Yritä uudelleen.';
+
+/**
+ * Files one disc under a course, or clears the one it has.
+ *
+ * Never throws: a transport failure comes back as an error result, so the
+ * caller has one thing to handle rather than two.
+ */
+export async function setDiscCourse(input: DiscCourseInput): Promise<ActionResult> {
+  const result = await postJson(COURSE_URL, input, GENERIC_ERROR);
+
+  return result.status === 'success' ? { status: 'success' } : result;
+}
+
+export type { DiscCourseInput };

--- a/app/features/discs/list/CourseForm.tsx
+++ b/app/features/discs/list/CourseForm.tsx
@@ -1,0 +1,105 @@
+import { useState, type FormEvent, type JSX } from 'react';
+
+/** The value the "no course" radio carries; empty so it cannot collide with a real name. */
+const NO_COURSE = '';
+
+type CourseFormProps = {
+  discName: string;
+  /** The course the disc is filed under now, or null when it has none. */
+  current: string | null;
+  /** The courses this club collects from. */
+  courses: string[];
+  /** Distinguishes this form's field ids and radio group from any other on the page. */
+  idPrefix: string;
+  /** Resolves to null on success, or to a message to show in the form. */
+  onSubmit: (course: string | null) => Promise<string | null>;
+  onCancel: () => void;
+};
+
+/**
+ * Files a disc under one of the club's courses, inline under the row.
+ *
+ * Deliberately not the DateAndMethodForm the two marks share: there is no date
+ * to record here, and the choice is one of a fixed list rather than an optional
+ * extra. "Ei rataa" is offered as a real option, since clearing a course that
+ * was set wrong is as much the point as setting one that was missed.
+ */
+export default function CourseForm({
+  discName,
+  current,
+  courses,
+  idPrefix,
+  onSubmit,
+  onCancel,
+}: CourseFormProps): JSX.Element {
+  const [course, setCourse] = useState<string>(current ?? NO_COURSE);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+    event.preventDefault();
+
+    setIsSaving(true);
+    setError(null);
+
+    const message = await onSubmit(course === NO_COURSE ? null : course);
+
+    setIsSaving(false);
+    setError(message);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-6 py-2">
+      {/* The form opens inside the dark disc table, so its text has to be
+          light, as in DateAndMethodForm. */}
+      <p className="basis-full text-xs text-gray-300">
+        Aseta rata: <b>{discName}</b>
+      </p>
+
+      <fieldset>
+        <legend className="text-xs font-bold text-gray-300 mb-1">Rata</legend>
+        <div className="flex flex-wrap items-center gap-4">
+          {courses.map((name) => (
+            <label key={name} className="inline-flex items-center gap-1">
+              <input
+                type="radio"
+                name={`${idPrefix}-course`}
+                value={name}
+                checked={course === name}
+                onChange={() => setCourse(name)}
+              />
+              {name}
+            </label>
+          ))}
+
+          <label className="inline-flex items-center gap-1">
+            <input
+              type="radio"
+              name={`${idPrefix}-course`}
+              value={NO_COURSE}
+              checked={course === NO_COURSE}
+              onChange={() => setCourse(NO_COURSE)}
+            />
+            Ei radan tietoa
+          </label>
+        </div>
+      </fieldset>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={isSaving}
+          className="bg-green-700 hover:bg-green-800 disabled:opacity-40 text-white rounded px-3 py-1"
+        >
+          {isSaving ? 'Tallennetaan...' : 'Tallenna rata'}
+        </button>
+
+        <button type="button" onClick={onCancel} className="border border-gray-300 hover:bg-white/10 rounded px-3 py-1">
+          Peruuta
+        </button>
+      </div>
+
+      {error && <p className="basis-full text-red-300">{error}</p>}
+    </form>
+  );
+}

--- a/app/features/discs/list/DiscListPage.tsx
+++ b/app/features/discs/list/DiscListPage.tsx
@@ -74,7 +74,8 @@ export default function DiscListPage(): JSX.Element {
   // records no course at all, so neither the filter nor the column applies.
   // Derived rather than a club id in a literal: the filter, the column and the
   // add form then agree by construction, all reading the one course list.
-  const isMultiCourseClub = clubId !== null && getDiscCourseNames(clubId).length > 0;
+  const clubCourses = clubId === null ? [] : getDiscCourseNames(clubId);
+  const isMultiCourseClub = clubCourses.length > 0;
 
   const hasDiscs = discs.length > 0;
   // A reload keeps the previous fetcher.data, so "loading with data already on
@@ -143,7 +144,7 @@ export default function DiscListPage(): JSX.Element {
             for the first load only, when there is nothing to show yet. */}
         {hasDiscs && (
           <div aria-busy={isReloading} className={isReloading ? 'opacity-50 transition-opacity' : undefined}>
-            <DiscTable discs={discs} showCourse={isMultiCourseClub} onChanged={() => fetcher.load('/discs/data')} />
+            <DiscTable discs={discs} courses={clubCourses} onChanged={() => fetcher.load('/discs/data')} />
           </div>
         )}
         {isFirstLoad && <CircularProgress style={{ width: '5rem', height: '5rem' }} />}

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -15,11 +15,13 @@ import {
   type SortingState,
 } from '@tanstack/react-table';
 
+import { setDiscCourse } from '~/features/discs/courseChange/setDiscCourse';
 import { deleteDisc } from '~/features/discs/deletion/deleteDisc';
 import { disposalMethodOptions } from '~/features/discs/disposal/disposalMethod';
 import { markForDisposal } from '~/features/discs/disposal/markForDisposal';
 import { markAsReturned } from '~/features/discs/return/markAsReturned';
 import { returnMethodOptions } from '~/features/discs/return/returnMethod';
+import CourseForm from '~/features/discs/list/CourseForm';
 import DateAndMethodForm from '~/features/discs/list/DateAndMethodForm';
 import {
   ArrowDownwardIcon,
@@ -27,6 +29,7 @@ import {
   CheckCircleIcon,
   DeleteIcon,
   InfoIcon,
+  PlaceIcon,
   SellIcon,
   TextsmsIcon,
   WarningIcon,
@@ -39,8 +42,12 @@ type DiscTableProps = {
   discs: DiscDTO[];
   /** Called after a disc has been deleted or marked returned, to reload the list. */
   onChanged?: () => void;
-  /** Only clubs that collect from more than one course record a course per disc. */
-  showCourse?: boolean;
+  /**
+   * The courses this club collects from; empty for a club that records none.
+   * Drives both the Rata column and the admin tool that sets it, so the two
+   * cannot disagree about whether this club files discs under a course.
+   */
+  courses?: string[];
 };
 
 interface Row {
@@ -179,7 +186,7 @@ function mapToDataRows(discs: DiscDTO[]): Row[] {
 type MarkKind = 'return' | 'disposal';
 
 /** What the row expanded under a disc is showing: a mark form, or its notes. */
-type PanelKind = MarkKind | 'info';
+type PanelKind = MarkKind | 'info' | 'course';
 
 type OpenPanel = { externalId: string; kind: PanelKind };
 
@@ -326,7 +333,9 @@ function DeleteButton({ row, onDeleted }: DeleteButtonProps): JSX.Element | null
   );
 }
 
-export default function DiscTable({ discs, onChanged, showCourse = false }: DiscTableProps): JSX.Element | null {
+export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableProps): JSX.Element | null {
+  const showCourse = courses.length > 0;
+
   const { session } = useOutletContext<OutletContext>();
   const isLoggedIn = !!session?.user?.id;
 
@@ -421,6 +430,23 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
                       >
                         <SellIcon width={18} height={18} />
                       </button>
+
+                      {/* Only for a club that files discs under a course.
+                          The fix for a disc saved before the course was
+                          picked, which used to mean editing the row by hand
+                          in the SQL editor. */}
+                      {showCourse && (
+                        <button
+                          type="button"
+                          aria-label={`Aseta kiekon ${row.original.discName} rata`}
+                          title="Aseta rata"
+                          aria-expanded={openForm?.externalId === row.original.externalId && openForm.kind === 'course'}
+                          onClick={() => toggleForm(row.original.externalId!, 'course')}
+                          className="inline-flex text-violet-400 hover:text-violet-300"
+                        >
+                          <PlaceIcon width={18} height={18} />
+                        </button>
+                      )}
 
                       {/* Most discs carry no notes, so this one is often
                           disabled — which is why the icons around it are
@@ -542,6 +568,26 @@ export default function DiscTable({ discs, onChanged, showCourse = false }: Disc
                   <td colSpan={row.getVisibleCells().length} {...stylex.props(styles.td)}>
                     {open.kind === 'info' ? (
                       <AdditionalInfoPanel row={row.original} />
+                    ) : open.kind === 'course' ? (
+                      <CourseForm
+                        discName={row.original.discName}
+                        current={row.original.course || null}
+                        courses={courses}
+                        idPrefix={`course-${open.externalId}`}
+                        onCancel={() => setOpenForm(null)}
+                        onSubmit={async (course) => {
+                          const result = await setDiscCourse({ externalId: open.externalId, course });
+
+                          if (result.status === 'error') {
+                            return result.message;
+                          }
+
+                          setOpenForm(null);
+                          onChanged?.();
+
+                          return null;
+                        }}
+                      />
                     ) : (
                       <MarkForm
                         row={row.original}

--- a/app/features/discs/submission/AddDiscsPage.tsx
+++ b/app/features/discs/submission/AddDiscsPage.tsx
@@ -1,8 +1,17 @@
-import { useRef, useState, type FormEvent, type JSX, type KeyboardEvent } from 'react';
+import { useState, useSyncExternalStore, type FormEvent, type JSX, type KeyboardEvent } from 'react';
 
 import * as stylex from '@stylexjs/stylex';
 
-import { parseDiscText, type ParsedDisc } from '~/features/discs/submission/parser/parseDiscText';
+import {
+  clearDraft,
+  getDraftSnapshot,
+  getServerDraftSnapshot,
+  nextDraftId,
+  subscribeToDraft,
+  updateDraft,
+  type DraftRow,
+} from '~/features/discs/submission/draftStorage';
+import { parseDiscText } from '~/features/discs/submission/parser/parseDiscText';
 import { submitDiscs, toSubmission } from '~/features/discs/submission/submitDiscs';
 import { DeleteIcon } from '~/ui/icons';
 import FormControlLabel from '~/ui/FormControlLabel';
@@ -19,7 +28,11 @@ type AddDiscsPageProps = {
 const NO_COURSE = '';
 
 export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Element {
-  const [rows, setRows] = useState<Row[]>([]);
+  // The rows live in a store backed by localStorage rather than in component
+  // state, so an accidental refresh before saving no longer throws the batch
+  // away. Read through useSyncExternalStore, which serves the empty server
+  // snapshot until hydration is done and so restores without a mismatch.
+  const rows = useSyncExternalStore(subscribeToDraft, getDraftSnapshot, getServerDraftSnapshot);
   // The course new rows are filed under. Kept across entries, since a batch is
   // normally one bin's worth. The course is never read out of the typed text:
   // this selection is its only source.
@@ -28,15 +41,17 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
   // The row whose delete button has been pressed and is awaiting a yes/no.
   const [confirmingDelete, setConfirmingDelete] = useState<number | null>(null);
   const [submitState, setSubmitState] = useState<SubmitState>({ status: 'idle' });
-  const nextId = useRef(1);
+  // Whether the "clear the draft" button has been pressed and is awaiting a yes/no.
+  const [isConfirmingClear, setIsConfirmingClear] = useState(false);
 
   /**
    * Any change to the table makes an earlier "saved" or "failed" box stale, so
    * it is cleared as soon as the data moves on.
    */
   function updateRows(update: (current: Row[]) => Row[]): void {
-    setRows(update);
+    updateDraft(update);
     setSubmitState({ status: 'idle' });
+    setIsConfirmingClear(false);
   }
 
   /** Writes an edited cell back to the in-memory table and closes the editor. */
@@ -91,7 +106,7 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
 
     updateRows((current) => [
       ...current,
-      { id: nextId.current++, input: text, course: course || null, ...parseDiscText(text) },
+      { id: nextDraftId(current), input: text, course: course || null, ...parseDiscText(text) },
     ]);
 
     // Clear so the next disc can be typed straight away.
@@ -121,11 +136,13 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
 
     setSubmitState({ status: 'success', savedCount: result.savedCount });
 
-    // The batch is persisted, so clear the table for the next one. Done with
-    // setRows rather than updateRows, which would wipe the success box.
-    setRows([]);
+    // The batch is persisted, so the draft has done its job: clear the table
+    // and the stored copy alike. Done with clearDraft rather than updateRows,
+    // which would wipe the success box.
+    clearDraft();
     setEditing(null);
     setConfirmingDelete(null);
+    setIsConfirmingClear(false);
   }
 
   return (
@@ -134,7 +151,7 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
 
       <p {...stylex.props(styles.intro)}>
         Korjaa tietoja napsauttamalla solua; Enter tallentaa, Esc peruu. Tallennus vie kiekot tietokantaan ja julkiselle
-        listalle.
+        listalle. Tallentamattomat rivit säilyvät selaimessa, joten sivun vahinkolataus ei hukkaa niitä.
       </p>
 
       <form onSubmit={handleSubmit} {...stylex.props(styles.form)}>
@@ -309,6 +326,36 @@ export default function AddDiscsPage({ courses }: AddDiscsPageProps): JSX.Elemen
             {rows.length} {rows.length === 1 ? 'kiekko' : 'kiekkoa'} tallennettavana.
           </span>
         )}
+
+        {/* Nothing cached, nothing to offer. Confirmed rather than immediate:
+            this throws away work the draft exists to protect. */}
+        {rows.length > 0 &&
+          !isSending &&
+          (isConfirmingClear ? (
+            <span {...stylex.props(styles.confirm)}>
+              Tyhjennetäänkö {rows.length} {rows.length === 1 ? 'kiekko' : 'kiekkoa'}?
+              <button
+                type="button"
+                onClick={() => {
+                  clearDraft();
+                  setEditing(null);
+                  setConfirmingDelete(null);
+                  setIsConfirmingClear(false);
+                  setSubmitState({ status: 'idle' });
+                }}
+                {...stylex.props(styles.confirmButton)}
+              >
+                Kyllä
+              </button>
+              <button type="button" onClick={() => setIsConfirmingClear(false)} {...stylex.props(styles.cancelButton)}>
+                Peruuta
+              </button>
+            </span>
+          ) : (
+            <button type="button" onClick={() => setIsConfirmingClear(true)} {...stylex.props(styles.applyButton)}>
+              Tyhjennä välimuisti
+            </button>
+          ))}
       </div>
 
       {/* Announced politely so the outcome reaches a screen reader too. */}
@@ -391,7 +438,7 @@ type EditableField =
   | 'ownerName'
   | 'additionalInfo';
 
-type Row = ParsedDisc & { id: number; input: string; course: string | null };
+type Row = DraftRow;
 
 /** Which cell, if any, is currently open for editing. */
 type EditTarget = { rowId: number; field: EditableField };

--- a/app/features/discs/submission/draftStorage.test.ts
+++ b/app/features/discs/submission/draftStorage.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { parseDiscText } from '~/features/discs/submission/parser/parseDiscText';
+
+import type { DraftRow } from './draftStorage';
+
+const STORAGE_KEY = 'lost-and-found:disc-draft:v1';
+
+/** A localStorage good enough for the store, with the failures it has to survive. */
+function stubStorage(initial: Record<string, string> = {}, mode: 'ok' | 'throws' = 'ok') {
+  const items = new Map(Object.entries(initial));
+
+  const storage = {
+    getItem: (key: string) => {
+      if (mode === 'throws') {
+        throw new Error('storage blocked');
+      }
+
+      return items.get(key) ?? null;
+    },
+    setItem: (key: string, value: string) => {
+      if (mode === 'throws') {
+        throw new Error('quota exceeded');
+      }
+
+      items.set(key, value);
+    },
+    removeItem: (key: string) => {
+      if (mode === 'throws') {
+        throw new Error('storage blocked');
+      }
+
+      items.delete(key);
+    },
+  };
+
+  vi.stubGlobal('window', { localStorage: storage });
+
+  return items;
+}
+
+/**
+ * A fresh copy of the store. Its draft is module state, deliberately, so each
+ * test needs its own module instance rather than a reset between them.
+ */
+async function loadStore() {
+  vi.resetModules();
+
+  return import('./draftStorage');
+}
+
+const row = (id: number, text: string): DraftRow => ({
+  id,
+  input: text,
+  course: null,
+  ...parseDiscText(text),
+});
+
+beforeEach(() => {
+  stubStorage();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('the draft store', () => {
+  it('starts empty when storage holds no draft', async () => {
+    const store = await loadStore();
+
+    expect(store.getDraftSnapshot()).toEqual([]);
+  });
+
+  it('never hands a stored draft to the server render', async () => {
+    stubStorage({ [STORAGE_KEY]: JSON.stringify([row(1, 'Mako3 keltainen')]) });
+
+    const store = await loadStore();
+
+    expect(store.getServerDraftSnapshot()).toEqual([]);
+  });
+
+  it('keeps rows across a reload', async () => {
+    const first = await loadStore();
+
+    first.updateDraft((current) => [...current, row(1, 'Star Destroyer punainen')]);
+
+    // A new module instance is what a refreshed page gets.
+    const second = await loadStore();
+
+    expect(second.getDraftSnapshot()).toMatchObject([{ id: 1, discName: 'Destroyer', plastic: 'Star' }]);
+  });
+
+  it('returns the same array until something changes, as useSyncExternalStore needs', async () => {
+    const store = await loadStore();
+
+    store.updateDraft(() => [row(1, 'Mako3 keltainen')]);
+
+    expect(store.getDraftSnapshot()).toBe(store.getDraftSnapshot());
+  });
+
+  it('tells subscribers when the draft changes', async () => {
+    const store = await loadStore();
+    const listener = vi.fn();
+
+    const unsubscribe = store.subscribeToDraft(listener);
+    store.updateDraft(() => [row(1, 'Mako3 keltainen')]);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    store.updateDraft(() => []);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the draft from storage as well as memory', async () => {
+    const items = stubStorage();
+    const store = await loadStore();
+
+    store.updateDraft(() => [row(1, 'Mako3 keltainen')]);
+    expect(items.has(STORAGE_KEY)).toBe(true);
+
+    store.clearDraft();
+
+    expect(store.getDraftSnapshot()).toEqual([]);
+    expect(items.has(STORAGE_KEY)).toBe(false);
+  });
+
+  it('leaves no empty draft behind when the last row is removed', async () => {
+    const items = stubStorage();
+    const store = await loadStore();
+
+    store.updateDraft(() => [row(1, 'Mako3 keltainen')]);
+    store.updateDraft((current) => current.filter((entry) => entry.id !== 1));
+
+    expect(items.has(STORAGE_KEY)).toBe(false);
+  });
+
+  describe('a draft that cannot be trusted', () => {
+    it('ignores one that is not JSON', async () => {
+      stubStorage({ [STORAGE_KEY]: 'not json {' });
+
+      expect((await loadStore()).getDraftSnapshot()).toEqual([]);
+    });
+
+    it('ignores one that is not an array', async () => {
+      stubStorage({ [STORAGE_KEY]: JSON.stringify({ id: 1 }) });
+
+      expect((await loadStore()).getDraftSnapshot()).toEqual([]);
+    });
+
+    it('drops the entries that are not rows', async () => {
+      stubStorage({ [STORAGE_KEY]: JSON.stringify([null, 'Mako3', row(1, 'Mako3 keltainen')]) });
+
+      expect((await loadStore()).getDraftSnapshot()).toHaveLength(1);
+    });
+
+    it('falls back on fields of the wrong type rather than passing them to the table', async () => {
+      stubStorage({
+        [STORAGE_KEY]: JSON.stringify([{ id: 'first', input: 42, discName: { name: 'Mako3' }, unmatched: 'kaikki' }]),
+      });
+
+      expect((await loadStore()).getDraftSnapshot()).toEqual([
+        {
+          id: 1,
+          input: '',
+          discName: null,
+          plastic: null,
+          manufacturer: null,
+          colour: null,
+          ownerName: null,
+          phoneNumber: null,
+          additionalInfo: null,
+          course: null,
+          unmatched: [],
+          confidence: { manufacturer: 'none' },
+        },
+      ]);
+    });
+
+    it('rejects a confidence outside the ones the table knows', async () => {
+      stubStorage({ [STORAGE_KEY]: JSON.stringify([{ id: 1, confidence: { manufacturer: 'certain' } }]) });
+
+      expect((await loadStore()).getDraftSnapshot()[0].confidence).toEqual({ manufacturer: 'none' });
+    });
+  });
+
+  describe('a browser that refuses storage', () => {
+    it('still starts, with an empty draft', async () => {
+      stubStorage({}, 'throws');
+
+      expect((await loadStore()).getDraftSnapshot()).toEqual([]);
+    });
+
+    it('still keeps the rows in memory when they cannot be written', async () => {
+      stubStorage({}, 'throws');
+
+      const store = await loadStore();
+
+      store.updateDraft(() => [row(1, 'Mako3 keltainen')]);
+
+      expect(store.getDraftSnapshot()).toHaveLength(1);
+    });
+  });
+});
+
+describe('nextDraftId', () => {
+  it('starts at 1 on an empty draft', async () => {
+    const { nextDraftId } = await loadStore();
+
+    expect(nextDraftId([])).toBe(1);
+  });
+
+  it('carries on past the ids a restored draft already uses', async () => {
+    const { nextDraftId } = await loadStore();
+
+    expect(nextDraftId([row(3, 'Mako3'), row(7, 'Wave'), row(2, 'Buzzz')])).toBe(8);
+  });
+});

--- a/app/features/discs/submission/draftStorage.ts
+++ b/app/features/discs/submission/draftStorage.ts
@@ -1,0 +1,179 @@
+import type { Confidence, ParsedDisc } from '~/features/discs/submission/parser/parseDiscText';
+
+/** One row of the add-discs table as it is held between page loads. */
+export type DraftRow = ParsedDisc & {
+  id: number;
+  /** The line as it was typed, kept so a row can be traced back to its input. */
+  input: string;
+  course: string | null;
+};
+
+const STORAGE_KEY = 'lost-and-found:disc-draft:v1';
+
+/**
+ * The rows the admin has entered but not yet saved.
+ *
+ * Held in a module-level store rather than in component state so that the draft
+ * outlives an accidental refresh: twenty discs typed in is half an hour of work
+ * that used to disappear. localStorage is the durable copy, but this array is
+ * the source of truth — a browser that refuses storage (private mode, blocked
+ * site data) then still gets a working page, it just loses the draft on
+ * refresh.
+ *
+ * Read through useSyncExternalStore, which is what keeps the restore free of
+ * hydration mismatches: the server and the first client render both see the
+ * empty server snapshot, and the stored rows arrive on the render after it.
+ */
+let rows: DraftRow[] = [];
+
+/** Whether localStorage has been read yet. Deferred so it never runs on the server. */
+let isLoaded = false;
+
+const listeners = new Set<() => void>();
+
+/** A stable empty array, so the server snapshot keeps its identity between calls. */
+const EMPTY: DraftRow[] = [];
+
+const CONFIDENCES: Confidence[] = ['high', 'medium', 'low', 'none'];
+
+function isConfidence(value: unknown): value is Confidence {
+  return typeof value === 'string' && (CONFIDENCES as string[]).includes(value);
+}
+
+function readString(row: Record<string, unknown>, field: string): string | null {
+  const value = row[field];
+
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Rebuilds one row from whatever was in storage.
+ *
+ * localStorage is writable by anything running on the origin and survives a
+ * deploy that changes the row shape, so nothing about it is assumed: a field of
+ * the wrong type falls back rather than reaching the table, where it would
+ * crash the render. The server validates the batch again on save regardless.
+ */
+function toDraftRow(value: unknown, index: number): DraftRow | null {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const row = value as Record<string, unknown>;
+  const confidence = (row.confidence ?? {}) as Record<string, unknown>;
+
+  return {
+    id: typeof row.id === 'number' && Number.isFinite(row.id) ? row.id : index + 1,
+    input: typeof row.input === 'string' ? row.input : '',
+    discName: readString(row, 'discName'),
+    plastic: readString(row, 'plastic'),
+    manufacturer: readString(row, 'manufacturer'),
+    colour: readString(row, 'colour'),
+    ownerName: readString(row, 'ownerName'),
+    phoneNumber: readString(row, 'phoneNumber'),
+    additionalInfo: readString(row, 'additionalInfo'),
+    course: readString(row, 'course'),
+    unmatched: Array.isArray(row.unmatched)
+      ? row.unmatched.filter((token): token is string => typeof token === 'string')
+      : [],
+    confidence: { manufacturer: isConfidence(confidence.manufacturer) ? confidence.manufacturer : 'none' },
+  };
+}
+
+function load(): DraftRow[] {
+  let raw: string | null;
+
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // Storage blocked outright. Carry on without a draft.
+    return EMPTY;
+  }
+
+  if (raw == null) {
+    return EMPTY;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return EMPTY;
+    }
+
+    const restored = parsed.map(toDraftRow).filter((row): row is DraftRow => row !== null);
+
+    return restored.length > 0 ? restored : EMPTY;
+  } catch {
+    // Not the JSON we wrote. Treat it as no draft rather than throwing on a
+    // page the admin is trying to work on.
+    return EMPTY;
+  }
+}
+
+/** Mirrors the draft to storage. Best effort: a full quota must not break the page. */
+function persist(): void {
+  try {
+    if (rows.length === 0) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(rows));
+    }
+  } catch {
+    // Storage blocked or full; the in-memory draft is unaffected.
+  }
+}
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeToDraft(listener: () => void): () => void {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * The current draft, loading it from storage the first time it is asked for.
+ *
+ * Returns the same array until something changes it, as useSyncExternalStore
+ * requires — a fresh array on every call would loop.
+ */
+export function getDraftSnapshot(): DraftRow[] {
+  if (!isLoaded) {
+    rows = load();
+    isLoaded = true;
+  }
+
+  return rows;
+}
+
+/** What the server and the hydrating render see: never a stored draft. */
+export function getServerDraftSnapshot(): DraftRow[] {
+  return EMPTY;
+}
+
+/** Applies a change to the draft and mirrors it to storage. */
+export function updateDraft(update: (current: DraftRow[]) => DraftRow[]): void {
+  rows = update(getDraftSnapshot());
+  persist();
+  notify();
+}
+
+/** Drops the draft, in memory and in storage. */
+export function clearDraft(): void {
+  rows = EMPTY;
+  isLoaded = true;
+  persist();
+  notify();
+}
+
+/** The id to give the next row, past anything a restored draft already uses. */
+export function nextDraftId(current: DraftRow[]): number {
+  return current.reduce((highest, row) => Math.max(highest, row.id), 0) + 1;
+}

--- a/app/models/discs.server.ts
+++ b/app/models/discs.server.ts
@@ -260,6 +260,21 @@ export async function markAsReturned(
 }
 
 /**
+ * Files one disc under a course, addressed by its external id.
+ *
+ * The fix for a disc saved before the course was picked, which otherwise meant
+ * editing the row by hand in the SQL editor. Null clears the course, so a disc
+ * filed under the wrong one can be put back to having none.
+ *
+ * The caller checks the name against the club's courses; this only writes it.
+ *
+ * Scoped to APP_CLUB_ID as well as the uuid.
+ */
+export async function setDiscCourse(externalId: string, course: string | null, request: Request): Promise<MarkOutcome> {
+  return updateDisc(externalId, { course }, request, 'Radan tallennus epäonnistui');
+}
+
+/**
  * Marks one disc as free to be sold or donated, addressed by its external id.
  *
  * The counterpart to markAsReturned: the same date-and-method pair, on the

--- a/app/routes/discs.course.tsx
+++ b/app/routes/discs.course.tsx
@@ -1,0 +1,13 @@
+import type { ActionFunctionArgs } from 'react-router';
+
+import { handleCourseRequest } from '~/features/discs/courseChange/handleCourseRequest.server';
+
+/**
+ * Files one disc under a course, or clears the one it has.
+ *
+ * A resource route for the same reason as /discs/create: a plain fetch POST to
+ * a page route is answered with a rendered document, not the action's JSON.
+ */
+export async function action({ request }: ActionFunctionArgs) {
+  return handleCourseRequest(request);
+}

--- a/app/ui/icons.tsx
+++ b/app/ui/icons.tsx
@@ -54,6 +54,14 @@ export function SellIcon(props: IconProps): JSX.Element {
   );
 }
 
+export function PlaceIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z" />
+    </SvgIcon>
+  );
+}
+
 export function InfoIcon(props: IconProps): JSX.Element {
   return (
     <SvgIcon {...props}>

--- a/e2e/discs-add.spec.ts
+++ b/e2e/discs-add.spec.ts
@@ -47,8 +47,10 @@ test.describe('/discs/add disc text parsing', () => {
 
     await expect(cells).toHaveText(['Destroyer', 'Star', 'Punainen', 'Innova', '0501234567', 'Steve D.']);
 
-    // Nothing was left over, so the leftovers cell shows a dash.
-    await expect(page.locator('tbody tr').first().locator('td').nth(6)).toHaveText('–');
+    // Nothing was left over, so the leftovers cell shows a dash. Counted from
+    // the end: it sits before the actions column whether or not this club
+    // records a course, and however many editable columns precede it.
+    await expect(page.locator('tbody tr').first().locator('td:nth-last-child(2)')).toHaveText('–');
 
     // The field clears so the next disc can be typed straight away.
     await expect(input).toHaveValue('');
@@ -101,7 +103,7 @@ test.describe('/discs/add disc text parsing', () => {
     const row = page.locator('tbody tr').first();
 
     await expect(row.locator('td:nth-child(-n+6)').nth(2)).toHaveText('–');
-    await expect(row.locator('td').nth(6)).toHaveText('punaienn');
+    await expect(row.locator('td:nth-last-child(2)')).toHaveText('punaienn');
   });
 
   test('leaves unidentified columns empty and keeps earlier rows', async ({ page }) => {
@@ -346,5 +348,142 @@ test.describe('/discs/add disc text parsing', () => {
     await input.press('Enter');
 
     await expect(page.getByRole('status')).toBeEmpty();
+  });
+
+  test('stores a note typed after a pipe, and keeps it out of the disc fields', async ({ page }) => {
+    await page.goto('/discs/add');
+
+    const input = page.getByLabel('Kiekon tiedot');
+
+    await input.fill('Mako3 keltainen | PDGA 12345, 175 g');
+    await input.press('Enter');
+
+    const row = page.locator('tbody tr').first();
+
+    await expect(row.locator('td:nth-child(-n+6)')).toHaveText(['Mako3', '–', 'Keltainen', 'Innova', '–', '–']);
+    await expect(row.locator('td').nth(6)).toHaveText('PDGA 12345, 175 g');
+  });
+});
+
+test.describe('/discs/add unsaved rows', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!EMAIL || !PASSWORD, 'Set E2E_EMAIL and E2E_PASSWORD to run these.');
+
+    await signIn(page);
+  });
+
+  test('keeps the typed rows across an accidental reload', async ({ page }) => {
+    await page.goto('/discs/add');
+
+    const input = page.getByLabel('Kiekon tiedot');
+
+    await input.fill('Mako3 keltainen');
+    await input.press('Enter');
+
+    await input.fill('Star Destroyer punainen');
+    await input.press('Enter');
+
+    await expect(page.locator('tbody tr')).toHaveCount(2);
+
+    await page.reload();
+
+    const rows = page.locator('tbody tr');
+
+    await expect(rows).toHaveCount(2);
+    await expect(rows.nth(0).locator('td:nth-child(-n+6)').nth(0)).toHaveText('Mako3');
+    await expect(rows.nth(1).locator('td:nth-child(-n+6)').nth(0)).toHaveText('Destroyer');
+  });
+
+  test('keeps an edit made before the reload, not just the parsed text', async ({ page }) => {
+    await page.goto('/discs/add');
+
+    const input = page.getByLabel('Kiekon tiedot');
+
+    await input.fill('Mako3 keltainen');
+    await input.press('Enter');
+
+    await page.getByRole('button', { name: 'Väri: Keltainen' }).click();
+
+    const editor = page.getByRole('textbox', { name: 'Väri' });
+
+    await editor.fill('Sininen');
+    await editor.press('Enter');
+
+    await page.reload();
+
+    await expect(page.locator('tbody tr').first().locator('td:nth-child(-n+6)').nth(2)).toHaveText('Sininen');
+  });
+
+  test('drops the stored rows once the batch is saved', async ({ page }) => {
+    await stubSave(page, { json: { savedCount: 1, externalIds: [] } });
+    await page.goto('/discs/add');
+
+    const input = page.getByLabel('Kiekon tiedot');
+
+    await input.fill('Mako3 keltainen');
+    await input.press('Enter');
+    await page.getByRole('button', { name: 'Tallenna kiekot' }).click();
+
+    await expect(page.getByRole('status')).toContainText('lisättiin');
+
+    await page.reload();
+
+    await expect(page.getByText('Ei vielä tunnistettuja kiekkoja.')).toBeVisible();
+  });
+
+  test('keeps the rows stored when the save fails, so they can be retried', async ({ page }) => {
+    await stubSave(page, { status: 500, json: { error: 'Tallennus epäonnistui.' } });
+    await page.goto('/discs/add');
+
+    const input = page.getByLabel('Kiekon tiedot');
+
+    await input.fill('Mako3 keltainen');
+    await input.press('Enter');
+    await page.getByRole('button', { name: 'Tallenna kiekot' }).click();
+
+    await expect(page.getByRole('status')).toContainText('Tallennus epäonnistui.');
+
+    await page.reload();
+
+    await expect(page.locator('tbody tr')).toHaveCount(1);
+  });
+
+  test('offers the clear button only once there is something to clear', async ({ page }) => {
+    await page.goto('/discs/add');
+
+    const clear = page.getByRole('button', { name: 'Tyhjennä välimuisti' });
+
+    await expect(clear).toHaveCount(0);
+
+    const input = page.getByLabel('Kiekon tiedot');
+
+    await input.fill('Mako3 keltainen');
+    await input.press('Enter');
+
+    await expect(clear).toBeVisible();
+  });
+
+  test('clears the stored rows only after the clear is confirmed', async ({ page }) => {
+    await page.goto('/discs/add');
+
+    const input = page.getByLabel('Kiekon tiedot');
+
+    await input.fill('Mako3 keltainen');
+    await input.press('Enter');
+
+    await page.getByRole('button', { name: 'Tyhjennä välimuisti' }).click();
+
+    // Backing out leaves the work alone.
+    await page.getByRole('button', { name: 'Peruuta' }).click();
+    await expect(page.locator('tbody tr')).toHaveCount(1);
+
+    await page.getByRole('button', { name: 'Tyhjennä välimuisti' }).click();
+    await page.getByRole('button', { name: 'Kyllä' }).click();
+
+    await expect(page.getByText('Ei vielä tunnistettuja kiekkoja.')).toBeVisible();
+
+    // Gone from storage too, not just from the table.
+    await page.reload();
+    await expect(page.getByText('Ei vielä tunnistettuja kiekkoja.')).toBeVisible();
   });
 });

--- a/prompts/support for adding multiple discs through website.md
+++ b/prompts/support for adding multiple discs through website.md
@@ -223,3 +223,17 @@ color might be suitable to indicate a disabled icon.
 
 Remember to edit the query and the response that are used for authenticated users to include
 `additional_info`.
+
+## Phase 12 - UX issues
+
+Create a new branch.
+
+When adding multiple discs, if I accidentally refresh the page after adding 20 new discs but before
+persisting, all work is wasted. Store the added discs to localstorage so that they persists.
+Clear them when the discs are successfully persisted. Add a "Tyhjennä välimuisti" button that does
+the same manually (hide it if nothing to clear).
+
+I've managed to forget selecting the course a couple of times now. First time I opened supabase sql
+editor and manually updated the course info. I don't want to do this. Add a new admin tool for setting
+a course for the selected row. IF pressed, open an inline editor (as usual) that allows me to select the
+course.


### PR DESCRIPTION
Phase 12. Two ways the add-and-list flow lost work.

## Unsaved rows survive a refresh

Twenty discs typed into the add form were gone the moment the page reloaded. The rows now live in a store backed by `localStorage` (`app/features/discs/submission/draftStorage.ts`).

- Read through **`useSyncExternalStore`**, which is the point of the design: the server and the hydrating render both see the empty server snapshot, so restoring the draft cannot produce a hydration mismatch. It also avoids adding a `react-hooks/set-state-in-effect` warning, which a restore-in-an-effect would have.
- The **in-memory array is the source of truth** and storage is a best-effort mirror, so a browser that blocks site data (private mode, blocked storage, full quota) still gets a working page — it just loses the draft on refresh.
- Stored JSON is **re-validated field by field** on load. `localStorage` is writable by anything on the origin and survives a deploy that changes the row shape, so a malformed draft falls back per field rather than reaching the table and crashing the render. The server still validates the batch on save regardless.
- Cleared automatically once the batch is saved; kept when a save **fails**, so it can be retried.

**"Tyhjennä välimuisti"** appears only when there are rows, and confirms inline (the Kyllä/Peruuta pattern the row delete already uses) — it discards exactly the work the draft exists to protect.

## Setting a course from the list

Forgetting to pick a course meant editing the row by hand in the Supabase SQL editor. A pin icon in the admin tools now opens an inline course picker under the row.

- New `discs/courseChange/` slice mirroring the existing disposal one: client `setDiscCourse` → `/discs/course` resource route → `handleCourseRequest.server.ts` → a `setDiscCourse` model function on the shared `updateDisc` helper, so it inherits the APP_CLUB_ID scoping and the `not-found` / `not-permitted` (RLS) outcomes.
- **"Ei radan tietoa" is a real option**, so a course set wrong can be cleared, not just replaced.
- The name is checked server-side against `getDiscCourseNames(APP_CLUB_ID)` rather than written through as posted — a stray value would otherwise become an extra option in the list page's course filter, which is why the add form validates it too.
- Shown only for a club that files discs under a course.

`DiscTable`'s `showCourse` boolean becomes a `courses` list, so the Rata column and the new tool derive from one source and cannot disagree about whether this club records one.

## Incidental fix

Two e2e assertions in `discs-add.spec.ts` quietly pointed at the wrong cell after the Lisätiedot column (#72) shifted the column indices. They now address the leftovers column from the end (`td:nth-last-child(2)`), which holds whether or not the club records a course. These specs skip without `E2E_EMAIL`/`E2E_PASSWORD`, so nothing caught it at the time.

## Test plan

- `npx vitest run` — 232 pass, 20 of them new: 16 covering the draft store (restore across a reload, snapshot identity as `useSyncExternalStore` requires, the empty server snapshot, subscribe/unsubscribe, clearing memory *and* storage, four kinds of untrusted stored draft, and a browser that throws on every storage call), 4 covering the `setDiscCourse` client.
- `npm run typecheck`, `npm run build`, `npx eslint app e2e` — all clean.
- **Playwright not run** — it needs credentials and a live server, and this repo's `.env` points at production. 10 new specs are included (draft across reload, an edit made before the reload, cleared on save, kept on failure, the clear button's visibility and confirmation, plus the Lisätiedot column that #72 never got e2e coverage for). Worth a run before merge.
- Manual: type several discs, refresh mid-batch, confirm the table comes back; save and confirm the draft is gone. On the list, use the pin to set a course on a disc that has none and to clear one that is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)