### PR TITLE
feat(messaging): group the phone number on the send page too

### DIFF
--- a/app/features/messaging/SendMessagePage.tsx
+++ b/app/features/messaging/SendMessagePage.tsx
@@ -4,7 +4,7 @@ import { Form, useFetcher } from 'react-router';
 
 import { convertLineBreaks, lineBreakToBr, replaceTokensWithValues } from '~/features/messaging/messageContent';
 import type { DiscDTO, MessageLogDTO, MessageTemplateDTO } from '~/types';
-import { formatDate } from '~/utils';
+import { formatDate, formatPhoneNumber } from '~/utils';
 import Button from '~/ui/Button';
 import H2 from '~/ui/H2';
 import H3 from '~/ui/H3';
@@ -20,6 +20,14 @@ type Props = {
   sentMessages: MessageLogDTO[];
 };
 
+/**
+ * The number as the phone should receive it: no grouping spaces, which an
+ * sms: target does not take.
+ */
+function toDiallable(phoneNumber: string): string {
+  return phoneNumber.replace(/\s/g, '');
+}
+
 export default function SendMessagePage({ data, messageTemplates, sentMessages }: Props): JSX.Element {
   const fetcher = useFetcher();
 
@@ -27,7 +35,10 @@ export default function SendMessagePage({ data, messageTemplates, sentMessages }
   // per disc, so there is nothing to sync afterwards.
   const defaultTemplate = messageTemplates.find((messageTemplate) => messageTemplate.isDefault === true);
 
-  const [phoneNumber, setPhoneNumber] = useState<string>(data.ownerPhoneNumber ?? '');
+  // Grouped for reading, the way the disc list shows it. The field stays
+  // editable, so what is typed into it is left alone — the sms: link takes the
+  // grouping back out rather than this reformatting as the admin types.
+  const [phoneNumber, setPhoneNumber] = useState<string>(formatPhoneNumber(data.ownerPhoneNumber));
   const [message, setMessage] = useState<string>(defaultTemplate?.content ?? '');
   const [selected, setSelected] = useState<number>(defaultTemplate?.id ?? -1);
   const ok: boolean = fetcher.data?.ok || false;
@@ -117,7 +128,7 @@ export default function SendMessagePage({ data, messageTemplates, sentMessages }
         </Button>
         <Button
           variant="contained"
-          to={`sms:${phoneNumber}&body=${convertLineBreaks(replaceTokensWithValues(message, data))}`}
+          to={`sms:${toDiallable(phoneNumber)}&body=${convertLineBreaks(replaceTokensWithValues(message, data))}`}
         >
           Lähetä tekstiviesti
         </Button>


### PR DESCRIPTION
## Summary

Follow-up to #75. The disc list groups the owner's number for reading, but the send-message page still showed ten digits in a row — and that page is the one place an admin reads the number off the screen to check it against the disc.

Reuses `formatPhoneNumber`, so the two screens agree and the unformattable values (a `?` where a digit could not be read, fragments, foreign forms) are shown as entered here too.

## The one wrinkle

That field is editable and its value feeds the `sms:` link, so grouping it needs care:

- The field is **seeded** with the grouped number, and what the admin types into it is left alone. Reformatting on every keystroke would fight whoever is correcting a digit.
- The `sms:` link **strips the grouping back out**, since spaces do not belong in an `sms:` target.

```
field:      040 686 1285
sms: link   sms:0406861285
```

## Test plan

Verified in the running app while signed in:

- [x] Field shows `040 686 1285` for a disc stored as `0406861285`
- [x] `sms:` target is `sms:0406861285` — no space in the number
- [x] Editing still flows through: typing `050 999 8877` yields `sms:0509998877`
- [x] `npm run typecheck`, `lint`, `format:check`, `build`, `test` (245) all clean

## Noticed, not touched

Two pre-existing oddities in the same field, left alone as out of scope:

- The input is declared `type="email" name="email"` with `placeholder="Sähköpostiosoite"` — leftovers from a copied field. On a phone it brings up the email keyboard rather than the number pad.
- The link builds `sms:<number>&body=…`; the first parameter should normally be `?body=`. May work on iOS and fail elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)