### PR TITLE
fix(discs): call the place the club's koppi, not its varasto

### DIFF
--- a/app/features/discs/ownerResponse/OwnerLinkPage.tsx
+++ b/app/features/discs/ownerResponse/OwnerLinkPage.tsx
@@ -36,7 +36,7 @@ type Props = {
 const OWNER_LABELS: Record<HandoverMethodValue, string> = {
   [HandoverMethod.ByMail]: 'Postita kiekko minulle',
   [HandoverMethod.PickedUpFromHome]: 'Noudan kiekon – sovitaan noudosta erikseen',
-  [HandoverMethod.PickedUpFromStorage]: 'Noudan kiekon seuran varastolta',
+  [HandoverMethod.PickedUpFromStorage]: 'Noudan kiekon seuran kopilta',
 };
 
 export default function OwnerLinkPage({ disc, clubPayment, contactEmail, token, result }: Props): JSX.Element {


### PR DESCRIPTION
The option an owner picks on `/kiekko/<token>` when they want to collect the disc themselves from the club's place now reads **Noudan kiekon seuran kopilta**, not `varastolta`.

One label, the one an owner reads. Three other strings still say varasto, and can follow if that is what the place is called everywhere:

- `handoverMethod.ts:24` — `Nouto varastolta`, the shorthand in the admin dropdowns (pinned by two assertions in `handoverMethod.test.ts`).
- `RetrievalListPage.tsx:29` — the Noutolista intro.
- `docs/getting-a-disc-back-to-its-owner.md:129` — the method table.

## Test plan

- `npm test` — 348 pass; `npm run typecheck`, `npm run lint` clean.
- By hand: open an owner link for a Talin disc still in the koppi and check the third option reads the new way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)