### PR TITLE
feat(discs): mark or delete a whole selection of discs at once

### DIFF
--- a/app/features/discs/batch/batchAction.test.ts
+++ b/app/features/discs/batch/batchAction.test.ts
@@ -1,19 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
 import { disposalMethodLabel } from '~/features/discs/disposal/disposalMethod';
+import { returnMethodLabel } from '~/features/discs/return/returnMethod';
 
-import { batchActionOutcome, confirmBatchAction, disposalMethodFor, isBatchAction } from './batchAction';
+import {
+  batchActionOutcome,
+  batchActionOrder,
+  confirmBatchAction,
+  disposalMethodFor,
+  isBatchAction,
+  returnMethodFor,
+} from './batchAction';
 
 describe('isBatchAction', () => {
-  it('accepts the four actions the bar offers', () => {
-    expect(isBatchAction('delete')).toBe(true);
-    expect(isBatchAction('return')).toBe(true);
-    expect(isBatchAction('sell')).toBe(true);
-    expect(isBatchAction('donate')).toBe(true);
+  it('accepts the five actions the dropdown offers', () => {
+    expect(batchActionOrder.every(isBatchAction)).toBe(true);
+    expect(batchActionOrder).toHaveLength(5);
   });
 
   it('rejects anything else a request might carry', () => {
+    // 'message' is the dropdown's sixth entry but not a batch write, and
+    // 'return' and 'disposal' are the names from before either mark carried
+    // its method.
     expect(isBatchAction('message')).toBe(false);
+    expect(isBatchAction('return')).toBe(false);
     expect(isBatchAction('disposal')).toBe(false);
     expect(isBatchAction('')).toBe(false);
     expect(isBatchAction(undefined)).toBe(false);
@@ -24,21 +34,22 @@ describe('isBatchAction', () => {
 describe('confirmBatchAction', () => {
   it('says what is about to happen and to how many discs', () => {
     expect(confirmBatchAction('delete', 12)).toBe('Poistetaanko 12 kiekkoa? Poistoa ei voi peruuttaa.');
-    expect(confirmBatchAction('return', 12)).toBe('Merkitäänkö 12 kiekkoa palautetuksi?');
+    expect(confirmBatchAction('returnByMail', 12)).toBe('Merkitäänkö 12 kiekkoa palautetuksi (postitettu)?');
+    expect(confirmBatchAction('returnPickedUp', 12)).toBe('Merkitäänkö 12 kiekkoa palautetuksi (noudettu)?');
     expect(confirmBatchAction('sell', 12)).toBe('Merkitäänkö 12 kiekkoa myytäväksi?');
     expect(confirmBatchAction('donate', 12)).toBe('Merkitäänkö 12 kiekkoa lahjoitettavaksi?');
   });
 
   it('counts one disc in the singular', () => {
     expect(confirmBatchAction('delete', 1)).toBe('Poistetaanko 1 kiekko? Poistoa ei voi peruuttaa.');
-    expect(confirmBatchAction('return', 1)).toBe('Merkitäänkö 1 kiekko palautetuksi?');
+    expect(confirmBatchAction('returnByMail', 1)).toBe('Merkitäänkö 1 kiekko palautetuksi (postitettu)?');
   });
 });
 
 describe('batchActionOutcome', () => {
   it('reports what was done when every disc was reached', () => {
     expect(batchActionOutcome('delete', 12, 12)).toBe('Poistettiin 12 kiekkoa.');
-    expect(batchActionOutcome('return', 1, 1)).toBe('Merkittiin palautetuksi 1 kiekko.');
+    expect(batchActionOutcome('returnPickedUp', 1, 1)).toBe('Merkittiin palautetuksi (noudettu) 1 kiekko.');
     expect(batchActionOutcome('sell', 3, 3)).toBe('Merkittiin myytäväksi 3 kiekkoa.');
     expect(batchActionOutcome('donate', 3, 3)).toBe('Merkittiin lahjoitettavaksi 3 kiekkoa.');
   });
@@ -47,17 +58,24 @@ describe('batchActionOutcome', () => {
     expect(batchActionOutcome('delete', 10, 12)).toBe(
       'Poistettiin 10 kiekkoa. 2 kiekkoa jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.',
     );
-    expect(batchActionOutcome('return', 1, 2)).toBe(
-      'Merkittiin palautetuksi 1 kiekko. 1 kiekko jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.',
+    expect(batchActionOutcome('returnByMail', 1, 2)).toBe(
+      'Merkittiin palautetuksi (postitettu) 1 kiekko. 1 kiekko jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.',
     );
   });
 });
 
-describe('disposalMethodFor', () => {
-  // Against the label rather than the number: the point is that a disc the
-  // club means to sell is not recorded as one it means to give away.
-  it('records the fate the action names', () => {
+// Against the labels rather than the numbers: the point is that a disc the club
+// means to sell is not recorded as one it means to give away, and one handed
+// over at the course is not recorded as posted. Nothing in the UI shows the
+// stored smallint, so an inversion would be invisible.
+describe('the method each action records', () => {
+  it('records the fate a release names', () => {
     expect(disposalMethodLabel(disposalMethodFor('sell'))).toBe('Myydään');
     expect(disposalMethodLabel(disposalMethodFor('donate'))).toBe('Lahjoitetaan');
+  });
+
+  it('records the way a return names', () => {
+    expect(returnMethodLabel(returnMethodFor('returnByMail'))).toBe('Postitettu');
+    expect(returnMethodLabel(returnMethodFor('returnPickedUp'))).toBe('Noudettu');
   });
 });

--- a/app/features/discs/batch/batchAction.test.ts
+++ b/app/features/discs/batch/batchAction.test.ts
@@ -3,14 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { disposalMethodLabel } from '~/features/discs/disposal/disposalMethod';
 import { returnMethodLabel } from '~/features/discs/return/returnMethod';
 
-import {
-  batchActionOutcome,
-  batchActionOrder,
-  confirmBatchAction,
-  disposalMethodFor,
-  isBatchAction,
-  returnMethodFor,
-} from './batchAction';
+import { batchActionOrder, batchActionOutcome, confirmBatchAction, isBatchAction, markFor } from './batchAction';
 
 describe('isBatchAction', () => {
   it('accepts the five actions the dropdown offers', () => {
@@ -68,14 +61,44 @@ describe('batchActionOutcome', () => {
 // means to sell is not recorded as one it means to give away, and one handed
 // over at the course is not recorded as posted. Nothing in the UI shows the
 // stored smallint, so an inversion would be invisible.
-describe('the method each action records', () => {
+// Two readers that also assert which columns the action writes: a mark of the
+// wrong kind cannot reach the label call.
+function disposalLabelFor(action: 'sell' | 'donate'): string | null {
+  const mark = markFor(action);
+
+  if (mark?.columns !== 'disposal') {
+    throw new Error(`${action} should record a disposal, got ${JSON.stringify(mark)}`);
+  }
+
+  return disposalMethodLabel(mark.method);
+}
+
+function returnLabelFor(action: 'returnByMail' | 'returnPickedUp'): string | null {
+  const mark = markFor(action);
+
+  if (mark?.columns !== 'return') {
+    throw new Error(`${action} should record a return, got ${JSON.stringify(mark)}`);
+  }
+
+  return returnMethodLabel(mark.method);
+}
+
+describe('markFor', () => {
   it('records the fate a release names', () => {
-    expect(disposalMethodLabel(disposalMethodFor('sell'))).toBe('Myydään');
-    expect(disposalMethodLabel(disposalMethodFor('donate'))).toBe('Lahjoitetaan');
+    expect(disposalLabelFor('sell')).toBe('Myydään');
+    expect(disposalLabelFor('donate')).toBe('Lahjoitetaan');
   });
 
   it('records the way a return names', () => {
-    expect(returnMethodLabel(returnMethodFor('returnByMail'))).toBe('Postitettu');
-    expect(returnMethodLabel(returnMethodFor('returnPickedUp'))).toBe('Noudettu');
+    expect(returnLabelFor('returnByMail')).toBe('Postitettu');
+    expect(returnLabelFor('returnPickedUp')).toBe('Noudettu');
+  });
+
+  it('has no mark for a delete, which records nothing', () => {
+    expect(markFor('delete')).toBeNull();
+  });
+
+  it('has a mark for every action that is not a delete', () => {
+    expect(batchActionOrder.filter((action) => markFor(action) === null)).toEqual(['delete']);
   });
 });

--- a/app/features/discs/batch/batchAction.test.ts
+++ b/app/features/discs/batch/batchAction.test.ts
@@ -1,16 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { batchActionOutcome, confirmBatchAction, isBatchAction } from './batchAction';
+import { disposalMethodLabel } from '~/features/discs/disposal/disposalMethod';
+
+import { batchActionOutcome, confirmBatchAction, disposalMethodFor, isBatchAction } from './batchAction';
 
 describe('isBatchAction', () => {
-  it('accepts the three actions the bar offers', () => {
+  it('accepts the four actions the bar offers', () => {
     expect(isBatchAction('delete')).toBe(true);
     expect(isBatchAction('return')).toBe(true);
-    expect(isBatchAction('disposal')).toBe(true);
+    expect(isBatchAction('sell')).toBe(true);
+    expect(isBatchAction('donate')).toBe(true);
   });
 
   it('rejects anything else a request might carry', () => {
     expect(isBatchAction('message')).toBe(false);
+    expect(isBatchAction('disposal')).toBe(false);
     expect(isBatchAction('')).toBe(false);
     expect(isBatchAction(undefined)).toBe(false);
     expect(isBatchAction(1)).toBe(false);
@@ -21,7 +25,8 @@ describe('confirmBatchAction', () => {
   it('says what is about to happen and to how many discs', () => {
     expect(confirmBatchAction('delete', 12)).toBe('Poistetaanko 12 kiekkoa? Poistoa ei voi peruuttaa.');
     expect(confirmBatchAction('return', 12)).toBe('Merkitäänkö 12 kiekkoa palautetuksi?');
-    expect(confirmBatchAction('disposal', 12)).toBe('Merkitäänkö 12 kiekkoa myytäväksi tai lahjoitettavaksi?');
+    expect(confirmBatchAction('sell', 12)).toBe('Merkitäänkö 12 kiekkoa myytäväksi?');
+    expect(confirmBatchAction('donate', 12)).toBe('Merkitäänkö 12 kiekkoa lahjoitettavaksi?');
   });
 
   it('counts one disc in the singular', () => {
@@ -34,7 +39,8 @@ describe('batchActionOutcome', () => {
   it('reports what was done when every disc was reached', () => {
     expect(batchActionOutcome('delete', 12, 12)).toBe('Poistettiin 12 kiekkoa.');
     expect(batchActionOutcome('return', 1, 1)).toBe('Merkittiin palautetuksi 1 kiekko.');
-    expect(batchActionOutcome('disposal', 3, 3)).toBe('Merkittiin myytäväksi tai lahjoitettavaksi 3 kiekkoa.');
+    expect(batchActionOutcome('sell', 3, 3)).toBe('Merkittiin myytäväksi 3 kiekkoa.');
+    expect(batchActionOutcome('donate', 3, 3)).toBe('Merkittiin lahjoitettavaksi 3 kiekkoa.');
   });
 
   it('reports the shortfall rather than the number asked for', () => {
@@ -44,5 +50,14 @@ describe('batchActionOutcome', () => {
     expect(batchActionOutcome('return', 1, 2)).toBe(
       'Merkittiin palautetuksi 1 kiekko. 1 kiekko jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.',
     );
+  });
+});
+
+describe('disposalMethodFor', () => {
+  // Against the label rather than the number: the point is that a disc the
+  // club means to sell is not recorded as one it means to give away.
+  it('records the fate the action names', () => {
+    expect(disposalMethodLabel(disposalMethodFor('sell'))).toBe('Myydään');
+    expect(disposalMethodLabel(disposalMethodFor('donate'))).toBe('Lahjoitetaan');
   });
 });

--- a/app/features/discs/batch/batchAction.test.ts
+++ b/app/features/discs/batch/batchAction.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { batchActionOutcome, confirmBatchAction, isBatchAction } from './batchAction';
+
+describe('isBatchAction', () => {
+  it('accepts the three actions the bar offers', () => {
+    expect(isBatchAction('delete')).toBe(true);
+    expect(isBatchAction('return')).toBe(true);
+    expect(isBatchAction('disposal')).toBe(true);
+  });
+
+  it('rejects anything else a request might carry', () => {
+    expect(isBatchAction('message')).toBe(false);
+    expect(isBatchAction('')).toBe(false);
+    expect(isBatchAction(undefined)).toBe(false);
+    expect(isBatchAction(1)).toBe(false);
+  });
+});
+
+describe('confirmBatchAction', () => {
+  it('says what is about to happen and to how many discs', () => {
+    expect(confirmBatchAction('delete', 12)).toBe('Poistetaanko 12 kiekkoa? Poistoa ei voi peruuttaa.');
+    expect(confirmBatchAction('return', 12)).toBe('Merkitäänkö 12 kiekkoa palautetuksi?');
+    expect(confirmBatchAction('disposal', 12)).toBe('Merkitäänkö 12 kiekkoa myytäväksi tai lahjoitettavaksi?');
+  });
+
+  it('counts one disc in the singular', () => {
+    expect(confirmBatchAction('delete', 1)).toBe('Poistetaanko 1 kiekko? Poistoa ei voi peruuttaa.');
+    expect(confirmBatchAction('return', 1)).toBe('Merkitäänkö 1 kiekko palautetuksi?');
+  });
+});
+
+describe('batchActionOutcome', () => {
+  it('reports what was done when every disc was reached', () => {
+    expect(batchActionOutcome('delete', 12, 12)).toBe('Poistettiin 12 kiekkoa.');
+    expect(batchActionOutcome('return', 1, 1)).toBe('Merkittiin palautetuksi 1 kiekko.');
+    expect(batchActionOutcome('disposal', 3, 3)).toBe('Merkittiin myytäväksi tai lahjoitettavaksi 3 kiekkoa.');
+  });
+
+  it('reports the shortfall rather than the number asked for', () => {
+    expect(batchActionOutcome('delete', 10, 12)).toBe(
+      'Poistettiin 10 kiekkoa. 2 kiekkoa jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.',
+    );
+    expect(batchActionOutcome('return', 1, 2)).toBe(
+      'Merkittiin palautetuksi 1 kiekko. 1 kiekko jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.',
+    );
+  });
+});

--- a/app/features/discs/batch/batchAction.ts
+++ b/app/features/discs/batch/batchAction.ts
@@ -20,11 +20,16 @@ export function isBatchAction(value: unknown): value is BatchAction {
  */
 export const MAX_BATCH_ACTION_SIZE = 500;
 
-/** The button that starts each action. */
+/**
+ * What each action is called where it is offered.
+ *
+ * They say nothing about a selection: the dropdown these sit in is beside the
+ * count of ticked discs, which is what they act on.
+ */
 export const batchActionLabels: Record<BatchAction, string> = {
-  delete: 'Poista valitut',
-  return: 'Merkitse valitut palautetuiksi',
-  disposal: 'Merkitse valitut myytäviksi tai lahjoitettaviksi',
+  delete: 'Poista',
+  return: 'Merkitse palautetuiksi',
+  disposal: 'Merkitse myytäviksi tai lahjoitettaviksi',
 };
 
 /** A count of discs, with the noun in the case Finnish puts it in. */

--- a/app/features/discs/batch/batchAction.ts
+++ b/app/features/discs/batch/batchAction.ts
@@ -1,24 +1,30 @@
 import { DisposalMethod, type DisposalMethodValue } from '~/features/discs/disposal/disposalMethod';
+import { ReturnMethod, type ReturnMethodValue } from '~/features/discs/return/returnMethod';
 
 /**
  * The actions that can be applied to a whole selection of discs at once.
  *
- * Releasing a disc is two of them rather than one with a method beside it.
- * Sale and donation are the whole point of that mark — a disc released without
- * saying which is a row nobody can act on — and asking in a second step for
- * something the admin has already decided is a step to click past. The single
- * disc form still asks, because there the method can be left unanswered.
+ * Both marks name their method rather than taking one beside them. The method
+ * is the whole point of either mark — a released disc that says neither sale
+ * nor donation, or a returned one that says neither by post nor in person, is a
+ * row nobody can act on — and by the time the admin picks the action the choice
+ * is already made, so a second step asking for it would be a step to click
+ * past. The single-disc forms still ask, because there either can be left
+ * unanswered.
  *
- * Messaging is not one of them: it is a walk through the selection one owner at
- * a time (see the send-batch page), not a single write.
+ * Messaging is not one of these: it is a walk through the selection one owner
+ * at a time (see the send-batch page), not a single write.
  */
-export const batchActions = ['delete', 'return', 'sell', 'donate'] as const;
+export const batchActions = ['delete', 'returnByMail', 'returnPickedUp', 'sell', 'donate'] as const;
 
 export type BatchAction = (typeof batchActions)[number];
 
 export function isBatchAction(value: unknown): value is BatchAction {
   return typeof value === 'string' && (batchActions as readonly string[]).includes(value);
 }
+
+/** The marks: everything but a delete records a date and a method. */
+export type MarkAction = Exclude<BatchAction, 'delete'>;
 
 /**
  * How many discs one batch may carry.
@@ -29,28 +35,20 @@ export function isBatchAction(value: unknown): value is BatchAction {
 export const MAX_BATCH_ACTION_SIZE = 500;
 
 /**
- * What each action is called where it is offered.
+ * Which fate a release records, and how a return got there, read off the action
+ * itself.
  *
- * They say nothing about a selection: the dropdown these sit in is beside the
- * count of ticked discs, which is what they act on.
- */
-export const batchActionLabels: Record<BatchAction, string> = {
-  delete: 'Poista',
-  return: 'Merkitse palautetuiksi',
-  sell: 'Merkitse myytäviksi',
-  donate: 'Merkitse lahjoitettaviksi',
-};
-
-/**
- * Which fate a release records, read off the action itself.
- *
- * The two are a smallint in the database and nothing in the UI shows the
- * number, so an inverted mapping here would write "donate" on every disc the
- * club means to sell without anything looking wrong. Pinned by a test against
- * the label.
+ * Both are a smallint in the database and nothing in the UI shows the number,
+ * so an inverted mapping would write "donate" on every disc the club means to
+ * sell, or "posted" on every one handed over in person, without anything
+ * looking wrong. Pinned by tests against the labels.
  */
 export function disposalMethodFor(action: 'sell' | 'donate'): DisposalMethodValue {
   return action === 'sell' ? DisposalMethod.Sold : DisposalMethod.Donated;
+}
+
+export function returnMethodFor(action: 'returnByMail' | 'returnPickedUp'): ReturnMethodValue {
+  return action === 'returnByMail' ? ReturnMethod.ByMail : ReturnMethod.PickedUp;
 }
 
 /** A count of discs, with the noun in the case Finnish puts it in. */
@@ -59,37 +57,57 @@ function discCount(count: number): string {
 }
 
 /**
- * What the browser asks before the action runs: what is about to happen, and to
- * how many discs.
+ * What each action is called where it is offered, what it asks before it runs,
+ * and what it calls what it did afterwards.
  *
- * Which discs is deliberately left out — the selection is on screen right
- * behind the dialog, and naming a dozen of them here would only be read as
- * noise and clicked past.
+ * The three kept together per action rather than in a table each: they are the
+ * same sentence in three tenses, and apart they drifted.
+ *
+ * The labels say nothing about a selection — the dropdown they sit in is beside
+ * the count of ticked discs, which is what says what they act on. What the
+ * confirmation leaves out is which discs: the selection is on screen right
+ * behind the dialog, and naming a dozen of them would be read as noise and
+ * clicked past.
  */
-export function confirmBatchAction(action: BatchAction, count: number): string {
-  switch (action) {
-    case 'delete': {
-      return `Poistetaanko ${discCount(count)}? Poistoa ei voi peruuttaa.`;
-    }
-    case 'return': {
-      return `Merkitäänkö ${discCount(count)} palautetuksi?`;
-    }
-    case 'sell': {
-      return `Merkitäänkö ${discCount(count)} myytäväksi?`;
-    }
-    case 'donate': {
-      return `Merkitäänkö ${discCount(count)} lahjoitettavaksi?`;
-    }
-  }
+const copy: Record<BatchAction, { label: string; asks: (discs: string) => string; did: string }> = {
+  returnByMail: {
+    label: 'Merkitse palautetuiksi (postitettu)',
+    asks: (discs) => `Merkitäänkö ${discs} palautetuksi (postitettu)?`,
+    did: 'Merkittiin palautetuksi (postitettu)',
+  },
+  returnPickedUp: {
+    label: 'Merkitse palautetuiksi (noudettu)',
+    asks: (discs) => `Merkitäänkö ${discs} palautetuksi (noudettu)?`,
+    did: 'Merkittiin palautetuksi (noudettu)',
+  },
+  sell: {
+    label: 'Merkitse myytäviksi',
+    asks: (discs) => `Merkitäänkö ${discs} myytäväksi?`,
+    did: 'Merkittiin myytäväksi',
+  },
+  donate: {
+    label: 'Merkitse lahjoitettaviksi',
+    asks: (discs) => `Merkitäänkö ${discs} lahjoitettavaksi?`,
+    did: 'Merkittiin lahjoitettavaksi',
+  },
+  delete: {
+    label: 'Poista',
+    asks: (discs) => `Poistetaanko ${discs}? Poistoa ei voi peruuttaa.`,
+    did: 'Poistettiin',
+  },
+};
+
+/** The order the dropdown offers the writes in. */
+export const batchActionOrder: BatchAction[] = ['returnByMail', 'returnPickedUp', 'sell', 'donate', 'delete'];
+
+export function batchActionLabel(action: BatchAction): string {
+  return copy[action].label;
 }
 
-/** What each action calls what it did, for the report afterwards. */
-const pastTense: Record<BatchAction, string> = {
-  delete: 'Poistettiin',
-  return: 'Merkittiin palautetuksi',
-  sell: 'Merkittiin myytäväksi',
-  donate: 'Merkittiin lahjoitettavaksi',
-};
+/** What the browser asks before the action runs. */
+export function confirmBatchAction(action: BatchAction, count: number): string {
+  return copy[action].asks(discCount(count));
+}
 
 /**
  * What the bar reports once the action has gone through.
@@ -99,7 +117,7 @@ const pastTense: Record<BatchAction, string> = {
  * handled when ten were.
  */
 export function batchActionOutcome(action: BatchAction, affected: number, requested: number): string {
-  const done = `${pastTense[action]} ${discCount(affected)}.`;
+  const done = `${copy[action].did} ${discCount(affected)}.`;
 
   if (affected < requested) {
     return `${done} ${discCount(requested - affected)} jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.`;

--- a/app/features/discs/batch/batchAction.ts
+++ b/app/features/discs/batch/batchAction.ts
@@ -1,10 +1,18 @@
+import { DisposalMethod, type DisposalMethodValue } from '~/features/discs/disposal/disposalMethod';
+
 /**
  * The actions that can be applied to a whole selection of discs at once.
+ *
+ * Releasing a disc is two of them rather than one with a method beside it.
+ * Sale and donation are the whole point of that mark — a disc released without
+ * saying which is a row nobody can act on — and asking in a second step for
+ * something the admin has already decided is a step to click past. The single
+ * disc form still asks, because there the method can be left unanswered.
  *
  * Messaging is not one of them: it is a walk through the selection one owner at
  * a time (see the send-batch page), not a single write.
  */
-export const batchActions = ['delete', 'return', 'disposal'] as const;
+export const batchActions = ['delete', 'return', 'sell', 'donate'] as const;
 
 export type BatchAction = (typeof batchActions)[number];
 
@@ -29,8 +37,21 @@ export const MAX_BATCH_ACTION_SIZE = 500;
 export const batchActionLabels: Record<BatchAction, string> = {
   delete: 'Poista',
   return: 'Merkitse palautetuiksi',
-  disposal: 'Merkitse myytäviksi tai lahjoitettaviksi',
+  sell: 'Merkitse myytäviksi',
+  donate: 'Merkitse lahjoitettaviksi',
 };
+
+/**
+ * Which fate a release records, read off the action itself.
+ *
+ * The two are a smallint in the database and nothing in the UI shows the
+ * number, so an inverted mapping here would write "donate" on every disc the
+ * club means to sell without anything looking wrong. Pinned by a test against
+ * the label.
+ */
+export function disposalMethodFor(action: 'sell' | 'donate'): DisposalMethodValue {
+  return action === 'sell' ? DisposalMethod.Sold : DisposalMethod.Donated;
+}
 
 /** A count of discs, with the noun in the case Finnish puts it in. */
 function discCount(count: number): string {
@@ -53,8 +74,11 @@ export function confirmBatchAction(action: BatchAction, count: number): string {
     case 'return': {
       return `Merkitäänkö ${discCount(count)} palautetuksi?`;
     }
-    case 'disposal': {
-      return `Merkitäänkö ${discCount(count)} myytäväksi tai lahjoitettavaksi?`;
+    case 'sell': {
+      return `Merkitäänkö ${discCount(count)} myytäväksi?`;
+    }
+    case 'donate': {
+      return `Merkitäänkö ${discCount(count)} lahjoitettavaksi?`;
     }
   }
 }
@@ -63,7 +87,8 @@ export function confirmBatchAction(action: BatchAction, count: number): string {
 const pastTense: Record<BatchAction, string> = {
   delete: 'Poistettiin',
   return: 'Merkittiin palautetuksi',
-  disposal: 'Merkittiin myytäväksi tai lahjoitettavaksi',
+  sell: 'Merkittiin myytäväksi',
+  donate: 'Merkittiin lahjoitettavaksi',
 };
 
 /**

--- a/app/features/discs/batch/batchAction.ts
+++ b/app/features/discs/batch/batchAction.ts
@@ -42,19 +42,22 @@ export function markFor(action: BatchAction): BatchMark | null {
 }
 
 /**
- * The most discs that may be ticked at once.
+ * The most discs one of these actions may write to at once.
  *
- * Small on purpose. These actions are irreversible from the UI — a delete
- * especially — and the number stands between a mis-click and real damage: it is
- * how much a wrong action can cost. Twenty is more than a normal batch and
- * still a set the admin can read down and check before confirming.
+ * Small on purpose. They are irreversible from the UI — a delete especially —
+ * and the number is what a mis-click can cost: twenty is more than a normal
+ * batch and still a set the admin can read down before confirming.
  *
- * Enforced twice. The list stops the twenty-first tick, so the limit is
- * something the admin meets while choosing rather than a refusal after
- * confirming; the route refuses a longer body regardless, since the list is not
- * the only thing that can post one.
+ * The cap is on the action, not on the selection. Ticking discs harms nothing,
+ * and the other thing a selection is for — walking through the owners to text
+ * them — writes nothing either, so there is no reason for it to inherit a limit
+ * that exists to bound a delete.
+ *
+ * Enforced twice: the dropdown withholds these actions from a larger selection
+ * and says why, and the route refuses a longer body regardless, since the list
+ * is not the only thing that can post one.
  */
-export const MAX_SELECTED_DISCS = 20;
+export const MAX_DISCS_PER_WRITE = 20;
 
 /** A count of discs, with the noun in the case Finnish puts it in. */
 function discCount(count: number): string {

--- a/app/features/discs/batch/batchAction.ts
+++ b/app/features/discs/batch/batchAction.ts
@@ -23,8 +23,23 @@ export function isBatchAction(value: unknown): value is BatchAction {
   return typeof value === 'string' && (batchActions as readonly string[]).includes(value);
 }
 
-/** The marks: everything but a delete records a date and a method. */
-export type MarkAction = Exclude<BatchAction, 'delete'>;
+/**
+ * What an action writes beyond the date: which pair of columns, and the method
+ * that goes in them. Null for a delete, which records nothing.
+ *
+ * The method is a smallint in the database and nothing in the UI shows the
+ * number, so a mapping that had sale and donation the wrong way round — or
+ * posted and collected — would be invisible. It is declared once, in the table
+ * below beside the action's own wording, and pinned by tests against the
+ * labels.
+ */
+export type BatchMark =
+  | { columns: 'return'; method: ReturnMethodValue }
+  | { columns: 'disposal'; method: DisposalMethodValue };
+
+export function markFor(action: BatchAction): BatchMark | null {
+  return copy[action].mark;
+}
 
 /**
  * The most discs that may be ticked at once.
@@ -41,34 +56,21 @@ export type MarkAction = Exclude<BatchAction, 'delete'>;
  */
 export const MAX_SELECTED_DISCS = 20;
 
-/**
- * Which fate a release records, and how a return got there, read off the action
- * itself.
- *
- * Both are a smallint in the database and nothing in the UI shows the number,
- * so an inverted mapping would write "donate" on every disc the club means to
- * sell, or "posted" on every one handed over in person, without anything
- * looking wrong. Pinned by tests against the labels.
- */
-export function disposalMethodFor(action: 'sell' | 'donate'): DisposalMethodValue {
-  return action === 'sell' ? DisposalMethod.Sold : DisposalMethod.Donated;
-}
-
-export function returnMethodFor(action: 'returnByMail' | 'returnPickedUp'): ReturnMethodValue {
-  return action === 'returnByMail' ? ReturnMethod.ByMail : ReturnMethod.PickedUp;
-}
-
 /** A count of discs, with the noun in the case Finnish puts it in. */
 function discCount(count: number): string {
   return count === 1 ? '1 kiekko' : `${count} kiekkoa`;
 }
 
 /**
- * What each action is called where it is offered, what it asks before it runs,
- * and what it calls what it did afterwards.
+ * Everything that varies per action: what it is called where it is offered,
+ * what it asks before it runs, what it calls what it did afterwards, and what
+ * it writes.
  *
- * The three kept together per action rather than in a table each: they are the
- * same sentence in three tenses, and apart they drifted.
+ * One row per action rather than a table per field. The three wordings are the
+ * same sentence in three tenses and had already drifted apart when they were
+ * separate; the mark belongs with them because an action's name and what it
+ * writes are the same decision, and a reader checking that "myytäviksi" really
+ * records a sale should not have to hold two files open.
  *
  * The labels say nothing about a selection — the dropdown they sit in is beside
  * the count of ticked discs, which is what says what they act on. What the
@@ -76,31 +78,39 @@ function discCount(count: number): string {
  * behind the dialog, and naming a dozen of them would be read as noise and
  * clicked past.
  */
-const copy: Record<BatchAction, { label: string; asks: (discs: string) => string; did: string }> = {
+const copy: Record<
+  BatchAction,
+  { label: string; asks: (discs: string) => string; did: string; mark: BatchMark | null }
+> = {
   returnByMail: {
     label: 'Merkitse palautetuiksi (postitettu)',
     asks: (discs) => `Merkitäänkö ${discs} palautetuksi (postitettu)?`,
     did: 'Merkittiin palautetuksi (postitettu)',
+    mark: { columns: 'return', method: ReturnMethod.ByMail },
   },
   returnPickedUp: {
     label: 'Merkitse palautetuiksi (noudettu)',
     asks: (discs) => `Merkitäänkö ${discs} palautetuksi (noudettu)?`,
     did: 'Merkittiin palautetuksi (noudettu)',
+    mark: { columns: 'return', method: ReturnMethod.PickedUp },
   },
   sell: {
     label: 'Merkitse myytäviksi',
     asks: (discs) => `Merkitäänkö ${discs} myytäväksi?`,
     did: 'Merkittiin myytäväksi',
+    mark: { columns: 'disposal', method: DisposalMethod.Sold },
   },
   donate: {
     label: 'Merkitse lahjoitettaviksi',
     asks: (discs) => `Merkitäänkö ${discs} lahjoitettavaksi?`,
     did: 'Merkittiin lahjoitettavaksi',
+    mark: { columns: 'disposal', method: DisposalMethod.Donated },
   },
   delete: {
     label: 'Poista',
     asks: (discs) => `Poistetaanko ${discs}? Poistoa ei voi peruuttaa.`,
     did: 'Poistettiin',
+    mark: null,
   },
 };
 

--- a/app/features/discs/batch/batchAction.ts
+++ b/app/features/discs/batch/batchAction.ts
@@ -1,0 +1,79 @@
+/**
+ * The actions that can be applied to a whole selection of discs at once.
+ *
+ * Messaging is not one of them: it is a walk through the selection one owner at
+ * a time (see the send-batch page), not a single write.
+ */
+export const batchActions = ['delete', 'return', 'disposal'] as const;
+
+export type BatchAction = (typeof batchActions)[number];
+
+export function isBatchAction(value: unknown): value is BatchAction {
+  return typeof value === 'string' && (batchActions as readonly string[]).includes(value);
+}
+
+/**
+ * How many discs one batch may carry.
+ *
+ * Generous enough that a whole club's list fits, so the cap is a bound on the
+ * query rather than something the admin runs into.
+ */
+export const MAX_BATCH_ACTION_SIZE = 500;
+
+/** The button that starts each action. */
+export const batchActionLabels: Record<BatchAction, string> = {
+  delete: 'Poista valitut',
+  return: 'Merkitse valitut palautetuiksi',
+  disposal: 'Merkitse valitut myytäviksi tai lahjoitettaviksi',
+};
+
+/** A count of discs, with the noun in the case Finnish puts it in. */
+function discCount(count: number): string {
+  return count === 1 ? '1 kiekko' : `${count} kiekkoa`;
+}
+
+/**
+ * What the browser asks before the action runs: what is about to happen, and to
+ * how many discs.
+ *
+ * Which discs is deliberately left out — the selection is on screen right
+ * behind the dialog, and naming a dozen of them here would only be read as
+ * noise and clicked past.
+ */
+export function confirmBatchAction(action: BatchAction, count: number): string {
+  switch (action) {
+    case 'delete': {
+      return `Poistetaanko ${discCount(count)}? Poistoa ei voi peruuttaa.`;
+    }
+    case 'return': {
+      return `Merkitäänkö ${discCount(count)} palautetuksi?`;
+    }
+    case 'disposal': {
+      return `Merkitäänkö ${discCount(count)} myytäväksi tai lahjoitettavaksi?`;
+    }
+  }
+}
+
+/** What each action calls what it did, for the report afterwards. */
+const pastTense: Record<BatchAction, string> = {
+  delete: 'Poistettiin',
+  return: 'Merkittiin palautetuksi',
+  disposal: 'Merkittiin myytäväksi tai lahjoitettavaksi',
+};
+
+/**
+ * What the bar reports once the action has gone through.
+ *
+ * A shortfall is reported rather than passed over: an id that no longer
+ * resolves is not an error, but the admin should not be told a dozen discs were
+ * handled when ten were.
+ */
+export function batchActionOutcome(action: BatchAction, affected: number, requested: number): string {
+  const done = `${pastTense[action]} ${discCount(affected)}.`;
+
+  if (affected < requested) {
+    return `${done} ${discCount(requested - affected)} jäi käsittelemättä – kiekkoja ei löytynyt tai niitä ei voitu muuttaa.`;
+  }
+
+  return done;
+}

--- a/app/features/discs/batch/batchAction.ts
+++ b/app/features/discs/batch/batchAction.ts
@@ -27,12 +27,19 @@ export function isBatchAction(value: unknown): value is BatchAction {
 export type MarkAction = Exclude<BatchAction, 'delete'>;
 
 /**
- * How many discs one batch may carry.
+ * The most discs that may be ticked at once.
  *
- * Generous enough that a whole club's list fits, so the cap is a bound on the
- * query rather than something the admin runs into.
+ * Small on purpose. These actions are irreversible from the UI — a delete
+ * especially — and the number stands between a mis-click and real damage: it is
+ * how much a wrong action can cost. Twenty is more than a normal batch and
+ * still a set the admin can read down and check before confirming.
+ *
+ * Enforced twice. The list stops the twenty-first tick, so the limit is
+ * something the admin meets while choosing rather than a refusal after
+ * confirming; the route refuses a longer body regardless, since the list is not
+ * the only thing that can post one.
  */
-export const MAX_BATCH_ACTION_SIZE = 500;
+export const MAX_SELECTED_DISCS = 20;
 
 /**
  * Which fate a release records, and how a return got there, read off the action

--- a/app/features/discs/batch/handleBatchRequest.server.ts
+++ b/app/features/discs/batch/handleBatchRequest.server.ts
@@ -2,7 +2,7 @@ import { requireAdminJson } from '~/lib/api/resourceRoute.server';
 import { isExternalId, isIsoDate } from '~/lib/api/validate';
 import { deleteDiscs, markDiscsAsReturned, markDiscsForDisposal } from '~/models/discs.server';
 
-import { isBatchAction, MAX_BATCH_ACTION_SIZE, type BatchAction } from './batchAction';
+import { disposalMethodFor, isBatchAction, MAX_BATCH_ACTION_SIZE, type BatchAction } from './batchAction';
 
 /** The ids a batch may act on, or the reason this selection is not one. */
 type Selection = { externalIds: string[] } | { error: string };
@@ -28,12 +28,14 @@ function readSelection(value: unknown): Selection {
 }
 
 /**
- * The two actions that record a date: returned to its owner, and free to be
- * sold or donated.
+ * The three actions that record a date: returned to its owner, up for sale, and
+ * up for donation.
  *
- * Both are dated but carry no method: over a selection there is no one method
- * that would be true of every disc in it, so the method is left unanswered —
- * which is what the column holds for any disc marked without one.
+ * A release carries its method, because which of the two it is comes from the
+ * action itself. A return does not: how a disc got back to its owner is a
+ * per-disc detail, and over a selection there is no one answer to it, so it is
+ * left unanswered — which is what the column holds for any disc marked without
+ * one.
  */
 function applyMark(
   action: Exclude<BatchAction, 'delete'>,
@@ -45,7 +47,14 @@ function applyMark(
     return markDiscsAsReturned(externalIds, { returnedToOwnerDate: date, returnMethod: null }, request);
   }
 
-  return markDiscsForDisposal(externalIds, { canBeSoldOrDonatedDate: date, canBeSoldOrDonatedMethod: null }, request);
+  return markDiscsForDisposal(
+    externalIds,
+    {
+      canBeSoldOrDonatedDate: date,
+      canBeSoldOrDonatedMethod: disposalMethodFor(action),
+    },
+    request,
+  );
 }
 
 /** Answers with how many discs the action reached, or with why it could not. */

--- a/app/features/discs/batch/handleBatchRequest.server.ts
+++ b/app/features/discs/batch/handleBatchRequest.server.ts
@@ -5,7 +5,7 @@ import { deleteDiscs, markDiscsAsReturned, markDiscsForDisposal } from '~/models
 import {
   disposalMethodFor,
   isBatchAction,
-  MAX_BATCH_ACTION_SIZE,
+  MAX_SELECTED_DISCS,
   returnMethodFor,
   type MarkAction,
 } from './batchAction';
@@ -26,8 +26,8 @@ function readSelection(value: unknown): Selection {
 
   const externalIds = [...new Set(value)];
 
-  if (externalIds.length > MAX_BATCH_ACTION_SIZE) {
-    return { error: `Yhdellä kertaa voi käsitellä enintään ${MAX_BATCH_ACTION_SIZE} kiekkoa.` };
+  if (externalIds.length > MAX_SELECTED_DISCS) {
+    return { error: `Yhdellä kertaa voi käsitellä enintään ${MAX_SELECTED_DISCS} kiekkoa.` };
   }
 
   return { externalIds };

--- a/app/features/discs/batch/handleBatchRequest.server.ts
+++ b/app/features/discs/batch/handleBatchRequest.server.ts
@@ -1,0 +1,92 @@
+import { requireAdminJson } from '~/lib/api/resourceRoute.server';
+import { isExternalId, isIsoDate } from '~/lib/api/validate';
+import { deleteDiscs, markDiscsAsReturned, markDiscsForDisposal } from '~/models/discs.server';
+
+import { isBatchAction, MAX_BATCH_ACTION_SIZE, type BatchAction } from './batchAction';
+
+/** The ids a batch may act on, or the reason this selection is not one. */
+type Selection = { externalIds: string[] } | { error: string };
+
+/**
+ * Reads the selection out of the request body.
+ *
+ * Deduplicated so the count reported back stands for discs, not for the number
+ * of times an id was sent.
+ */
+function readSelection(value: unknown): Selection {
+  if (!Array.isArray(value) || value.length === 0 || !value.every(isExternalId)) {
+    return { error: 'Virheellinen kiekkojen tunnistelista.' };
+  }
+
+  const externalIds = [...new Set(value)];
+
+  if (externalIds.length > MAX_BATCH_ACTION_SIZE) {
+    return { error: `Yhdellä kertaa voi käsitellä enintään ${MAX_BATCH_ACTION_SIZE} kiekkoa.` };
+  }
+
+  return { externalIds };
+}
+
+/**
+ * The two actions that record a date: returned to its owner, and free to be
+ * sold or donated.
+ *
+ * Both are dated but carry no method: over a selection there is no one method
+ * that would be true of every disc in it, so the method is left unanswered —
+ * which is what the column holds for any disc marked without one.
+ */
+function applyMark(
+  action: Exclude<BatchAction, 'delete'>,
+  externalIds: string[],
+  date: string,
+  request: Request,
+): Promise<number> {
+  if (action === 'return') {
+    return markDiscsAsReturned(externalIds, { returnedToOwnerDate: date, returnMethod: null }, request);
+  }
+
+  return markDiscsForDisposal(externalIds, { canBeSoldOrDonatedDate: date, canBeSoldOrDonatedMethod: null }, request);
+}
+
+/** Answers with how many discs the action reached, or with why it could not. */
+async function report(apply: () => Promise<number>): Promise<Response> {
+  try {
+    return Response.json({ affected: await apply() });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Toimenpide epäonnistui.';
+
+    return Response.json({ error: message }, { status: 500 });
+  }
+}
+
+/** Authorises, validates and applies an action posted to /discs/batch. */
+export async function handleBatchRequest(request: Request): Promise<Response> {
+  const gate = await requireAdminJson(request);
+
+  if ('response' in gate) {
+    return gate.response;
+  }
+
+  const { action, externalIds, date } = (gate.body ?? {}) as Record<string, unknown>;
+
+  if (!isBatchAction(action)) {
+    return Response.json({ error: 'Tuntematon toimenpide.' }, { status: 422 });
+  }
+
+  const selection = readSelection(externalIds);
+
+  if ('error' in selection) {
+    return Response.json({ error: selection.error }, { status: 422 });
+  }
+
+  // A delete records nothing, so it is the one action that needs no date.
+  if (action === 'delete') {
+    return report(() => deleteDiscs(selection.externalIds, request));
+  }
+
+  if (!isIsoDate(date)) {
+    return Response.json({ error: 'Virheellinen päivämäärä.' }, { status: 422 });
+  }
+
+  return report(() => applyMark(action, selection.externalIds, date, request));
+}

--- a/app/features/discs/batch/handleBatchRequest.server.ts
+++ b/app/features/discs/batch/handleBatchRequest.server.ts
@@ -2,13 +2,7 @@ import { requireAdminJson } from '~/lib/api/resourceRoute.server';
 import { isExternalId, isIsoDate } from '~/lib/api/validate';
 import { deleteDiscs, markDiscsAsReturned, markDiscsForDisposal } from '~/models/discs.server';
 
-import {
-  disposalMethodFor,
-  isBatchAction,
-  MAX_SELECTED_DISCS,
-  returnMethodFor,
-  type MarkAction,
-} from './batchAction';
+import { isBatchAction, markFor, MAX_SELECTED_DISCS, type BatchMark } from './batchAction';
 
 /** The ids a batch may act on, or the reason this selection is not one. */
 type Selection = { externalIds: string[] } | { error: string };
@@ -33,28 +27,33 @@ function readSelection(value: unknown): Selection {
   return { externalIds };
 }
 
+type MarkInput = {
+  mark: BatchMark;
+  externalIds: string[];
+  /** ISO date, y-MM-dd. */
+  date: string;
+};
+
 /**
- * The four actions that record a date, each carrying the method its own name
- * gives: returned by post or in person, up for sale or up for donation.
+ * Applies a mark to the selection: which columns and which method both come
+ * from the action's own row in the batch action table.
  */
-function applyMark(action: MarkAction, externalIds: string[], date: string, request: Request): Promise<number> {
-  if (action === 'returnByMail' || action === 'returnPickedUp') {
-    return markDiscsAsReturned(
+function applyMark(request: Request, { mark, externalIds, date }: MarkInput): Promise<number> {
+  if (mark.columns === 'return') {
+    return markDiscsAsReturned(request, {
       externalIds,
-      { returnedToOwnerDate: date, returnMethod: returnMethodFor(action) },
-      request,
-    );
+      details: { returnedToOwnerDate: date, returnMethod: mark.method },
+    });
   }
 
-  return markDiscsForDisposal(
+  return markDiscsForDisposal(request, {
     externalIds,
-    { canBeSoldOrDonatedDate: date, canBeSoldOrDonatedMethod: disposalMethodFor(action) },
-    request,
-  );
+    details: { canBeSoldOrDonatedDate: date, canBeSoldOrDonatedMethod: mark.method },
+  });
 }
 
 /** Answers with how many discs the action reached, or with why it could not. */
-async function report(apply: () => Promise<number>): Promise<Response> {
+async function respondWithCount(apply: () => Promise<number>): Promise<Response> {
   try {
     return Response.json({ affected: await apply() });
   } catch (error) {
@@ -84,14 +83,17 @@ export async function handleBatchRequest(request: Request): Promise<Response> {
     return Response.json({ error: selection.error }, { status: 422 });
   }
 
-  // A delete records nothing, so it is the one action that needs no date.
-  if (action === 'delete') {
-    return report(() => deleteDiscs(selection.externalIds, request));
+  const mark = markFor(action);
+
+  // No mark to write is a delete, and a delete records nothing — so it is the
+  // one action that needs no date.
+  if (mark === null) {
+    return respondWithCount(() => deleteDiscs(request, selection.externalIds));
   }
 
   if (!isIsoDate(date)) {
     return Response.json({ error: 'Virheellinen päivämäärä.' }, { status: 422 });
   }
 
-  return report(() => applyMark(action, selection.externalIds, date, request));
+  return respondWithCount(() => applyMark(request, { mark, externalIds: selection.externalIds, date }));
 }

--- a/app/features/discs/batch/handleBatchRequest.server.ts
+++ b/app/features/discs/batch/handleBatchRequest.server.ts
@@ -2,7 +2,7 @@ import { requireAdminJson } from '~/lib/api/resourceRoute.server';
 import { isExternalId, isIsoDate } from '~/lib/api/validate';
 import { deleteDiscs, markDiscsAsReturned, markDiscsForDisposal } from '~/models/discs.server';
 
-import { isBatchAction, markFor, MAX_SELECTED_DISCS, type BatchMark } from './batchAction';
+import { isBatchAction, markFor, MAX_DISCS_PER_WRITE, type BatchMark } from './batchAction';
 
 /** The ids a batch may act on, or the reason this selection is not one. */
 type Selection = { externalIds: string[] } | { error: string };
@@ -20,8 +20,8 @@ function readSelection(value: unknown): Selection {
 
   const externalIds = [...new Set(value)];
 
-  if (externalIds.length > MAX_SELECTED_DISCS) {
-    return { error: `Yhdellä kertaa voi käsitellä enintään ${MAX_SELECTED_DISCS} kiekkoa.` };
+  if (externalIds.length > MAX_DISCS_PER_WRITE) {
+    return { error: `Yhdellä kertaa voi käsitellä enintään ${MAX_DISCS_PER_WRITE} kiekkoa.` };
   }
 
   return { externalIds };

--- a/app/features/discs/batch/handleBatchRequest.server.ts
+++ b/app/features/discs/batch/handleBatchRequest.server.ts
@@ -2,7 +2,13 @@ import { requireAdminJson } from '~/lib/api/resourceRoute.server';
 import { isExternalId, isIsoDate } from '~/lib/api/validate';
 import { deleteDiscs, markDiscsAsReturned, markDiscsForDisposal } from '~/models/discs.server';
 
-import { disposalMethodFor, isBatchAction, MAX_BATCH_ACTION_SIZE, type BatchAction } from './batchAction';
+import {
+  disposalMethodFor,
+  isBatchAction,
+  MAX_BATCH_ACTION_SIZE,
+  returnMethodFor,
+  type MarkAction,
+} from './batchAction';
 
 /** The ids a batch may act on, or the reason this selection is not one. */
 type Selection = { externalIds: string[] } | { error: string };
@@ -28,31 +34,21 @@ function readSelection(value: unknown): Selection {
 }
 
 /**
- * The three actions that record a date: returned to its owner, up for sale, and
- * up for donation.
- *
- * A release carries its method, because which of the two it is comes from the
- * action itself. A return does not: how a disc got back to its owner is a
- * per-disc detail, and over a selection there is no one answer to it, so it is
- * left unanswered — which is what the column holds for any disc marked without
- * one.
+ * The four actions that record a date, each carrying the method its own name
+ * gives: returned by post or in person, up for sale or up for donation.
  */
-function applyMark(
-  action: Exclude<BatchAction, 'delete'>,
-  externalIds: string[],
-  date: string,
-  request: Request,
-): Promise<number> {
-  if (action === 'return') {
-    return markDiscsAsReturned(externalIds, { returnedToOwnerDate: date, returnMethod: null }, request);
+function applyMark(action: MarkAction, externalIds: string[], date: string, request: Request): Promise<number> {
+  if (action === 'returnByMail' || action === 'returnPickedUp') {
+    return markDiscsAsReturned(
+      externalIds,
+      { returnedToOwnerDate: date, returnMethod: returnMethodFor(action) },
+      request,
+    );
   }
 
   return markDiscsForDisposal(
     externalIds,
-    {
-      canBeSoldOrDonatedDate: date,
-      canBeSoldOrDonatedMethod: disposalMethodFor(action),
-    },
+    { canBeSoldOrDonatedDate: date, canBeSoldOrDonatedMethod: disposalMethodFor(action) },
     request,
   );
 }

--- a/app/features/discs/batch/runBatchAction.ts
+++ b/app/features/discs/batch/runBatchAction.ts
@@ -1,0 +1,41 @@
+import { format } from 'date-fns';
+
+import { postJson } from '~/lib/api/postJson';
+
+import type { BatchAction } from './batchAction';
+
+/** The resource route that applies the action. */
+const BATCH_URL = '/discs/batch';
+
+const GENERIC_ERROR = 'Toimenpide epäonnistui. Yritä uudelleen.';
+
+/** How many discs the action reached, or why it did not run. */
+export type BatchActionResult = { status: 'success'; affected: number } | { status: 'error'; message: string };
+
+/**
+ * Applies one action to a selection of discs.
+ *
+ * Never throws: a transport failure comes back as an error result, so the
+ * caller has one thing to handle rather than two.
+ *
+ * The date the marks record is today's, taken from the browser rather than the
+ * server: the server runs in UTC, which is the wrong day for a Finnish evening.
+ * The single-disc forms date a mark the same way.
+ */
+export async function runBatchAction(action: BatchAction, externalIds: string[]): Promise<BatchActionResult> {
+  const result = await postJson(BATCH_URL, { action, externalIds, date: format(new Date(), 'y-MM-dd') }, GENERIC_ERROR);
+
+  if (result.status === 'error') {
+    return result;
+  }
+
+  const affected = (result.body as { affected?: unknown })?.affected;
+
+  // The route reports a count on every path it answers 200 on, so a body
+  // without one never came from it.
+  if (typeof affected !== 'number') {
+    return { status: 'error', message: GENERIC_ERROR };
+  }
+
+  return { status: 'success', affected };
+}

--- a/app/features/discs/batch/useBatchAction.ts
+++ b/app/features/discs/batch/useBatchAction.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+
+import { batchActionOutcome, confirmBatchAction, type BatchAction } from './batchAction';
+import { runBatchAction } from './runBatchAction';
+
+/**
+ * What the caller has to say about the last thing it tried, and which of the
+ * two moments it belongs to.
+ *
+ * A report of what was done belongs to a finished action, with the selection
+ * emptied behind it; an error belongs to a selection that is still there to try
+ * again. Callers render them in different places for that reason.
+ */
+export type BatchNotice = { kind: 'done' | 'error'; text: string };
+
+type Options = {
+  /** Called once a write has gone through, to clear the ticks and reload. */
+  onDone: () => void;
+};
+
+/**
+ * Running one batch action: the confirmation, the request, and what to say
+ * afterwards.
+ *
+ * Kept out of the selection bar, which otherwise owned four unrelated things
+ * at once — this state machine, the navigation to the message walk, the
+ * dropdown, and the cap messaging.
+ */
+export function useBatchAction({ onDone }: Options) {
+  const [isBusy, setIsBusy] = useState(false);
+  const [notice, setNotice] = useState<BatchNotice | null>(null);
+
+  /**
+   * Confirms, runs, and reports. Resolves to true only when the write went
+   * through, so the caller can reset itself on that and leave it alone
+   * otherwise.
+   */
+  const run = async (action: BatchAction, externalIds: string[]): Promise<boolean> => {
+    if (!window.confirm(confirmBatchAction(action, externalIds.length))) {
+      return false;
+    }
+
+    setIsBusy(true);
+    setNotice(null);
+
+    const result = await runBatchAction(action, externalIds);
+
+    setIsBusy(false);
+
+    if (result.status === 'error') {
+      setNotice({ kind: 'error', text: result.message });
+
+      return false;
+    }
+
+    setNotice({ kind: 'done', text: batchActionOutcome(action, result.affected, externalIds.length) });
+    onDone();
+
+    return true;
+  };
+
+  /** For something the caller itself refused, before any request was made. */
+  const fail = (text: string): void => setNotice({ kind: 'error', text });
+
+  return { isBusy, notice, run, fail };
+}

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -24,6 +24,7 @@ import { markAsReturned } from '~/features/discs/return/markAsReturned';
 import { returnMethodOptions } from '~/features/discs/return/returnMethod';
 import CourseForm from '~/features/discs/list/CourseForm';
 import DateAndMethodForm from '~/features/discs/list/DateAndMethodForm';
+import { MAX_SELECTED_DISCS } from '~/features/discs/batch/batchAction';
 import SelectedDiscsActions, { type SelectedDisc } from '~/features/discs/list/SelectedDiscsActions';
 import {
   ArrowDownwardIcon,
@@ -170,6 +171,17 @@ const styles = stylex.create({
     touchAction: 'none',
   },
 });
+
+/**
+ * Why a row's box will not take a tick, when it will not.
+ *
+ * Only the cap is explained: a row with no external id is unselectable for a
+ * different reason, and a signed-in admin is sent an id for every disc, so that
+ * case is not one anybody sees.
+ */
+function selectionTitle(canSelect: boolean, hasExternalId: boolean): string | undefined {
+  return !canSelect && hasExternalId ? `Kerralla voi valita enintään ${MAX_SELECTED_DISCS} kiekkoa` : undefined;
+}
 
 /** Columns sized by their content rather than by a resizable width. */
 function isTightColumn(columnId: string): boolean {
@@ -354,6 +366,10 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
   // Keyed on external id (see getRowId), so a tick survives re-sorting.
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
+  // Read off the selection state rather than asked of the table: the cap is
+  // part of the table's own configuration, which cannot query itself.
+  const selectedCount = Object.values(rowSelection).filter(Boolean).length;
+
   /** Opens the given panel on the given disc, or closes it if already open. */
   const toggleForm = (externalId: string, kind: PanelKind): void =>
     setOpenForm((current) =>
@@ -372,31 +388,35 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
               id: 'select',
               enableSorting: false,
               enableResizing: false,
+              // Clears the selection, and does nothing else. There is
+              // deliberately no way to tick every disc: the actions behind a
+              // selection cannot be undone, and one click that arms all of
+              // them is the mis-click worth designing out. Emptying a
+              // selection is safe, so that half stays.
               header: ({ table }) => {
-                // Counted over the rows on screen rather than asked of the
-                // table, so the box agrees with the filtered list the admin is
-                // looking at.
-                const selectable = table.getRowModel().rows.filter((row) => row.getCanSelect());
-                const selected = selectable.filter((row) => row.getIsSelected());
-                const allSelected = selectable.length > 0 && selected.length === selectable.length;
+                const selected = table.getRowModel().rows.filter((row) => row.getIsSelected()).length;
+
+                if (selected === 0) {
+                  return null;
+                }
 
                 return (
                   <Checkbox
-                    aria-label={allSelected ? 'Poista kaikkien kiekkojen valinta' : 'Valitse kaikki kiekot'}
-                    checked={allSelected}
-                    indeterminate={selected.length > 0 && !allSelected}
-                    disabled={selectable.length === 0}
-                    onChange={() => table.toggleAllRowsSelected(!allSelected)}
+                    aria-label="Poista kaikkien kiekkojen valinta"
+                    checked
+                    onChange={() => table.resetRowSelection()}
                   />
                 );
               },
               cell: ({ row }) => (
-                <Checkbox
-                  aria-label={`Valitse kiekko ${row.original.discName}`}
-                  checked={row.getIsSelected()}
-                  disabled={!row.getCanSelect()}
-                  onChange={row.getToggleSelectedHandler()}
-                />
+                <span title={selectionTitle(row.getCanSelect(), !!row.original.externalId)}>
+                  <Checkbox
+                    aria-label={`Valitse kiekko ${row.original.discName}`}
+                    checked={row.getIsSelected()}
+                    disabled={!row.getCanSelect()}
+                    onChange={row.getToggleSelectedHandler()}
+                  />
+                </span>
               ),
             } satisfies ColumnDef<Row>,
           ]
@@ -547,7 +567,12 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
     // An id to address the disc by is all a selection needs. A missing number
     // only rules out the message batch, which leaves those discs out itself —
     // marking a disc returned or deleting it has no use for one.
-    enableRowSelection: (row) => !!row.original.externalId,
+    //
+    // Past the cap only the discs already ticked stay selectable, so unticking
+    // still works and the limit is met while choosing rather than after
+    // confirming.
+    enableRowSelection: (row) =>
+      !!row.original.externalId && (row.getIsSelected() || selectedCount < MAX_SELECTED_DISCS),
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     columnResizeMode: 'onChange',

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -24,7 +24,6 @@ import { markAsReturned } from '~/features/discs/return/markAsReturned';
 import { returnMethodOptions } from '~/features/discs/return/returnMethod';
 import CourseForm from '~/features/discs/list/CourseForm';
 import DateAndMethodForm from '~/features/discs/list/DateAndMethodForm';
-import { MAX_SELECTED_DISCS } from '~/features/discs/batch/batchAction';
 import SelectedDiscsActions, { type SelectedDisc } from '~/features/discs/list/SelectedDiscsActions';
 import {
   ArrowDownwardIcon,
@@ -171,17 +170,6 @@ const styles = stylex.create({
     touchAction: 'none',
   },
 });
-
-/**
- * Why a row's box will not take a tick, when it will not.
- *
- * Only the cap is explained: a row with no external id is unselectable for a
- * different reason, and a signed-in admin is sent an id for every disc, so that
- * case is not one anybody sees.
- */
-function selectionTitle(canSelect: boolean, hasExternalId: boolean): string | undefined {
-  return !canSelect && hasExternalId ? `Kerralla voi valita enintään ${MAX_SELECTED_DISCS} kiekkoa` : undefined;
-}
 
 /** Columns sized by their content rather than by a resizable width. */
 function isTightColumn(columnId: string): boolean {
@@ -368,21 +356,6 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
 
   const rows = useMemo(() => mapToDataRows(discs), [discs]);
 
-  /**
-   * How many of the discs on screen are ticked.
-   *
-   * Counted over the discs this table was given, not over every key in the
-   * selection state: the list arrives already filtered, and a tick survives a
-   * filter that hides its disc. Counting the hidden ones would let the cap
-   * block a tick while the bar showed room for it, and the bar, the
-   * confirmation and the request all count what is on screen — one number for
-   * all four, or they contradict each other.
-   *
-   * Read off the selection state rather than asked of the table because the cap
-   * is part of the table's own configuration, which cannot query itself.
-   */
-  const selectedCount = rows.filter((row) => row.externalId != null && rowSelection[row.externalId]).length;
-
   /** Opens the given panel on the given disc, or closes it if already open. */
   const toggleForm = (externalId: string, kind: PanelKind): void =>
     setOpenForm((current) =>
@@ -420,14 +393,12 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
                 );
               },
               cell: ({ row }) => (
-                <span title={selectionTitle(row.getCanSelect(), !!row.original.externalId)}>
-                  <Checkbox
-                    aria-label={`Valitse kiekko ${row.original.discName}`}
-                    checked={row.getIsSelected()}
-                    disabled={!row.getCanSelect()}
-                    onChange={row.getToggleSelectedHandler()}
-                  />
-                </span>
+                <Checkbox
+                  aria-label={`Valitse kiekko ${row.original.discName}`}
+                  checked={row.getIsSelected()}
+                  disabled={!row.getCanSelect()}
+                  onChange={row.getToggleSelectedHandler()}
+                />
               ),
             } satisfies ColumnDef<Row>,
           ]
@@ -579,11 +550,9 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
     // only rules out the message batch, which leaves those discs out itself —
     // marking a disc returned or deleting it has no use for one.
     //
-    // Past the cap only the discs already ticked stay selectable, so unticking
-    // still works and the limit is met while choosing rather than after
-    // confirming.
-    enableRowSelection: (row) =>
-      !!row.original.externalId && (row.getIsSelected() || selectedCount < MAX_SELECTED_DISCS),
+    // Unlimited on purpose: ticking a disc changes nothing, and the actions
+    // that do are capped where they are chosen.
+    enableRowSelection: (row) => !!row.original.externalId,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     columnResizeMode: 'onChange',

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -366,17 +366,28 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
   // Keyed on external id (see getRowId), so a tick survives re-sorting.
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  // Read off the selection state rather than asked of the table: the cap is
-  // part of the table's own configuration, which cannot query itself.
-  const selectedCount = Object.values(rowSelection).filter(Boolean).length;
+  const rows = useMemo(() => mapToDataRows(discs), [discs]);
+
+  /**
+   * How many of the discs on screen are ticked.
+   *
+   * Counted over the discs this table was given, not over every key in the
+   * selection state: the list arrives already filtered, and a tick survives a
+   * filter that hides its disc. Counting the hidden ones would let the cap
+   * block a tick while the bar showed room for it, and the bar, the
+   * confirmation and the request all count what is on screen — one number for
+   * all four, or they contradict each other.
+   *
+   * Read off the selection state rather than asked of the table because the cap
+   * is part of the table's own configuration, which cannot query itself.
+   */
+  const selectedCount = rows.filter((row) => row.externalId != null && rowSelection[row.externalId]).length;
 
   /** Opens the given panel on the given disc, or closes it if already open. */
   const toggleForm = (externalId: string, kind: PanelKind): void =>
     setOpenForm((current) =>
       current?.externalId === externalId && current.kind === kind ? null : { externalId, kind },
     );
-
-  const rows = useMemo(() => mapToDataRows(discs), [discs]);
 
   const columns = useMemo<ColumnDef<Row>[]>(
     () => [

--- a/app/features/discs/list/DiscTable.tsx
+++ b/app/features/discs/list/DiscTable.tsx
@@ -24,7 +24,7 @@ import { markAsReturned } from '~/features/discs/return/markAsReturned';
 import { returnMethodOptions } from '~/features/discs/return/returnMethod';
 import CourseForm from '~/features/discs/list/CourseForm';
 import DateAndMethodForm from '~/features/discs/list/DateAndMethodForm';
-import SelectedDiscsActions from '~/features/discs/list/SelectedDiscsActions';
+import SelectedDiscsActions, { type SelectedDisc } from '~/features/discs/list/SelectedDiscsActions';
 import {
   ArrowDownwardIcon,
   ArrowUpwardIcon,
@@ -391,16 +391,12 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
                 );
               },
               cell: ({ row }) => (
-                // A disc with no phone number cannot be messaged, so it cannot
-                // be part of a batch; the title says why the box is dead.
-                <span title={row.getCanSelect() ? undefined : 'Kiekolla ei ole puhelinnumeroa'}>
-                  <Checkbox
-                    aria-label={`Valitse kiekko ${row.original.discName}`}
-                    checked={row.getIsSelected()}
-                    disabled={!row.getCanSelect()}
-                    onChange={row.getToggleSelectedHandler()}
-                  />
-                </span>
+                <Checkbox
+                  aria-label={`Valitse kiekko ${row.original.discName}`}
+                  checked={row.getIsSelected()}
+                  disabled={!row.getCanSelect()}
+                  onChange={row.getToggleSelectedHandler()}
+                />
               ),
             } satisfies ColumnDef<Row>,
           ]
@@ -548,27 +544,29 @@ export default function DiscTable({ discs, onChanged, courses = [] }: DiscTableP
     // The external id, so a tick follows its disc through a re-sort rather
     // than sticking to a row position. Rows without one cannot be selected.
     getRowId: (row) => row.externalId ?? `row-${row.id}`,
-    // Messaging is the point of a selection, and that needs a number to send
-    // to and an id to record against.
-    enableRowSelection: (row) => !!row.original.externalId && !!row.original.ownerPhoneNumber,
+    // An id to address the disc by is all a selection needs. A missing number
+    // only rules out the message batch, which leaves those discs out itself —
+    // marking a disc returned or deleting it has no use for one.
+    enableRowSelection: (row) => !!row.original.externalId,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     columnResizeMode: 'onChange',
     enableColumnResizing: true,
   });
 
-  // Taken from the rows on screen, in the order they are shown: the batch then
+  // Taken from the rows on screen, in the order they are shown: a batch then
   // works through the discs the way the admin sees them, and the count in the
   // bar can never stand for discs a filter has since hidden.
-  const selectedExternalIds = table
+  const selectedDiscs: SelectedDisc[] = table
     .getRowModel()
     .rows.filter((row) => row.getIsSelected())
-    .map((row) => row.original.externalId)
-    .filter((externalId): externalId is string => externalId != null);
+    .map((row) => row.original)
+    .filter((disc): disc is Row & { externalId: string } => disc.externalId != null)
+    .map((disc) => ({ externalId: disc.externalId, hasPhoneNumber: !!disc.ownerPhoneNumber }));
 
   return (
     <>
-      <SelectedDiscsActions externalIds={selectedExternalIds} onClear={() => table.resetRowSelection()} />
+      <SelectedDiscsActions selected={selectedDiscs} onClear={() => table.resetRowSelection()} onChanged={onChanged} />
 
       <table {...stylex.props(styles.table)}>
         <thead>

--- a/app/features/discs/list/SelectedDiscsActions.tsx
+++ b/app/features/discs/list/SelectedDiscsActions.tsx
@@ -1,5 +1,12 @@
-import type { JSX } from 'react';
+import { useState, type JSX } from 'react';
 
+import {
+  batchActionLabels,
+  batchActionOutcome,
+  confirmBatchAction,
+  type BatchAction,
+} from '~/features/discs/batch/batchAction';
+import { runBatchAction } from '~/features/discs/batch/runBatchAction';
 import Button from '~/ui/Button';
 
 /**
@@ -13,47 +20,123 @@ import Button from '~/ui/Button';
  */
 const MAX_HREF_LENGTH = 6000;
 
+/** One ticked disc, and whether there is anyone to text about it. */
+export type SelectedDisc = { externalId: string; hasPhoneNumber: boolean };
+
 type Props = {
-  /** The selected discs' external ids, in the order the list shows them. */
-  externalIds: string[];
+  /** The selected discs, in the order the list shows them. */
+  selected: SelectedDisc[];
   onClear: () => void;
+  /** Called after discs have been deleted or marked, to reload the list. */
+  onChanged?: () => void;
 };
+
+/** The three actions, in the order the bar offers them. */
+const actions: BatchAction[] = ['return', 'disposal', 'delete'];
+
+/**
+ * What the bar has to say, and which of the two moments it belongs to.
+ *
+ * A report of what was done belongs to a finished action, and the selection is
+ * empty behind it; ticking the next batch is what makes it stale, so it is only
+ * rendered while nothing is selected. An error belongs to a selection that is
+ * still there to try again, so it is rendered beside the buttons.
+ */
+type Notice = { kind: 'done' | 'error'; text: string };
 
 /**
  * What can be done with the discs ticked in the list.
  *
  * Shown only once something is selected: an empty bar above the table would be
- * clutter for the far more common case of just reading the list.
+ * clutter for the far more common case of just reading the list. It stays for
+ * one more render after an action, with the selection cleared, so its report of
+ * what happened does not vanish with the ticks.
  *
- * The link is written out here, as the row's own message icon writes out
- * /message/send/:externalId. How many discs one batch may carry is the send
+ * The message link is written out here, as the row's own message icon writes
+ * out /message/send/:externalId. How many discs one batch may carry is the send
  * page's rule and it says so itself; the only thing stopped from this side is a
  * link too long to survive the trip.
  */
-export default function SelectedDiscsActions({ externalIds, onClear }: Props): JSX.Element | null {
-  if (externalIds.length === 0) {
-    return null;
+export default function SelectedDiscsActions({ selected, onClear, onChanged }: Props): JSX.Element | null {
+  const [busy, setBusy] = useState<BatchAction | null>(null);
+  const [notice, setNotice] = useState<Notice | null>(null);
+
+  const handle = async (action: BatchAction): Promise<void> => {
+    const externalIds = selected.map((disc) => disc.externalId);
+
+    if (!window.confirm(confirmBatchAction(action, externalIds.length))) {
+      return;
+    }
+
+    setBusy(action);
+    setNotice(null);
+
+    const result = await runBatchAction(action, externalIds);
+
+    setBusy(null);
+
+    if (result.status === 'error') {
+      setNotice({ kind: 'error', text: result.message });
+
+      return;
+    }
+
+    setNotice({ kind: 'done', text: batchActionOutcome(action, result.affected, externalIds.length) });
+    onClear();
+    onChanged?.();
+  };
+
+  if (selected.length === 0) {
+    return notice?.kind === 'done' ? (
+      <p className="mb-4 text-sm" aria-live="polite">
+        {notice.text}
+      </p>
+    ) : null;
   }
 
-  const href = `/message/send-batch?ids=${externalIds.join(',')}`;
+  // Texting needs a number to send to, and a disc can be ticked without one:
+  // those are simply left out of the message batch rather than kept out of the
+  // selection, which the other three actions have no use for a number in.
+  const messageableIds = selected.filter((disc) => disc.hasPhoneNumber).map((disc) => disc.externalId);
+  const href = `/message/send-batch?ids=${messageableIds.join(',')}`;
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-4">
       <span aria-live="polite">
-        {externalIds.length} {externalIds.length === 1 ? 'kiekko' : 'kiekkoa'} valittu
+        {selected.length} {selected.length === 1 ? 'kiekko' : 'kiekkoa'} valittu
       </span>
 
-      {href.length <= MAX_HREF_LENGTH ? (
+      {messageableIds.length === 0 ? (
+        <span className="text-sm">Valituilla kiekoilla ei ole puhelinnumeroa.</span>
+      ) : href.length <= MAX_HREF_LENGTH ? (
         <Button variant="contained" to={href}>
-          Lähetä sms valituille henkilöille
+          {`Lähetä sms ${messageableIds.length} henkilölle`}
         </Button>
       ) : (
         <span className="text-sm">Valinta on liian suuri kerralla lähetettäväksi. Valitse pienempi joukko.</span>
       )}
 
-      <Button variant="outlined" onClick={onClear}>
+      {actions.map((action) => (
+        <Button
+          key={action}
+          variant={action === 'delete' ? 'contained' : 'outlined'}
+          color={action === 'delete' ? 'error' : 'primary'}
+          disabled={busy !== null}
+          onClick={() => handle(action)}
+        >
+          {busy === action ? 'Käsitellään...' : batchActionLabels[action]}
+        </Button>
+      ))}
+
+      <Button variant="outlined" disabled={busy !== null} onClick={onClear}>
         Tyhjennä valinta
       </Button>
+
+      {notice?.kind === 'error' && (
+        <p className="basis-full text-sm" aria-live="polite">
+          {notice.text}
+        </p>
+      )}
     </div>
   );
 }

--- a/app/features/discs/list/SelectedDiscsActions.tsx
+++ b/app/features/discs/list/SelectedDiscsActions.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router';
 import {
   batchActionLabel,
   batchActionOrder,
-  MAX_SELECTED_DISCS,
+  MAX_DISCS_PER_WRITE,
   type BatchAction,
 } from '~/features/discs/batch/batchAction';
 import { useBatchAction } from '~/features/discs/batch/useBatchAction';
@@ -78,6 +78,16 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
   const messageableIds = selected.filter((disc) => disc.hasPhoneNumber).map((disc) => disc.externalId);
   const withoutNumber = selected.length - messageableIds.length;
 
+  // Two reasons an action is left out rather than offered and then refused:
+  // there is nobody to text, or the selection is larger than a write may
+  // cover. Either way the note beside the dropdown says which.
+  const tooManyToWrite = selected.length > MAX_DISCS_PER_WRITE;
+
+  const options = actionOrder.filter((option) => (option === 'message' ? messageableIds.length > 0 : !tooManyToWrite));
+
+  const labelFor = (option: SelectedAction): string =>
+    option === 'message' ? `Lähetä sms ${messageableIds.length} henkilölle` : batchActionLabel(option);
+
   const startMessaging = (): void => {
     const href = `/message/send-batch?ids=${messageableIds.join(',')}`;
 
@@ -91,7 +101,9 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
   };
 
   const handleRun = (): void => {
-    if (action === '') {
+    // The chosen action can have left the dropdown between choosing it and
+    // pressing the button — a tick past the write cap does that.
+    if (action === '' || !options.includes(action)) {
       return;
     }
 
@@ -114,13 +126,6 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
       </p>
     ) : null;
   }
-
-  // Left out rather than offered and refused when not one selected disc has a
-  // number: there would be nobody to send to.
-  const options = messageableIds.length > 0 ? actionOrder : actionOrder.filter((option) => option !== 'message');
-
-  const labelFor = (option: SelectedAction): string =>
-    option === 'message' ? `Lähetä sms ${messageableIds.length} henkilölle` : batchActionLabel(option);
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-4">
@@ -161,10 +166,12 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
         </span>
       )}
 
-      {/* Said here as well as on the boxes it disables: the admin who has just
-          hit the cap is looking at the count, not hovering a checkbox. */}
-      {selected.length >= MAX_SELECTED_DISCS && (
-        <span className="text-sm">Enimmäismäärä {MAX_SELECTED_DISCS} kiekkoa valittu.</span>
+      {/* The selection itself is not limited — only what may be written to at
+          once, so this says what is missing from the dropdown and why. */}
+      {tooManyToWrite && (
+        <span className="text-sm">
+          Merkintä ja poisto koskevat enintään {MAX_DISCS_PER_WRITE} kiekkoa kerralla – valitse pienempi joukko.
+        </span>
       )}
 
       {notice?.kind === 'error' && (

--- a/app/features/discs/list/SelectedDiscsActions.tsx
+++ b/app/features/discs/list/SelectedDiscsActions.tsx
@@ -3,7 +3,8 @@ import { useState, type JSX } from 'react';
 import { useNavigate } from 'react-router';
 
 import {
-  batchActionLabels,
+  batchActionLabel,
+  batchActionOrder,
   batchActionOutcome,
   confirmBatchAction,
   type BatchAction,
@@ -45,8 +46,8 @@ type Props = {
  */
 type SelectedAction = BatchAction | 'message';
 
-/** The order the dropdown offers them in, messaging first as the most used. */
-const actionOrder: SelectedAction[] = ['message', 'return', 'sell', 'donate', 'delete'];
+/** Messaging first, as the most used; the writes in the order they are listed. */
+const actionOrder: SelectedAction[] = ['message', ...batchActionOrder];
 
 /**
  * What can be done with the discs ticked in the list.
@@ -137,7 +138,7 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
   const options = messageableIds.length > 0 ? actionOrder : actionOrder.filter((option) => option !== 'message');
 
   const labelFor = (option: SelectedAction): string =>
-    option === 'message' ? `Lähetä sms ${messageableIds.length} henkilölle` : batchActionLabels[option];
+    option === 'message' ? `Lähetä sms ${messageableIds.length} henkilölle` : batchActionLabel(option);
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-4">

--- a/app/features/discs/list/SelectedDiscsActions.tsx
+++ b/app/features/discs/list/SelectedDiscsActions.tsx
@@ -5,12 +5,10 @@ import { useNavigate } from 'react-router';
 import {
   batchActionLabel,
   batchActionOrder,
-  batchActionOutcome,
-  confirmBatchAction,
   MAX_SELECTED_DISCS,
   type BatchAction,
 } from '~/features/discs/batch/batchAction';
-import { runBatchAction } from '~/features/discs/batch/runBatchAction';
+import { useBatchAction } from '~/features/discs/batch/useBatchAction';
 import Button from '~/ui/Button';
 import Select, { MenuItem } from '~/ui/Select';
 
@@ -19,9 +17,8 @@ import Select, { MenuItem } from '~/ui/Select';
  *
  * The selection rides in the query string, and a request line past about eight
  * kilobytes is refused by the server with a 431 before any of this app's code
- * runs — a selection of every disc in the list reaches fourteen. Well clear of
- * that, and still far more than the send page will accept, so a batch it would
- * take is never blocked here.
+ * runs. A selection is capped well below that now, so this is a backstop rather
+ * than something reachable.
  */
 const MAX_HREF_LENGTH = 6000;
 
@@ -41,9 +38,9 @@ type Props = {
 /**
  * What the bar can be asked to do.
  *
- * Messaging sits alongside the three writes here because it is a fourth thing
- * to do with a selection, but it is not one of them: it navigates to a walk
- * through the owners one at a time, and the server knows nothing of it.
+ * Messaging sits alongside the writes here because it is another thing to do
+ * with a selection, but it is not one of them: it navigates to a walk through
+ * the owners one at a time, and the server knows nothing of it.
  */
 type SelectedAction = BatchAction | 'message';
 
@@ -58,58 +55,39 @@ const actionOrder: SelectedAction[] = ['message', ...batchActionOrder];
  * one more render after an action, with the selection cleared, so its report of
  * what happened does not vanish with the ticks.
  *
- * One dropdown and a button rather than a button per action: four of them side
+ * One dropdown and a button rather than a button per action: five of them side
  * by side filled the width above the table and gave a delete the same weight as
- * the one action that is used daily.
+ * the one action used daily.
  */
 export default function SelectedDiscsActions({ selected, onClear, onChanged }: Props): JSX.Element | null {
   const navigate = useNavigate();
 
   const [action, setAction] = useState<SelectedAction | ''>('');
-  const [isBusy, setIsBusy] = useState(false);
-  const [notice, setNotice] = useState<Notice | null>(null);
+
+  const { isBusy, notice, run, fail } = useBatchAction({
+    onDone: () => {
+      setAction('');
+      onClear();
+      onChanged?.();
+    },
+  });
 
   // Texting needs a number to send to, and a disc can be ticked without one:
-  // those are simply left out of the message batch rather than kept out of the
-  // selection, which the other three actions have no use for a number in.
+  // those are left out of the message batch rather than kept out of the
+  // selection, which the writes have no use for a number in.
   const messageableIds = selected.filter((disc) => disc.hasPhoneNumber).map((disc) => disc.externalId);
+  const withoutNumber = selected.length - messageableIds.length;
 
   const startMessaging = (): void => {
     const href = `/message/send-batch?ids=${messageableIds.join(',')}`;
 
     if (href.length > MAX_HREF_LENGTH) {
-      setNotice({ kind: 'error', text: TOO_LARGE_TO_SEND });
+      fail(TOO_LARGE_TO_SEND);
 
       return;
     }
 
     navigate(href);
-  };
-
-  const runWrite = async (write: BatchAction): Promise<void> => {
-    const externalIds = selected.map((disc) => disc.externalId);
-
-    if (!window.confirm(confirmBatchAction(write, externalIds.length))) {
-      return;
-    }
-
-    setIsBusy(true);
-    setNotice(null);
-
-    const result = await runBatchAction(write, externalIds);
-
-    setIsBusy(false);
-
-    if (result.status === 'error') {
-      setNotice({ kind: 'error', text: result.message });
-
-      return;
-    }
-
-    setNotice({ kind: 'done', text: batchActionOutcome(write, result.affected, externalIds.length) });
-    setAction('');
-    onClear();
-    onChanged?.();
   };
 
   const handleRun = (): void => {
@@ -123,7 +101,10 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
       return;
     }
 
-    void runWrite(action);
+    void run(
+      action,
+      selected.map((disc) => disc.externalId),
+    );
   };
 
   if (selected.length === 0) {
@@ -169,7 +150,16 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
         Tyhjennä valinta
       </Button>
 
-      {messageableIds.length === 0 && <span className="text-sm">Valituilla kiekoilla ei ole puhelinnumeroa.</span>}
+      {/* Said outright rather than left to be inferred from an sms count that
+          is lower than the number of ticks. The writes still cover every
+          selected disc, so this only qualifies the message option. */}
+      {withoutNumber > 0 && (
+        <span className="text-sm">
+          {messageableIds.length === 0
+            ? 'Valituilla kiekoilla ei ole puhelinnumeroa.'
+            : `${withoutNumber} valitulla kiekolla ei ole puhelinnumeroa – ne jäävät viestin ulkopuolelle.`}
+        </span>
+      )}
 
       {/* Said here as well as on the boxes it disables: the admin who has just
           hit the cap is looking at the count, not hovering a checkbox. */}
@@ -185,13 +175,3 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
     </div>
   );
 }
-
-/**
- * What the bar has to say, and which of the two moments it belongs to.
- *
- * A report of what was done belongs to a finished action, and the selection is
- * empty behind it; ticking the next batch is what makes it stale, so it is only
- * rendered while nothing is selected. An error belongs to a selection that is
- * still there to try again, so it is rendered beside the buttons.
- */
-type Notice = { kind: 'done' | 'error'; text: string };

--- a/app/features/discs/list/SelectedDiscsActions.tsx
+++ b/app/features/discs/list/SelectedDiscsActions.tsx
@@ -7,6 +7,7 @@ import {
   batchActionOrder,
   batchActionOutcome,
   confirmBatchAction,
+  MAX_SELECTED_DISCS,
   type BatchAction,
 } from '~/features/discs/batch/batchAction';
 import { runBatchAction } from '~/features/discs/batch/runBatchAction';
@@ -169,6 +170,12 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
       </Button>
 
       {messageableIds.length === 0 && <span className="text-sm">Valituilla kiekoilla ei ole puhelinnumeroa.</span>}
+
+      {/* Said here as well as on the boxes it disables: the admin who has just
+          hit the cap is looking at the count, not hovering a checkbox. */}
+      {selected.length >= MAX_SELECTED_DISCS && (
+        <span className="text-sm">Enimmäismäärä {MAX_SELECTED_DISCS} kiekkoa valittu.</span>
+      )}
 
       {notice?.kind === 'error' && (
         <p className="basis-full text-sm" aria-live="polite">

--- a/app/features/discs/list/SelectedDiscsActions.tsx
+++ b/app/features/discs/list/SelectedDiscsActions.tsx
@@ -46,7 +46,7 @@ type Props = {
 type SelectedAction = BatchAction | 'message';
 
 /** The order the dropdown offers them in, messaging first as the most used. */
-const actionOrder: SelectedAction[] = ['message', 'return', 'disposal', 'delete'];
+const actionOrder: SelectedAction[] = ['message', 'return', 'sell', 'donate', 'delete'];
 
 /**
  * What can be done with the discs ticked in the list.

--- a/app/features/discs/list/SelectedDiscsActions.tsx
+++ b/app/features/discs/list/SelectedDiscsActions.tsx
@@ -1,5 +1,7 @@
 import { useState, type JSX } from 'react';
 
+import { useNavigate } from 'react-router';
+
 import {
   batchActionLabels,
   batchActionOutcome,
@@ -8,6 +10,7 @@ import {
 } from '~/features/discs/batch/batchAction';
 import { runBatchAction } from '~/features/discs/batch/runBatchAction';
 import Button from '~/ui/Button';
+import Select, { MenuItem } from '~/ui/Select';
 
 /**
  * How long the handover link may get.
@@ -20,6 +23,8 @@ import Button from '~/ui/Button';
  */
 const MAX_HREF_LENGTH = 6000;
 
+const TOO_LARGE_TO_SEND = 'Valinta on liian suuri kerralla lähetettäväksi. Valitse pienempi joukko.';
+
 /** One ticked disc, and whether there is anyone to text about it. */
 export type SelectedDisc = { externalId: string; hasPhoneNumber: boolean };
 
@@ -31,18 +36,17 @@ type Props = {
   onChanged?: () => void;
 };
 
-/** The three actions, in the order the bar offers them. */
-const actions: BatchAction[] = ['return', 'disposal', 'delete'];
-
 /**
- * What the bar has to say, and which of the two moments it belongs to.
+ * What the bar can be asked to do.
  *
- * A report of what was done belongs to a finished action, and the selection is
- * empty behind it; ticking the next batch is what makes it stale, so it is only
- * rendered while nothing is selected. An error belongs to a selection that is
- * still there to try again, so it is rendered beside the buttons.
+ * Messaging sits alongside the three writes here because it is a fourth thing
+ * to do with a selection, but it is not one of them: it navigates to a walk
+ * through the owners one at a time, and the server knows nothing of it.
  */
-type Notice = { kind: 'done' | 'error'; text: string };
+type SelectedAction = BatchAction | 'message';
+
+/** The order the dropdown offers them in, messaging first as the most used. */
+const actionOrder: SelectedAction[] = ['message', 'return', 'disposal', 'delete'];
 
 /**
  * What can be done with the discs ticked in the list.
@@ -52,28 +56,47 @@ type Notice = { kind: 'done' | 'error'; text: string };
  * one more render after an action, with the selection cleared, so its report of
  * what happened does not vanish with the ticks.
  *
- * The message link is written out here, as the row's own message icon writes
- * out /message/send/:externalId. How many discs one batch may carry is the send
- * page's rule and it says so itself; the only thing stopped from this side is a
- * link too long to survive the trip.
+ * One dropdown and a button rather than a button per action: four of them side
+ * by side filled the width above the table and gave a delete the same weight as
+ * the one action that is used daily.
  */
 export default function SelectedDiscsActions({ selected, onClear, onChanged }: Props): JSX.Element | null {
-  const [busy, setBusy] = useState<BatchAction | null>(null);
+  const navigate = useNavigate();
+
+  const [action, setAction] = useState<SelectedAction | ''>('');
+  const [isBusy, setIsBusy] = useState(false);
   const [notice, setNotice] = useState<Notice | null>(null);
 
-  const handle = async (action: BatchAction): Promise<void> => {
-    const externalIds = selected.map((disc) => disc.externalId);
+  // Texting needs a number to send to, and a disc can be ticked without one:
+  // those are simply left out of the message batch rather than kept out of the
+  // selection, which the other three actions have no use for a number in.
+  const messageableIds = selected.filter((disc) => disc.hasPhoneNumber).map((disc) => disc.externalId);
 
-    if (!window.confirm(confirmBatchAction(action, externalIds.length))) {
+  const startMessaging = (): void => {
+    const href = `/message/send-batch?ids=${messageableIds.join(',')}`;
+
+    if (href.length > MAX_HREF_LENGTH) {
+      setNotice({ kind: 'error', text: TOO_LARGE_TO_SEND });
+
       return;
     }
 
-    setBusy(action);
+    navigate(href);
+  };
+
+  const runWrite = async (write: BatchAction): Promise<void> => {
+    const externalIds = selected.map((disc) => disc.externalId);
+
+    if (!window.confirm(confirmBatchAction(write, externalIds.length))) {
+      return;
+    }
+
+    setIsBusy(true);
     setNotice(null);
 
-    const result = await runBatchAction(action, externalIds);
+    const result = await runBatchAction(write, externalIds);
 
-    setBusy(null);
+    setIsBusy(false);
 
     if (result.status === 'error') {
       setNotice({ kind: 'error', text: result.message });
@@ -81,9 +104,24 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
       return;
     }
 
-    setNotice({ kind: 'done', text: batchActionOutcome(action, result.affected, externalIds.length) });
+    setNotice({ kind: 'done', text: batchActionOutcome(write, result.affected, externalIds.length) });
+    setAction('');
     onClear();
     onChanged?.();
+  };
+
+  const handleRun = (): void => {
+    if (action === '') {
+      return;
+    }
+
+    if (action === 'message') {
+      startMessaging();
+
+      return;
+    }
+
+    void runWrite(action);
   };
 
   if (selected.length === 0) {
@@ -94,11 +132,12 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
     ) : null;
   }
 
-  // Texting needs a number to send to, and a disc can be ticked without one:
-  // those are simply left out of the message batch rather than kept out of the
-  // selection, which the other three actions have no use for a number in.
-  const messageableIds = selected.filter((disc) => disc.hasPhoneNumber).map((disc) => disc.externalId);
-  const href = `/message/send-batch?ids=${messageableIds.join(',')}`;
+  // Left out rather than offered and refused when not one selected disc has a
+  // number: there would be nobody to send to.
+  const options = messageableIds.length > 0 ? actionOrder : actionOrder.filter((option) => option !== 'message');
+
+  const labelFor = (option: SelectedAction): string =>
+    option === 'message' ? `Lähetä sms ${messageableIds.length} henkilölle` : batchActionLabels[option];
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-4">
@@ -106,31 +145,29 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
         {selected.length} {selected.length === 1 ? 'kiekko' : 'kiekkoa'} valittu
       </span>
 
-      {messageableIds.length === 0 ? (
-        <span className="text-sm">Valituilla kiekoilla ei ole puhelinnumeroa.</span>
-      ) : href.length <= MAX_HREF_LENGTH ? (
-        <Button variant="contained" to={href}>
-          {`Lähetä sms ${messageableIds.length} henkilölle`}
-        </Button>
-      ) : (
-        <span className="text-sm">Valinta on liian suuri kerralla lähetettäväksi. Valitse pienempi joukko.</span>
-      )}
+      <Select
+        aria-label="Toimenpide valituille kiekoille"
+        value={action}
+        disabled={isBusy}
+        onChange={(event) => setAction(event.currentTarget.value as SelectedAction | '')}
+      >
+        <MenuItem value="">Valitse toimenpide...</MenuItem>
+        {options.map((option) => (
+          <MenuItem key={option} value={option}>
+            {labelFor(option)}
+          </MenuItem>
+        ))}
+      </Select>
 
-      {actions.map((action) => (
-        <Button
-          key={action}
-          variant={action === 'delete' ? 'contained' : 'outlined'}
-          color={action === 'delete' ? 'error' : 'primary'}
-          disabled={busy !== null}
-          onClick={() => handle(action)}
-        >
-          {busy === action ? 'Käsitellään...' : batchActionLabels[action]}
-        </Button>
-      ))}
+      <Button variant="contained" disabled={action === '' || isBusy} onClick={handleRun}>
+        {isBusy ? 'Käsitellään...' : 'Suorita'}
+      </Button>
 
-      <Button variant="outlined" disabled={busy !== null} onClick={onClear}>
+      <Button variant="outlined" disabled={isBusy} onClick={onClear}>
         Tyhjennä valinta
       </Button>
+
+      {messageableIds.length === 0 && <span className="text-sm">Valituilla kiekoilla ei ole puhelinnumeroa.</span>}
 
       {notice?.kind === 'error' && (
         <p className="basis-full text-sm" aria-live="polite">
@@ -140,3 +177,13 @@ export default function SelectedDiscsActions({ selected, onClear, onChanged }: P
     </div>
   );
 }
+
+/**
+ * What the bar has to say, and which of the two moments it belongs to.
+ *
+ * A report of what was done belongs to a finished action, and the selection is
+ * empty behind it; ticking the next batch is what makes it stale, so it is only
+ * rendered while nothing is selected. An error belongs to a selection that is
+ * still there to try again, so it is rendered beside the buttons.
+ */
+type Notice = { kind: 'done' | 'error'; text: string };

--- a/app/models/discs.server.ts
+++ b/app/models/discs.server.ts
@@ -225,7 +225,7 @@ export async function createDiscs(discs: DiscDTO[], request: Request): Promise<s
  * another club — so the caller can tell "already gone" from "deleted".
  */
 export async function deleteDisc(externalId: string, request: Request): Promise<boolean> {
-  return (await deleteDiscs([externalId], request)) > 0;
+  return (await deleteDiscs(request, [externalId])) > 0;
 }
 
 /**
@@ -238,7 +238,7 @@ export async function deleteDisc(externalId: string, request: Request): Promise<
  * it asked for: an id that no longer resolves is not an error, but a shortfall
  * is worth reporting.
  */
-export async function deleteDiscs(externalIds: string[], request: Request): Promise<number> {
+export async function deleteDiscs(request: Request, externalIds: string[]): Promise<number> {
   const clubId = process.env.APP_CLUB_ID;
 
   const supabase = createSupabaseServerClient(request);
@@ -394,11 +394,15 @@ function disposalPatch(details: DiscDisposalDetails): Record<string, unknown> {
  * shortfall, and telling them apart would mean a second query per id that says
  * nothing the admin can act on differently.
  */
+type UpdateDiscsInput = {
+  externalIds: string[];
+  patch: Record<string, unknown>;
+  failureMessage: string;
+};
+
 async function updateDiscs(
-  externalIds: string[],
-  patch: Record<string, unknown>,
   request: Request,
-  failureMessage: string,
+  { externalIds, patch, failureMessage }: UpdateDiscsInput,
 ): Promise<number> {
   const clubId = process.env.APP_CLUB_ID;
 
@@ -418,20 +422,29 @@ async function updateDiscs(
   return data?.length ?? 0;
 }
 
-/** Marks several discs as returned to their owners, all on the same date. */
+/**
+ * Marks several discs as returned to their owners, or as free to be sold or
+ * donated, all on the same date.
+ *
+ * These take the request first and their arguments in an object, which is the
+ * documented shape for anything past two parameters; the single-disc marks
+ * above predate it and are left as they are rather than migrated from here.
+ */
 export async function markDiscsAsReturned(
-  externalIds: string[],
-  details: DiscReturnDetails,
   request: Request,
+  { externalIds, details }: MarkDiscsInput<DiscReturnDetails>,
 ): Promise<number> {
-  return updateDiscs(externalIds, returnPatch(details), request, RETURN_FAILURE);
+  return updateDiscs(request, { externalIds, patch: returnPatch(details), failureMessage: RETURN_FAILURE });
 }
 
-/** Marks several discs as free to be sold or donated, all on the same date. */
 export async function markDiscsForDisposal(
-  externalIds: string[],
-  details: DiscDisposalDetails,
   request: Request,
+  { externalIds, details }: MarkDiscsInput<DiscDisposalDetails>,
 ): Promise<number> {
-  return updateDiscs(externalIds, disposalPatch(details), request, DISPOSAL_FAILURE);
+  return updateDiscs(request, { externalIds, patch: disposalPatch(details), failureMessage: DISPOSAL_FAILURE });
 }
+
+type MarkDiscsInput<D> = {
+  externalIds: string[];
+  details: D;
+};

--- a/app/models/discs.server.ts
+++ b/app/models/discs.server.ts
@@ -225,6 +225,20 @@ export async function createDiscs(discs: DiscDTO[], request: Request): Promise<s
  * another club — so the caller can tell "already gone" from "deleted".
  */
 export async function deleteDisc(externalId: string, request: Request): Promise<boolean> {
+  return (await deleteDiscs([externalId], request)) > 0;
+}
+
+/**
+ * Deletes several discs at once, addressed by their external ids.
+ *
+ * Scoped to APP_CLUB_ID like the single-disc delete, so an id belonging to
+ * another club is simply not among the rows that go.
+ *
+ * Returns how many rows were deleted, which the caller compares with how many
+ * it asked for: an id that no longer resolves is not an error, but a shortfall
+ * is worth reporting.
+ */
+export async function deleteDiscs(externalIds: string[], request: Request): Promise<number> {
   const clubId = process.env.APP_CLUB_ID;
 
   const supabase = createSupabaseServerClient(request);
@@ -232,15 +246,15 @@ export async function deleteDisc(externalId: string, request: Request): Promise<
   const { data, error } = await supabase
     .from('discs')
     .delete()
-    .eq('external_id', externalId)
+    .in('external_id', externalIds)
     .eq('club_id', clubId)
     .select('external_id');
 
   if (error) {
-    throw new Error(`Kiekon poisto epäonnistui: ${error.message}`);
+    throw new Error(`Kiekkojen poisto epäonnistui: ${error.message}`);
   }
 
-  return (data?.length ?? 0) > 0;
+  return data?.length ?? 0;
 }
 
 /**
@@ -309,16 +323,7 @@ export async function markAsReturned(
   details: DiscReturnDetails,
   request: Request,
 ): Promise<MarkOutcome> {
-  return updateDisc(
-    externalId,
-    {
-      is_returned_to_owner: true,
-      returned_to_owner_date: details.returnedToOwnerDate,
-      return_method: details.returnMethod,
-    },
-    request,
-    'Kiekon merkitseminen palautetuksi epäonnistui',
-  );
+  return updateDisc(externalId, returnPatch(details), request, RETURN_FAILURE);
 }
 
 /**
@@ -351,14 +356,82 @@ export async function markForDisposal(
   details: DiscDisposalDetails,
   request: Request,
 ): Promise<MarkOutcome> {
-  return updateDisc(
-    externalId,
-    {
-      can_be_sold_or_donated: true,
-      can_be_sold_or_donated_date: details.canBeSoldOrDonatedDate,
-      can_be_sold_or_donated_method: details.canBeSoldOrDonatedMethod,
-    },
-    request,
-    'Kiekon merkitseminen myytäväksi tai lahjoitettavaksi epäonnistui',
-  );
+  return updateDisc(externalId, disposalPatch(details), request, DISPOSAL_FAILURE);
+}
+
+const RETURN_FAILURE = 'Kiekon merkitseminen palautetuksi epäonnistui';
+
+const DISPOSAL_FAILURE = 'Kiekon merkitseminen myytäväksi tai lahjoitettavaksi epäonnistui';
+
+/**
+ * The columns a return writes, and the ones a disposal writes.
+ *
+ * Written once and used by both the single-disc mark and the batch one, so the
+ * two cannot drift into recording a return differently.
+ */
+function returnPatch(details: DiscReturnDetails): Record<string, unknown> {
+  return {
+    is_returned_to_owner: true,
+    returned_to_owner_date: details.returnedToOwnerDate,
+    return_method: details.returnMethod,
+  };
+}
+
+function disposalPatch(details: DiscDisposalDetails): Record<string, unknown> {
+  return {
+    can_be_sold_or_donated: true,
+    can_be_sold_or_donated_date: details.canBeSoldOrDonatedDate,
+    can_be_sold_or_donated_method: details.canBeSoldOrDonatedMethod,
+  };
+}
+
+/**
+ * Applies one patch to several discs at once, addressed by their external ids
+ * and scoped to APP_CLUB_ID, and reports how many rows it changed.
+ *
+ * A count rather than the three outcomes the single-disc update reports: over a
+ * selection, a missing disc and one a policy refused both come out as the same
+ * shortfall, and telling them apart would mean a second query per id that says
+ * nothing the admin can act on differently.
+ */
+async function updateDiscs(
+  externalIds: string[],
+  patch: Record<string, unknown>,
+  request: Request,
+  failureMessage: string,
+): Promise<number> {
+  const clubId = process.env.APP_CLUB_ID;
+
+  const supabase = createSupabaseServerClient(request);
+
+  const { data, error } = await supabase
+    .from('discs')
+    .update(patch)
+    .in('external_id', externalIds)
+    .eq('club_id', clubId)
+    .select('external_id');
+
+  if (error) {
+    throw new Error(`${failureMessage}: ${error.message}`);
+  }
+
+  return data?.length ?? 0;
+}
+
+/** Marks several discs as returned to their owners, all on the same date. */
+export async function markDiscsAsReturned(
+  externalIds: string[],
+  details: DiscReturnDetails,
+  request: Request,
+): Promise<number> {
+  return updateDiscs(externalIds, returnPatch(details), request, RETURN_FAILURE);
+}
+
+/** Marks several discs as free to be sold or donated, all on the same date. */
+export async function markDiscsForDisposal(
+  externalIds: string[],
+  details: DiscDisposalDetails,
+  request: Request,
+): Promise<number> {
+  return updateDiscs(externalIds, disposalPatch(details), request, DISPOSAL_FAILURE);
 }

--- a/app/routes/discs.batch.tsx
+++ b/app/routes/discs.batch.tsx
@@ -1,0 +1,14 @@
+import type { ActionFunctionArgs } from 'react-router';
+
+import { handleBatchRequest } from '~/features/discs/batch/handleBatchRequest.server';
+
+/**
+ * Applies one action — delete, returned, or free to be sold or donated — to a
+ * selection of discs at once.
+ *
+ * A resource route for the same reason as /discs/delete: a plain fetch POST to
+ * a page route is answered with a rendered document, not the action's JSON.
+ */
+export async function action({ request }: ActionFunctionArgs) {
+  return handleBatchRequest(request);
+}

--- a/app/ui/Select.tsx
+++ b/app/ui/Select.tsx
@@ -26,6 +26,8 @@ const styles = stylex.create({
 type SelectProps = {
   id?: string;
   name?: string;
+  /** For a select with no visible label of its own. */
+  'aria-label'?: string;
   value?: string;
   defaultValue?: string;
   disabled?: boolean;


### PR DESCRIPTION
## Summary

Selecting discs in the list already existed, for the SMS batch. This extends it to the other three per-disc admin actions:

- **Merkitse valitut palautetuiksi** — marks every selected disc returned to its owner
- **Merkitse valitut myytäviksi tai lahjoitettaviksi** — marks them free to be sold or donated
- **Poista valitut** — deletes them

Each asks for confirmation first, naming the action and how many discs it covers (`Poistetaanko 12 kiekkoa? Poistoa ei voi peruuttaa.`). The discs themselves are deliberately not listed: the selection is on screen right behind the dialog.

The bar reports what happened afterwards, and reports a shortfall rather than passing over it — `Poistettiin 10 kiekkoa. 2 kiekkoa jäi käsittelemättä…` — so a count can never overstate what was done.

### Two decisions worth naming

**The marks are dated today, and each carries its own method.** Both marks exist to record which of two things happened, so each is two entries in the dropdown rather than one with a method beside it — and by the time the action is picked the choice is already made, so a second step asking for it would be a step to click past. The single-disc forms go on asking, because there either method can be left unanswered. The date comes from the browser, not the server: the server runs in UTC, which is the wrong day for a Finnish evening.

```
Valitse toimenpide...
Lähetä sms N henkilölle              → the owner-by-owner walk, unchanged
Merkitse palautetuiksi (postitettu)  → return_method = 0 (Postitettu)
Merkitse palautetuiksi (noudettu)    → return_method = 1 (Noudettu)
Merkitse myytäviksi                  → can_be_sold_or_donated_method = 0 (Myydään)
Merkitse lahjoitettaviksi            → can_be_sold_or_donated_method = 1 (Lahjoitetaan)
Poista
```

Both mappings from action to stored smallint sit behind `returnMethodFor` / `disposalMethodFor` and are pinned by tests against the **labels**, not the numbers: nothing in the UI shows the smallint, so an inversion would mark every disc for donation, or every one collected at the course as posted, with nothing looking wrong.

**A selection is capped at 20 discs, and there is no select-all.** These actions cannot be undone from the UI, so the size of a selection is how much a mis-click can cost. The header checkbox appears only once something is selected and only clears it — one click that arms a delete on the whole list is the mis-click worth designing out, while emptying a selection is safe. Past twenty ticks only the already-selected discs stay selectable, so unticking still frees a slot and the limit is met while choosing rather than as a refusal after confirming; the disabled boxes say why and so does the bar. `/discs/batch` enforces the same twenty on its own, since the list is not the only thing that can post to it.

**Ticking a row no longer requires a phone number.** That gate existed because messaging was the only thing a selection did. Deleting a disc has no use for a number, so the gate is now just "has an external id". The SMS button filters the selection itself and says how many owners it will reach (`Lähetä sms 8 henkilölle` for 12 selected discs, 4 of them numberless).

### Shape

- `app/features/discs/batch/` — a slice of its own: the action list and its Finnish wording (`batchAction.ts`, pure and unit-tested), the client call (`runBatchAction.ts`), the server handler (`handleBatchRequest.server.ts`)
- `app/routes/discs.batch.tsx` — a resource route, for the same reason `/discs/delete` is one
- `deleteDiscs` / `markDiscsAsReturned` / `markDiscsForDisposal` in `discs.server.ts`, all scoped to `APP_CLUB_ID` like their single-disc counterparts. The column names a return or a disposal writes are now built in one place and shared by the single and batch paths, so the two cannot drift.
- The batch update reports a count rather than the single-disc `MarkOutcome`: over a selection a missing disc and one a policy refused come out as the same shortfall, and telling them apart would cost a query per id to say nothing the admin could act on differently.

## Test plan

`npm test` (257 pass, 6 new), `npm run typecheck`, `npm run build`, eslint and prettier all clean.

Verified in the browser against the live list (469 discs), **without writing to any real disc**:

- [x] Every row is tickable now, numberless ones included (470 checkboxes for 469 rows + the header)
- [x] 4 discs selected, 2 with numbers → bar reads `4 kiekkoa valittu` and `Lähetä sms 2 henkilölle`, and the link carries exactly 2 ids
- [x] All three confirmations read correctly, and declining posts nothing and keeps the selection
- [x] The route itself, exercised with a valid-shaped uuid matching no disc — so real SQL ran and touched zero rows: all three actions `200 {affected: 0}`; duplicate ids collapse to one; unknown action, malformed ids, empty selection, missing date, `2026-02-30`, and 501 ids each `422` with their own message
- [x] Success path with a canned response: today's local date sent, ticks cleared, list reloaded, report shown — including the shortfall wording
- [x] A report disappears when the next batch is ticked; an error stays beside the buttons where the retry is

The one thing left for a real click is a batch that actually writes, which needs live discs to spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


