### PR TITLE
docs(specs): as-built specifications for the twelve major features

### DIFF
--- a/.claude/skills/project-conventions/SKILL.md
+++ b/.claude/skills/project-conventions/SKILL.md
@@ -1,10 +1,19 @@
 ---
 name: project-conventions
-description: Project architecture and code conventions — route structure, feature organization, database query naming, and file organization.
+description: Project architecture and code conventions — route structure, feature organization, database query naming, and file organization. Note that feature work also requires a spec in specs/; see the separate specs skill.
 user-invocable: false
 ---
 
 # Project conventions
+
+## Specs come first
+
+Every major feature has a specification in `specs/`. Write or update the spec
+**before** implementing a feature or changing behaviour, and verify it against
+the code once lint, typecheck and tests are green.
+
+The full workflow and the writing rules live in the `specs` skill — read it
+before touching anything in `specs/`.
 
 ## Slim routes
 

--- a/.claude/skills/specs/SKILL.md
+++ b/.claude/skills/specs/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: specs
+description: How to write and maintain the feature specifications in specs/ — write or update a spec before implementing a feature, verify it against the code once lint, typecheck and tests are green, and keep it readable for a human who does not already know the code. Use whenever adding a feature, changing behaviour, or reading specs/ to understand how something works.
+user-invocable: true
+---
+
+# Specs
+
+Every major feature has a specification in `specs/`, indexed by `specs/README.md`
+and structured by `specs/_TEMPLATE.md`. A spec describes what the system **does
+today**, not what it should eventually do.
+
+The specs exist to answer two questions that the code answers badly: *why is it
+like this*, and *what will I break if I change it*. Optimise for those.
+
+## Who you are writing for
+
+Write for a competent developer who has never seen this codebase, reading the
+spec a year from now, without the code open beside them.
+
+That person is not stupid, but they do not share your context. They do not know
+what "the composite state" means here, they have not read the migration you just
+read, and they will not recognise an abbreviation you invented this afternoon.
+
+## Writing rules
+
+### Introduce an abbreviation once, then use it
+
+Abbreviations and established technical terms are welcome. They are often the
+precise name for a thing, and a reader in this field expects them. The problem is
+never that a spec says "RLS" — it is that the spec says "RLS" without ever having
+said what it stands for.
+
+The rule is about repetition, not about avoidance:
+
+- **Used more than once in the file** — introduce it at the first mention, with
+  the expansion and a short plain-language explanation in parentheses or after a
+  dash. Then use the short form freely for the rest of the file. Do not re-explain
+  it, and do not alternate between the long and short forms.
+- **Used exactly once** — just write the plain phrase. Do not introduce an
+  abbreviation you will never use again; "(DTO)" after a single mention of "data
+  transfer object" is noise.
+
+```
+Row level security (RLS) — the PostgreSQL feature that decides, row by row,
+whether a database role may read or write it — is the second line of defence
+here. The RLS policies are listed below, and RLS is what stops an anonymous
+visitor writing to `discs` even if the route forgets to check.
+```
+
+How much explanation an abbreviation needs depends on how far it sits from
+everyday knowledge. "URL" needs nothing. "DTO (data transfer object)" needs the
+expansion but not a definition. "RLS" needs the expansion *and* a sentence,
+because the reader's decisions depend on understanding what it actually enforces.
+When in doubt, give the sentence — it costs one line.
+
+Each spec stands alone, so this restarts in every file. A term explained in
+`05-owner-link-and-responses.md` is still unexplained in `06-messaging-and-templates.md`.
+
+This applies to project-local shorthand too, not only industry acronyms.
+`APP_CLUB_ID`, `external_id` and "the anon key" all deserve one plain sentence at
+their first mention in a file — the reader cannot look these up anywhere.
+
+Finnish user-visible strings follow the same shape: quoted exactly as they appear
+in the code, with a short English gloss in parentheses at first use — "Merkitse
+käsitellyksi" (mark as handled) — and the bare Finnish quote thereafter. The
+gloss is for the reader; the quoted Finnish is the contract with the UI.
+
+### Prefer plain words to impressive ones
+
+Jargon that sounds sophisticated but adds nothing is the main thing that makes a
+spec unreadable. Pick the ordinary word.
+
+| Instead of | Write |
+|---|---|
+| leverage, utilise | use |
+| orchestrate | run, coordinate |
+| surface (verb) | show, report |
+| hydrate the DTO | fill in the object |
+| idempotent | running it twice changes nothing |
+| the happy path | when everything works |
+| performant | fast |
+| single source of truth | the one place this is decided |
+
+Keep a technical term when it is genuinely the precise name for a thing —
+`SECURITY DEFINER`, `WITH CHECK`, foreign key, transaction. Then explain it once.
+The test is whether the word carries information the plain phrasing would lose.
+
+### Be as long as the subject needs
+
+Brevity is not the goal; clarity is. A one-line summary that leaves the reader
+guessing has saved nobody anything.
+
+- Simple mechanism, few rules → short section. Do not pad it.
+- Subtle rule, non-obvious reason, or something that has already caused a bug →
+  spend the paragraph. Explain the mechanism, then why it is that way.
+- Security and data-retention rules always get the full explanation, including
+  which layer actually enforces them and what happens if someone bypasses the UI.
+
+When a section is longer than a screen, it usually wants a small table.
+
+### Say why, not only what
+
+The code already states what happens. A spec earns its place by recording the
+reasoning that is invisible in the diff:
+
+> `owner_link_token` is a separate column rather than reusing `external_id`,
+> so that a leaked link can be revoked with a single UPDATE without changing the
+> identity the SMS history refers to.
+
+If you cannot reconstruct the reason, write that plainly — "reason not recorded"
+is more useful than an invented rationale.
+
+### Concrete over abstract
+
+Name the actual file, column, route, limit and Finnish label. "Validation is
+applied" tells the reader nothing; "`parseBatch` rejects more than 100 rows and
+returns a 422 naming the offending row number" tells them what to expect and
+where to look.
+
+## Structure
+
+Follow `specs/_TEMPLATE.md` section for section, keeping every heading even when
+a section is thin — consistency is what makes twelve specs skimmable. Sections:
+Purpose, Actors, User-facing behaviour, Data, Routes & entry points, Rules &
+constraints, Edge cases & known gaps, Open questions.
+
+"Open questions" may be empty. Say "None" rather than deleting the heading.
+
+Numbering: `specs/NN-<kebab-name>.md`, matching the row in `specs/README.md`.
+
+## Before implementing
+
+Do not start a feature or a behaviour change without its spec.
+
+1. Find the affected spec(s) in `specs/README.md`. A change usually touches more
+   than one — a new disc action touches `03-disc-lifecycle-actions.md` and often
+   `01-public-disc-list.md` too.
+2. **Changing existing behaviour:** update the spec first, so the diff shows the
+   intended change in plain language before any code exists.
+3. **A genuinely new feature:** create the file from `_TEMPLATE.md` and add a row
+   to the table in `specs/README.md`.
+4. If writing it down raises a question the spec cannot answer, ask it before
+   writing code. That is the point of doing this first.
+
+A spec written ahead of the code is a plan, so it may use future tense while the
+work is in flight. Rewrite it in the as-built present tense before the work is
+done.
+
+Small changes still count: a validation limit, a new enum value or a changed
+Finnish label all live in "Rules & constraints" or "Data". The exception is work
+that changes no behaviour at all — a pure refactor, a rename, a formatting pass.
+
+## After implementing
+
+When the code is written and the basic checks pass, verify the spec against what
+was actually built. The checks gate the start of that review; they are not the
+end of the task:
+
+```
+npm run lint
+npm run typecheck
+npm test
+npm run format:check
+```
+
+With those green, re-read every spec you touched and confirm, section by section:
+
+- **User-facing behaviour** — every scenario matches the shipped flow, including
+  the Finnish labels, quoted exactly as they appear in the code.
+- **Data** — columns, types, nullability and enum values match the migration that
+  shipped. Numeric enum values matter; they are stored in the database.
+- **Routes & entry points** — every route, its methods, and its real
+  authentication requirement. Check the `action`, not only the `loader`.
+- **Rules & constraints** — limits and permissions match the code, and the spec
+  names the layer that actually enforces them. Where an anonymous visitor is
+  involved, that layer is the database, not the browser.
+- **Edge cases & known gaps** — add anything you found but deliberately did not
+  fix; remove entries this work fixed.
+- **Open questions** — resolve the ones this work answered, add any it raised.
+
+Then strip any remaining future tense.
+
+If the implementation diverged from the spec, the spec changes — it records
+reality. Say so in the pull request description, because a divergence usually
+means the original plan was wrong somewhere worth mentioning.
+
+## Recording gaps honestly
+
+"Edge cases & known gaps" is the most valuable section in a spec, and only stays
+valuable if it is candid. Write down the thing that is broken, unfinished or
+merely sharp, in plain words, without softening it:
+
+> Marking a disc returned does not close its open row in `disc_retrievals`. The
+> row keeps `retrieved_at` empty for ever; it merely stops appearing as pending
+> because the disc is no longer listed. Any later "how long did a fetch take"
+> query would count these as still open.
+
+Do not quietly fix a gap you noticed while writing — note it, finish the task at
+hand, and raise it. Do not delete an entry because it is embarrassing.

--- a/specs/01-public-disc-list.md
+++ b/specs/01-public-disc-list.md
@@ -1,0 +1,77 @@
+# Public disc list & search
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+The front page of the app: every disc the club currently holds and has not
+returned, sold, donated or archived. An owner comes here to find their own disc
+and recognise it by the last four digits of the phone number written on it. The
+same page is the club admin's working surface — signed in, each row grows the
+lifecycle actions and the club-internal notes.
+
+## Actors
+- **Anonymous visitor** — browses, filters and searches; sees no phone numbers in full, no notes and no actions.
+- **Club admin** (signed in via Supabase) — same list plus full phone numbers, `additional_info`, row actions and batch selection.
+
+## User-facing behaviour
+1. When the page loads, the client fetches `/discs/data` (`useFetcher`) and shows a spinner until the first payload arrives; a later reload keeps the table on screen at 50% opacity with `aria-busy`.
+2. When the club has an emptying log, "Löytökiekot tarkistettu viimeksi" (last checked) is shown above the filters; the course name is shown only when there is more than one entry.
+3. When a visitor picks a disc name in the "Kiekko" combobox (`DiscSelector`, downshift), the list is filtered to rows whose `discName` is exactly that string.
+4. When a visitor types more than 2 characters into "Puh nro., 4 viimeistä" (phone no., last 4), a 300 ms-debounced filter keeps rows whose `ownerPhoneNumber` *ends with* the typed digits.
+5. When the club records courses **and** the loaded discs name more than one, a "Rata" (course) radio row appears with "Kaikki radat" (all courses) plus one option per course found in the data.
+6. When a header is clicked, the table re-sorts (TanStack Table); default sort is `addedAt` descending. Column widths are pointer-draggable.
+7. When a disc has been held over three months, a red warning icon sits next to its "Lisätty" (added) date.
+8. When signed in, each row gains a checkbox, an SMS link, and the action icons (return, disposal, retrieval, course, notes, delete); the panels open as an extra row under the disc.
+9. When an admin action succeeds, `DiscListPage.reload()` re-fetches `/discs/data` **and** revalidates the root loader, so the retrieval badge in the menu stays in step.
+
+## Data
+Reads `public.discs`, scoped to `club_id = APP_CLUB_ID`.
+
+| Column | Notes |
+|---|---|
+| `external_id` | uuid, NOT NULL, unique, default `gen_random_uuid()`. Sent to signed-in visitors only; every admin action is keyed on it. |
+| `internal_disc_id` | Nullable — web-added discs have no Google Sheet row. |
+| `disc_name`, `disc_colour`, `disc_manufacturer` | Public. `disc_name` carries "Mould, Plastic". |
+| `owner_name`, `owner_club_name` | Public. |
+| `owner_phone_number` | Truncated to the last 4 digits for anonymous visitors in `toListedDiscs` (`app/models/discs.server.ts`), before the payload is built. |
+| `added_at` | Public; drives the >3-month warning. |
+| `course` | Nullable; only Puskasoturit (club 1) records one. |
+| `additional_info` | Left out of the `SELECT` entirely unless signed in. |
+| `is_returned_to_owner`, `can_be_sold_or_donated`, `archived_at` | Exclusion filters, see below. |
+
+Also reads `emptying_log` (via `getEmptyingLogItemsForClub`) and, for a signed-in
+admin of a retrieval-list club, `disc_retrievals` (`queryPendingRetrievalMethods`).
+
+Exclusion is a single query in `getDiscs()`:
+`is_returned_to_owner = false AND can_be_sold_or_donated = false AND archived_at IS NULL AND club_id = APP_CLUB_ID`,
+ordered by `disc_name` ascending. `archived_at` (indexed) means "the club stopped
+listing it" without claiming what became of it; statistics deliberately ignore it.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/` (`app/routes/_index.tsx`) | GET | public | Renders `DiscListPage`; no loader of its own. |
+| `/discs/data` (`app/routes/discs.data.tsx`) | GET | public (content varies by session) | The loader the page fetches: `{ clubId, data, pendingRetrievals, distinctDiscNames, distinctCourses, emptyingLogItems }`. |
+| `/discs/course` (`app/routes/discs.course.tsx`) | POST | admin (`requireAdminJson`) | Sets or clears one disc's course from the row action; course must be one of `getDiscCourseNames(APP_CLUB_ID)`. |
+
+## Rules & constraints
+- **Phone truncation happens server-side.** `PUBLIC_PHONE_DIGITS = 4`; the digits an anonymous visitor never receives cannot be read out of the payload.
+- **`externalId` is stripped for anonymous visitors** in `loadDiscListData`, and `DiscTable` renders the checkbox/action columns only when `session.user.id` exists (read from the root outlet context). Both must hold: the columns key off the session, the data off the loader.
+- **`additional_info` is never selected** for an anonymous request, rather than selected and dropped.
+- **Club scoping is from `APP_CLUB_ID`**, never from the request.
+- **The course filter has two gates**: the club must have >1 configured `discCourseName` (`getDiscCourseNames`) *and* the loaded discs must name >1 distinct course. The `Rata` column follows the first gate only.
+- Row selection is keyed on `external_id` (`getRowId`), so a tick survives re-sorting; rows without one cannot be selected. There is deliberately **no select-all** — only a clear-selection checkbox.
+- `getDistinctCourses` sorts with the `fi` collator and drops discs with no course, so those appear only under "Kaikki radat".
+
+## Edge cases & known gaps
+- The phone search filters on whatever the DTO holds, so for an anonymous visitor only a suffix of ≤4 digits can ever match, while the field's own label says "4 viimeistä". A signed-in admin matches against the full number, so the same input can give different results to the two audiences.
+- The search fires from 3 characters, not 4, despite the label.
+- `getDistinctDiscNames` dedupes case-insensitively but keeps the first spelling seen; the filter then compares `discName` with `===`, so discs whose name differs only in case are unreachable through the combobox.
+- The list is ordered `disc_name` ascending by the DB but immediately re-sorted client-side by `addedAt desc`, so the SQL `ORDER BY` only affects the row numbering (`#` is the array index at map time, not a stable id).
+- The `#` column therefore renumbers on every filter or reload; it is a display counter, not an identifier.
+- The disc-name filter is exact-match, not substring.
+- Everything is loaded and filtered client-side — there is no pagination and no server-side search.
+- `DiscListIntro` warns that a disc's state may be wrong, i.e. the list can show a disc the club no longer holds.
+
+## Open questions
+- CDN caching of `/discs/data` is designed but **not implemented** (`docs/caching-the-public-disc-list.md`, deferred 2026-08-30). The blocker recorded there: the same URL serves two payloads (with and without `externalId`) and Vercel's edge cache does not vary on `Cookie`, so a cached anonymous copy would silently strip an admin's action buttons.

--- a/specs/02-disc-submission.md
+++ b/specs/02-disc-submission.md
@@ -1,0 +1,105 @@
+# Disc submission (adding discs)
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+Lets a club admin empty a bin of found discs into the database by typing one
+free-text line per disc — "Star Destroyer punainen 050 123 4567 Steve D." — with
+a parser splitting that line into mould, plastic, colour, manufacturer, phone
+number and owner. Replaces typing seven fields per disc, and replaces the Google
+Sheet as the entry point for discs found by the club itself.
+
+## Actors
+- **Club admin** (signed in). `/discs/add` redirects to `/sign-in` otherwise, and `/discs/create` refuses with 401.
+
+## User-facing behaviour
+1. When the admin types a line into "Kiekon tiedot" (disc details) and presses Enter, `parseDiscText` runs and a row is appended to the draft table; the field clears for the next disc.
+2. When the club records courses, a "Rata" radio row offers each course plus "Ei radan tietoa" (no course info); the choice applies to rows added **from then on**, never to what was typed. A "Aseta rata ... kaikille riveille" / "Poista rata kaikilta riveiltä" button retro-fits the whole draft.
+3. When some rows lack a course, a quiet `role="status"` reminder counts them. It never blocks saving.
+4. When the parser had to choose between two makers (`confidence.manufacturer === 'low'`), the Valmistaja cell is flagged with "?" and "Valmistaja on epävarma – tarkista.".
+5. When a word could not be placed, it appears in the "Ohitettu" (skipped) column, so a typo is visible rather than silently lost.
+6. When any cell is clicked, it becomes an input: Enter or blur commits, Esc cancels. Editing Valmistaja by hand raises its confidence to `high` and clears the flag.
+7. When a row's delete icon is pressed, an inline "Poistetaanko?" yes/no replaces it. "Tyhjennä välimuisti" (clear cache) drops the whole draft, also behind a confirm.
+8. When "Tallenna kiekot" (save discs) is pressed, the batch is POSTed to `/discs/create`; on success the page shows "Tallennettu. N kiekkoa lisättiin." and the draft — memory and localStorage — is cleared.
+9. When the page is reloaded before saving, the draft comes back from localStorage.
+
+## What the parser recognises, in order
+`app/features/discs/submission/parser/parseDiscText.ts`:
+
+1. **Note** — everything after the **first** `|` is `additionalInfo`, kept verbatim and never tokenized. A later `|` belongs to the note; a blank note is `null`.
+2. **Phone number** — regex `(?:\+|\b0)[\d\s-]{5,}\d`, 7–15 digits, spaces/hyphens removed, leading `+` kept. Requiring a leading `0`/`+` keeps "Mako3" and a weight like "175" out. The match is blanked from the text before tokenizing.
+3. **Segmentation** — longest-first n-gram lookup against the dictionary, so "Active Premium" beats "Active" and "Keltainen, musta halo" beats "Keltainen". `normalize` lowercases and drops `,`, `.` and `°`; hyphens and digits are kept ("S-Line", "DD3").
+4. **Finnish genitive makers** — a span that does not match directly is retried through `resolveManufacturer`: suffixes `:n`, `in`, `n` stripped, then a first-word match ("Innovan", "Latitude 64:n", "Westsiden"). Irregulars ("Prodiscuksen", "Thought Spacen") live in `aliases.ts`.
+5. **Unknown-disc phrase** — a "Tuntematon" marker grows outwards over adjacent manufacturer and disc-type words ("kiekko", "draiveri", "väylädraiveri", "midari", "putteri"); the whole phrase becomes the disc name verbatim and the maker inside it is still reported.
+6. **Slot assignment** — unambiguous spans claim their slot first (`discName`, `plastic`, `colour`, `manufacturer`), then ambiguous ones take the first free slot in that order. This is what makes "Eclipse Wave" a plastic followed by a disc name.
+7. **Manufacturer inference** — stated outright ⇒ `high` (and it wins even against a disagreeing disc name); disc name and plastic agreeing ⇒ `high`; several agreeing ⇒ `medium`; disagreeing ⇒ disc name wins at `low`; one signal only ⇒ `medium`, or `low` if that word names several makers; nothing ⇒ `none`.
+8. **Leftovers** — remaining tokens starting with an uppercase letter become `ownerName` (joined by spaces); the rest go to `unmatched`. A lower-case name is missed rather than guessed at. This relies on the established convention that the owner name is never interleaved between disc-property words.
+
+The dictionary (`dictionary.ts`) is built eagerly from `parser/data/*.json` (23
+vendored manufacturer files: disc names + plastics), plus `discColors.ts`,
+`vocabulary.ts` (the unknown marker and disc types) and `aliases.ts`. A term that
+is both a disc name and a plastic keeps every candidate so ambiguity is reported,
+not guessed. Data files stay a straight copy of upstream; additions go in
+`aliases.ts`.
+
+## Data
+Rows are inserted into `public.discs` by `createDiscs` / `toInsertRows`
+(`app/models/discs.server.ts`):
+
+| Column | Value on a web-added disc |
+|---|---|
+| `external_id` | uuid generated in the app (not by the column default), so the caller learns the ids without a second round trip. |
+| `internal_disc_id` | **NULL** — no Google Sheet row. `syncNewDiscs` uses `max(internal_disc_id)`, which ignores NULLs, so these cannot shadow the import. |
+| `club_id` | `APP_CLUB_ID`, never from the request. |
+| `disc_name` | `"<mould>, <plastic>"` (`toDiscName`) — the shape the sheet has always used, so the public list's name filter keeps working. |
+| `disc_colour` | `''` when unparsed (not NULL). |
+| `disc_manufacturer`, `owner_name`, `owner_phone_number`, `course`, `additional_info` | As parsed/edited; `undefined` keys are dropped before insert. |
+| `added_at` | Today (`y-MM-dd`) unless the DTO carries one. |
+| `is_returned_to_owner`, `can_be_sold_or_donated` | `false`. |
+| `id`, `created_at`, `updated_at`, `owner_link_token` | Left to the database. |
+
+Disc weight is deliberately not a field — it lands in the free-text note if
+written at all.
+
+Draft storage: `localStorage` key `lost-and-found:disc-draft:v1`, holding
+`ParsedDisc & { id, input, course }` rows. A module-level array is the source of
+truth, read through `useSyncExternalStore` (the server snapshot is always empty,
+so a restore causes no hydration mismatch); localStorage is a best-effort mirror.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/discs/add` (`app/routes/discs.add.tsx`) | GET | admin; redirects to `/sign-in` | Renders `AddDiscsPage`; loader supplies `getDiscCourseNames(APP_CLUB_ID)`. Linked from `AdminMenu` as "Lisää kiekkoja". |
+| `/discs/create` (`app/routes/discs.create.tsx`) | POST JSON | admin (`requireAdminJson`) | Resource route (no default export) that validates and inserts the batch; answers `{ savedCount, externalIds }` or `{ error }`. |
+
+`/discs/create` is a resource route rather than an action on `/discs/add`
+because a plain `fetch` POST to a page route is a document request and would be
+answered with rendered HTML.
+
+## Rules & constraints
+- Server-side validation in `parseBatch` (`toDiscDTO.ts`), which trusts nothing about the body:
+  - body must be `{ discs: [...] }`, non-empty, at most `MAX_BATCH_SIZE = 100`.
+  - each of the 8 known fields must be a string or nullish; blanks are trimmed to `null`.
+  - length caps: 200 chars, except `additionalInfo` at 500.
+  - `course` must be one of this club's `getDiscCourseNames`, or absent — a stray value would become a phantom option in the public list's course filter.
+  - a row with neither disc name nor plastic is rejected ("kiekolla on oltava nimi tai muovi").
+  - errors are Finnish, row-numbered, and returned as HTTP 422.
+- `requireAdminJson` enforces POST-only (405), a live session (401) and a parseable JSON body (400).
+- The client never sends a club id; `handleCreateRequest` reads `APP_CLUB_ID`.
+- The course is never read out of the typed text — the radio selection is its only source, and the Rata cell is not editable.
+- There is no autocomplete on the entry field; the dictionary is used for parsing only.
+- `submitDiscs` never throws: a dropped connection or a non-JSON response comes back as an error result, and a 2xx without a numeric `savedCount` is treated as a failure.
+- `draftStorage.toDraftRow` re-validates every restored field, because localStorage survives a deploy that changes the row shape and is writable by anything on the origin.
+
+## Edge cases & known gaps
+- A browser that blocks site data still works; it just loses the draft on refresh.
+- A partially failed insert has no partial reporting — `createDiscs` inserts the batch in one statement and throws on error.
+- `additionalInfo` is parsed as a note but there is no length check client-side; a >500-char note is only rejected by the server, after the admin has typed it.
+- The parser has no confidence signal for anything but the manufacturer, and only `low` is surfaced (`medium` fires on about half of all entries, so showing it would be noise).
+- An owner name written in lower case is dropped into `unmatched` rather than the owner field.
+- A second disc name, plastic or colour in one line is discarded into `unmatched` (the slot is already taken).
+- `disc_colour` is stored as `''` rather than NULL when no colour was recognised, unlike every other unparsed field.
+- Nothing deduplicates: the same disc typed twice is inserted twice.
+
+## Open questions
+None recorded.

--- a/specs/03-disc-lifecycle-actions.md
+++ b/specs/03-disc-lifecycle-actions.md
@@ -1,0 +1,184 @@
+# Disc lifecycle actions
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+Once a disc is in the club's inventory, an admin records what became of it: it went back
+to its owner, it was released for sale or donation, it was filed under the wrong course,
+or it was entered by mistake. Talin Tallaajat additionally keeps a *noutolista*
+("retrieval list") of discs that have to be fetched out of the club's storage before an
+owner can get them.
+
+## Actors
+- **Club admin** (signed in) — the only actor. Every action below is behind
+  `requireAdminJson` or an `isUserLoggedIn` check.
+- No anonymous or cron path writes any of these.
+
+## Disc state model
+
+A disc's state is not one column. It is the combination of three flags/timestamps on
+`discs` plus the presence of an open row in `disc_retrievals`.
+
+| State | How it is stored | Public list shows it? |
+|---|---|---|
+| Listed (default) | `is_returned_to_owner = false`, `can_be_sold_or_donated = false`, `archived_at IS NULL` | yes |
+| Returned to owner | `is_returned_to_owner = true` + `returned_to_owner_date` + `return_method` | no |
+| Released for sale/donation | `can_be_sold_or_donated = true` + `can_be_sold_or_donated_date` + `can_be_sold_or_donated_method` | no |
+| Archived | `archived_at` set | no |
+| Deleted | row gone (`disc_retrievals` cascades) | no |
+| On the retrieval list | orthogonal: an open `disc_retrievals` row (`retrieved_at IS NULL`) on a *listed* disc | yes, with an extra icon |
+
+Transitions:
+
+```
+                    +-- mark returned ---> Returned  (terminal in the UI)
+                    |
+   Listed ----------+-- mark disposal ---> Released  (terminal in the UI)
+     |  ^           |
+     |  |           +-- delete ----------> gone
+     |  |
+     |  +-- (manual SQL) archived_at cleared
+     +----- (archive:discs script) archived_at set -----> Archived
+
+   Listed --- request retrieval ---> on retrieval list (open row)
+                  ^        |
+                  |        +-- change method (updates the same open row)
+                  |        |
+                  |        +-- "Merkitse noudetuksi" --> retrieved_at set, row closes
+                  |
+                  +-- a later request inserts a NEW row (history keeps both)
+
+   Marking a listed disc returned / released / archived silently drops any
+   open retrieval row off the list (it is filtered out, never closed).
+```
+
+Course is not a state; `setDiscCourse` can run in any state.
+
+## User-facing behaviour
+1. When an admin clicks the return icon on a disc row, an inline
+   "Merkitse palautetuksi" (mark as returned) form opens with today's date and optional
+   radios "Postitettu"/"Noudettu"; submitting sets the three return columns.
+2. When an admin clicks the sale icon, "Merkitse myytäväksi tai lahjoitettavaksi"
+   (mark for sale or donation) opens with the same shape and radios
+   "Myydään"/"Lahjoitetaan".
+3. When an admin clicks the delete icon, `window.confirm`
+   "Poistetaanko kiekko X (owner)? Poistoa ei voi peruuttaa." precedes a hard delete.
+4. When a club has courses configured, a course icon opens `CourseForm`; "Ei rataa"
+   (no course) is a real option that clears `discs.course`.
+5. When the club is Talin Tallaajat, a storage icon opens `RetrievalMethodForm`; the
+   method is **required** ("Postitus"/"Nouto (minulta)"). The icon turns orange once the
+   disc is on the list, and reopening the form preselects the current method.
+6. When an admin opens `/retrieval`, "Noutolista" lists the pending errands oldest first
+   as phone-sized cards: colour + name, date entered, method, request date, a `tel:` link
+   and the owner's name. "Merkitse noudetuksi" (mark as fetched), behind a confirm, closes
+   the row.
+7. When the retrieval list has pending rows, the admin menu item shows the count
+   (`loadRetrievalCount.server.ts`); the item is absent entirely for other clubs.
+
+## Data
+
+`discs` columns this feature owns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `is_returned_to_owner` | bool | set by the return mark |
+| `returned_to_owner_date` | date | |
+| `return_method` | smallint, nullable | CHECK in (0,1); nullable = "unanswered" |
+| `can_be_sold_or_donated` | bool | set by the disposal mark |
+| `can_be_sold_or_donated_date` | date | |
+| `can_be_sold_or_donated_method` | smallint, nullable | CHECK in (0,1) |
+| `can_be_sold_or_donated_text` | text | legacy free text from the Sheet; never written by these actions |
+| `archived_at` | timestamptz, nullable | "club stopped listing it", indexed; stats ignore it |
+| `course` | text, nullable | |
+
+`disc_retrievals` (`20260903000000_disc_retrievals.sql`) — one row per errand, deliberately
+not columns on `discs`:
+
+- `disc_id BIGINT` FK to `discs.id` `ON DELETE CASCADE` (numeric id, not `external_id`)
+- `requested_at`, `retrieved_at` (nullable — NULL is what puts the row on the list)
+- `retrieval_method SMALLINT NOT NULL`, CHECK in (0,1)
+- CHECK `retrieved_at >= requested_at`; partial UNIQUE index on `disc_id WHERE retrieved_at IS NULL`
+- RLS: `authenticated` only, all four verbs; nothing for `anon`
+- `requested_by` existed in the original migration and was dropped again in
+  `20260904010000_owner_link_club_scope.sql` — provenance lives in `disc_owner_responses`.
+
+### Three distinct method enums
+
+| Enum | Where stored | Values | Labels |
+|---|---|---|---|
+| `ReturnMethod` (`return/returnMethod.ts`) | `discs.return_method` | 0, 1 | "Postitettu", "Noudettu" (past tense — what happened) |
+| `DisposalMethod` (`disposal/disposalMethod.ts`) | `discs.can_be_sold_or_donated_method` | 0, 1 | "Myydään", "Lahjoitetaan" |
+| `RetrievalMethod` (`retrieval/retrievalMethod.ts`) | `disc_retrievals.retrieval_method` | 0, 1 | "Postitus", "Nouto (minulta)" (what was asked for) |
+
+`RetrievalMethod` is **not its own enum**: it is `HandoverMethod`
+(`app/features/discs/handoverMethod.ts`, values 0 `ByMail` / 1 `PickedUpFromHome` /
+2 `PickedUpFromStorage`) narrowed to `FETCHING_HANDOVER_METHODS` — the two that require a
+trip to storage. `PickedUpFromStorage` (2) is rejected by `isRetrievalMethod` and by the DB
+CHECK. All three enums are built by `app/lib/methodEnum.ts`; the numbers are persisted, so
+add, never renumber, and extend the CHECK alongside.
+
+## Routes & entry points
+
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/discs/return` | POST JSON | admin | `{externalId, returnedToOwnerDate, returnMethod\|null}` → `{returned:true}` |
+| `/discs/disposal` | POST JSON | admin | `{externalId, canBeSoldOrDonatedDate, canBeSoldOrDonatedMethod\|null}` → `{marked:true}` |
+| `/discs/delete` | POST JSON | admin | `{externalId}` → `{deleted:true}` |
+| `/discs/course` | POST JSON | admin | `{externalId, course\|null}` → `{marked:true}` |
+| `/discs/retrieval` | POST JSON | admin + Talin only | `{externalId, retrievalMethod}` → `{onRetrievalList:true}` |
+| `/retrieval` | GET | signed in + Talin only | the "Noutolista" page |
+| `/retrieval` | POST form | signed in + Talin only | `externalId` → closes the open row, revalidates |
+
+All five JSON routes are resource routes (no component) delegating to a
+`handle*Request.server.ts`.
+
+## Rules & constraints
+- `requireAdminJson`: POST only (405), signed in (401), parseable JSON (400).
+- `isExternalId` is a strict uuid regex; `isIsoDate` rejects `2026-02-30`.
+- Return and disposal methods are **optional** (`null` allowed, and clearable). The
+  retrieval method is **required** — a list line that does not say post-or-hand-over sends
+  the admin back to the SMS thread.
+- Course is validated against `getDiscCourseNames(APP_CLUB_ID)`; an unknown name is a 422
+  `Tuntematon rata "X".` so it cannot leak into the list page's course filter.
+- Every write is scoped to `APP_CLUB_ID`: the disc updates/deletes add `.eq('club_id', …)`,
+  and every `disc_retrievals` write resolves `external_id → id` through
+  `queryDiscIdByExternalId.server.ts`, which carries the club filter.
+- `updateDisc` distinguishes `not-found` (404) from `not-permitted` (403) by re-selecting
+  the row: RLS refuses an UPDATE by filtering, not by raising. `markRefusal` maps both.
+- `queryPendingRetrievals.server.ts` is the single filter chain behind the page, the menu
+  count and the row icons: open row **and** disc still listed (not returned, not released,
+  not archived), club-scoped through the `discs!inner` join.
+- The retrieval list is gated by `isRetrievalListEnabled()` in `app/config/clubs.ts` —
+  hardcoded `currentClubId() === TALIN_TALLAAJAT` — checked in the loader, the action and
+  the list loader, not only in the UI.
+- Dates are formatted in the browser (`format(new Date(), 'y-MM-dd')`), because the server
+  runs in UTC and a Finnish evening is already the next day there.
+
+## Edge cases & known gaps
+- **Archiving has no UI.** `archived_at` is read by `getDiscs`, the owner-link loader
+  and the retrieval filter, and mapped by `DiscMapper`, but no route or action writes it.
+  It is set by the maintenance script `scripts/archiveStaleDiscs.ts`
+  (`npm run archive:discs`), which archives unresolved discs added before a cutoff.
+  Clearing it (putting a disc back on the list) is a manual SQL update.
+- No transition is reversible from the UI: nothing clears `is_returned_to_owner`,
+  `can_be_sold_or_donated` or `archived_at`. A wrong mark is fixed in SQL.
+- Two maintenance scripts sit outside the UI entirely and are the only writers of their
+  columns: `npm run archive:discs` and `npm run import:puskasoturit` (spec 09).
+- The return mark does *not* close an open retrieval row. The row stays in the table with
+  `retrieved_at IS NULL` for ever; it merely stops being *pending* because the disc is no
+  longer listed. Retrieval-duration statistics computed later would see these as open.
+- `queryCompleteRetrieval` reports `done` for a disc with no open request, so a double tap
+  on "Merkitse noudetuksi" is not an error.
+- `handleRetrievedRequest` returns `null` for a disc from another club: the club filter
+  lives in `queryDiscIdByExternalId`, and a `not-found` outcome is discarded.
+- `queryRetrievalList` falls back to `RetrievalMethod.PickedUp` for an out-of-range
+  smallint — a wasted trip rather than a wasted stamp.
+- Two sources of truth for "this club stores discs offsite": `isRetrievalListEnabled()`
+  hardcodes club 2 in TypeScript, while `clubs.stores_discs_offsite` (set for club 2 in
+  `20260903010000_owner_responses.sql`) says the same thing in SQL for the owner-link
+  functions. They can drift.
+- The delete is a hard delete; `disc_retrievals` cascades, message log rows do not go with it.
+
+## Open questions
+- Whether a return mark should close the open retrieval row rather than let it be
+  filtered out.

--- a/specs/04-batch-operations.md
+++ b/specs/04-batch-operations.md
@@ -1,0 +1,124 @@
+# Batch operations
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+An admin clearing out the club's disc bin marks a dozen discs the same way at once
+instead of opening a form per row. Discs are ticked in the disc list, one action is
+picked from a dropdown above the table, and it is applied to the whole selection in a
+single request.
+
+## Actors
+- **Club admin** (signed in). The select column and the external ids the selection is
+  keyed on are only sent to a signed-in visitor.
+
+## User-facing behaviour
+1. When an admin is signed in, the disc table grows a leading checkbox column
+   (`app/features/discs/list/DiscTable.tsx`); ticking rows reveals the action bar
+   `SelectedDiscsActions.tsx`, which reads "N kiekkoa valittu" (N discs selected).
+2. When rows are ticked, the header cell becomes a single checked box,
+   "Poista kaikkien kiekkojen valinta" (clear all selection). There is deliberately **no
+   select-all**.
+3. When the admin picks an action and presses "Suorita" (run), `window.confirm` states
+   what will happen and to how many — e.g. "Poistetaanko 12 kiekkoa? Poistoa ei voi
+   peruuttaa."
+4. When the write returns, the bar reports it — "Poistettiin 12 kiekkoa." — the ticks
+   clear and the list reloads. The report survives one more render with an empty
+   selection so it does not vanish with the ticks.
+5. When fewer discs were reached than asked for, the report names the shortfall:
+   "Poistettiin 10 kiekkoa. 2 kiekkoa jäi käsittelemättä – kiekkoja ei löytynyt tai niitä
+   ei voitu muuttaa."
+6. When more than 20 discs are ticked, the write actions leave the dropdown and a note
+   explains why: "Merkintä ja poisto koskevat enintään 20 kiekkoa kerralla – valitse
+   pienempi joukko." The selection itself is not capped.
+7. When some ticked discs have no phone number, "Lähetä sms N henkilölle" (send SMS to N
+   people) counts only those that do, and a note says how many fall outside the message.
+
+## The five batch actions
+`app/features/discs/batch/batchAction.ts` holds one row per action — label, confirm
+wording, past-tense wording, and what it writes — so the three tenses cannot drift apart
+and the smallint mapping is declared once.
+
+| Action | Dropdown label | Writes |
+|---|---|---|
+| `returnByMail` | "Merkitse palautetuiksi (postitettu)" | return columns, `ReturnMethod.ByMail` |
+| `returnPickedUp` | "Merkitse palautetuiksi (noudettu)" | return columns, `ReturnMethod.PickedUp` |
+| `sell` | "Merkitse myytäviksi" | disposal columns, `DisposalMethod.Sold` |
+| `donate` | "Merkitse lahjoitettaviksi" | disposal columns, `DisposalMethod.Donated` |
+| `delete` | "Poista" | nothing — hard delete, and the only action needing no date |
+
+Dropdown order is `['message', returnByMail, returnPickedUp, sell, donate, delete]`.
+
+**`message` is not a batch action.** It is a sixth dropdown entry that navigates to
+`/message/send-batch?ids=…` — a walk through the owners one at a time. `isBatchAction`
+rejects it, along with the pre-method names `'return'` and `'disposal'`.
+
+Neither batch mark asks for a method in a second step: the action name already carries it.
+The single-disc forms still ask, because there the method may be left unanswered.
+
+## Data
+No tables of its own. It writes exactly the columns the single-disc marks write, through
+the shared `returnPatch` / `disposalPatch` helpers in `app/models/discs.server.ts`:
+`is_returned_to_owner` + date + `return_method`, or `can_be_sold_or_donated` + date +
+`can_be_sold_or_donated_method`. `deleteDiscs` is a hard delete.
+
+## Routes & entry points
+
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/discs/batch` | POST JSON | admin | `{action, externalIds[], date?}` → `{affected: number}` |
+
+Client: `runBatchAction.ts` posts it; `useBatchAction.ts` owns the confirm → request →
+report state machine; `SelectedDiscsActions.tsx` renders the bar.
+
+## Rules & constraints
+- `requireAdminJson` first: POST only (405), signed in (401), parseable JSON (400).
+- `action` must be one of the five (`isBatchAction`) else 422 "Tuntematon toimenpide."
+- `externalIds` must be a non-empty array of valid uuids (`isExternalId` on every element)
+  else 422 "Virheellinen kiekkojen tunnistelista."
+- The array is **deduplicated** (`new Set`) before the size check and before the write, so
+  the reported count stands for discs, not for repeated ids.
+- `MAX_DISCS_PER_WRITE = 20`, checked *after* dedup: 422 "Yhdellä kertaa voi käsitellä
+  enintään 20 kiekkoa." Enforced twice — the dropdown withholds the actions, and the route
+  refuses regardless, since the list is not the only thing that can post.
+- The cap is on the write, not on the selection or on messaging, which writes nothing.
+- `date` is required for the four marks (`isIsoDate`, so `2026-02-30` is rejected), and is
+  omitted for `delete`. It is today's date taken from the **browser**, because the server
+  runs in UTC.
+- Messaging has its own separate bound: the ids ride in the query string, and
+  `MAX_HREF_LENGTH = 6000` guards against a 431 before app code runs. With the 20-disc cap
+  this is a backstop.
+- Every model call is scoped to `APP_CLUB_ID` (`.eq('club_id', clubId)`), so an id from
+  another club is simply not among the rows affected.
+- `runBatchAction` treats a 200 without a numeric `affected` as an error: the route reports
+  a count on every success path.
+- `handleRun` re-checks that the chosen action is still in the dropdown — one more tick can
+  push the selection past the cap between choosing and pressing.
+
+## Partial failure
+There is none in the transactional sense. Each action is a single Supabase statement
+(`.update(...).in('external_id', ids)` or `.delete().in(...)`), so it either raises — 500,
+nothing reported as done — or succeeds and returns the rows it touched.
+
+`updateDiscs` / `deleteDiscs` return `data?.length ?? 0`. A shortfall means some ids did
+not resolve (unknown, another club's, already deleted) **or** RLS filtered the update out;
+the batch path deliberately does not tell those apart, unlike the single-disc `updateDisc`
+which re-selects to distinguish `not-found` from `not-permitted`. `batchActionOutcome`
+reports the shortfall without calling it an error.
+
+## Edge cases & known gaps
+- A shortfall is unattributed: the admin is told two discs were missed, never which two.
+- No batch course change and no batch retrieval-list action — those are single-disc only.
+- Rows without an `externalId` (anonymous loader payload) cannot be selected
+  (`enableRowSelection`), and `getRowId` falls back to `row-<id>` for them.
+- The dedup means posting the same id 25 times is accepted, not rejected as oversized.
+- `batchAction.test.ts` pins the smallint mapping against the *labels* rather than the
+  numbers, because nothing in the UI shows the stored number — an inverted sell/donate or
+  posted/collected mapping would otherwise be invisible. It also asserts that `delete` is
+  the only action with no mark.
+- Nothing tests `handleBatchRequest.server.ts` itself; the validation branches (dedup, cap,
+  missing date) are covered only by reading.
+- The confirmation names no discs — the selection is behind the dialog on screen.
+
+## Open questions
+None.

--- a/specs/05-owner-link-and-responses.md
+++ b/specs/05-owner-link-and-responses.md
@@ -1,0 +1,170 @@
+# Owner link & owner responses
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+An owner who gets an sms about a lost disc answers in one tap, instead of the
+admin reading a free-text reply and writing it down. The link in the message
+opens a page for that one disc where the owner says whether they want it back
+and how, and gives a postal address if it is to be posted. Answers land in the
+admin's inbox at `/vastaukset`. Background: `docs/getting-a-disc-back-to-its-owner.md`.
+
+## Actors
+- **Anonymous owner** — holds the link from the sms. No account, no login.
+- **Club admin** — signed in, reads and clears the inbox.
+
+## User-facing behaviour
+1. Owner opens `/kiekko/<token>` → sees colour, disc name, manufacturer and the
+   last four digits of their phone number ("Puhelinnumero ****1234"), under
+   "Löytynyt kiekkosi" (your found disc).
+2. Owner picks "Kyllä, haluan kiekon takaisin" (yes, I want it back) or "Ei,
+   seura saa pitää kiekon" (no, the club may keep it).
+3. Choosing "yes" opens the handover options the disc's *location* allows —
+   "Postita kiekko minulle", "Noudan kiekon – sovitaan noudosta erikseen",
+   "Noudan kiekon seuran kopilta" (post it / I'll collect it / I'll collect it
+   from the club's koppi).
+4. Choosing post shows the postage fee, the MobilePay payee, the club's optional
+   voluntary payment, and the five address fields; submitting stores them.
+5. Ticking "Minulla on useampia kiekkoja" (I have several discs) unmounts the
+   address fields — the answer is submitted with no address and the page says
+   the club will be in touch.
+6. Collecting from the admin names only the district ("Kiekon voi noutaa Espoon
+   Lintuvaarasta") and promises a message; collecting from the koppi asks
+   nothing further.
+7. After a submit: "Kiitos vastauksesta!" plus a link back to the same page —
+   answering again is how a choice or a typo is changed.
+8. A token that is unknown, malformed, belongs to another club, or names a disc
+   already returned / released / archived → "Linkki ei ole enää käytössä" (this
+   link is no longer in use), with the club's contact email. Same screen for all
+   of them, so a guess learns nothing.
+9. Admin opens `/vastaukset` ("Omistajien vastaukset") → unhandled answers,
+   newest first: disc, choice, method, owner name, tappable phone number, the
+   address if there is one. "Merkitse käsitellyksi" (mark as handled) asks for
+   confirmation, removes the card and **wipes the address**.
+10. The admin menu item reads "Vastaukset (3)" while answers are unhandled; the
+    count disappears at zero and the item is absent when signed out.
+
+## Data
+**`discs.owner_link_token uuid`** — NOT NULL, unique, `default gen_random_uuid()`,
+backfilled. Deliberately *not* `external_id`: this is a credential and can be
+rotated with one UPDATE to kill every link already sent.
+
+**`disc_owner_responses`** — one row per answer, append-only in practice; the
+latest row wins.
+
+| Column | Notes |
+|---|---|
+| `disc_id` | FK to `discs`, ON DELETE CASCADE |
+| `responded_at` | default `now()` |
+| `choice` | 0 = gives the disc up, 1 = wants it back (`app/features/discs/ownerResponse/ownerChoice.ts`) |
+| `handover_method` | 0 post, 1 collect from admin, 2 collect from koppi; NULL iff `choice = 0` |
+| `has_more_discs` | boolean, only ever true for post |
+| `shipping_name / _street / _postal_code / _city / _country` | nullable; only for post. NULL country means Finland |
+| `shipping_cleared_at` | when the address was wiped |
+| `handled_at` | NULL = still in the inbox; drives the menu count |
+
+**`clubs.stores_discs_offsite`** — boolean, true for club 2 (Talin Tallaajat).
+What `disc_is_in_storage()` reads.
+
+CHECK constraints: choice in (0,1); method in (0,1,2) or NULL; `(choice = 1) =
+(handover_method IS NOT NULL)`; post ⇒ street **or** wiped **or**
+`has_more_discs`; an address only ever with post; `has_more_discs` only with
+post; and the address length limits below.
+
+Not enforced by the schema: nothing stops two answers for one disc (deliberate),
+and nothing turns an answer into a `disc_retrievals` row or a `discs` update —
+the admin acts by hand.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/kiekko/:token` | GET, POST | none — the token is the permission | The owner's page and its submit |
+| `/vastaukset` | GET, POST | signed in (redirect `/sign-in`) | The inbox; POST marks one answer handled |
+
+`GET /kiekko/:token` sends `Referrer-Policy: no-referrer` and
+`X-Robots-Tag: noindex, nofollow` so the token leaks into neither a `Referer`
+header nor a search index.
+
+Database entry points, both `SECURITY DEFINER`, `REVOKE ALL FROM PUBLIC` and
+`GRANT EXECUTE ... TO anon, authenticated`:
+
+- `owner_link_disc(p_token uuid, p_club_id bigint)` — returns name, colour,
+  manufacturer, the last four **digits** of the phone number (separators
+  stripped first), and `in_storage`. No row for a returned / released / archived
+  disc, or one of another club.
+- `submit_owner_response(p_token, p_club_id, p_choice, p_handover_method,
+  five address params, p_has_more_discs)` — inserts one row; every failure
+  raises the same `unknown token`.
+
+`disc_is_in_storage(bigint)` is revoked from PUBLIC and granted to nobody; it is
+only called from inside those two.
+
+## Rules & constraints
+- **The link is the whole permission.** No expiry — an owner may answer weeks
+  later. Its power ends with the disc's state instead: returned, released or
+  archived and the page stops working.
+- **`anon` has no policy at all on `disc_owner_responses`** (`docs/rls.md`).
+  `SUPABASE_KEY` is the anon key and is in every page's source, so an INSERT
+  policy would let anyone spray answers at enumerable `disc_id`s. The one way in
+  is the function, which resolves the token itself.
+- **Club scoping.** Both clubs share one database; each deployment passes its
+  own `APP_CLUB_ID` as `p_club_id`, so a Talin token opened on the Puskasoturit
+  deployment is simply not found. Every admin query joins `discs!inner` and
+  filters `club_id`.
+- **The page never renders a stored address back.** A forwarded link must not
+  read out someone's home address; a typo is fixed by answering again.
+- **Handover options come from the disc's location, not its club.**
+  `handoverMethodsFor(isInStorage)` adds method 2 only while
+  `disc_is_in_storage()` is true. Enforced three times: the page renders only
+  the allowed options, `parseOwnerResponse` refuses a method outside `allowed`,
+  and `submit_owner_response` refuses method 2 for a disc not in storage.
+- **Address length limits, in three places, and the DB one is the boundary.**
+
+  | Field | Max | Client label |
+  |---|---|---|
+  | `shippingName` | 100 | Nimi |
+  | `shippingStreet` | 150 | Katuosoite |
+  | `shippingPostalCode` | 16 | Postinumero |
+  | `shippingCity` | 60 | Postitoimipaikka |
+  | `shippingCountry` | 60 | Maa |
+
+  `ADDRESS_LIMITS` in `app/features/discs/ownerResponse/parseOwnerResponse.ts`
+  supplies both the input `maxLength` (stops typing) and the server-side check
+  (names the offending line: "Katuosoite on liian pitkä – enintään 150
+  merkkiä."). Neither is the boundary: `submit_owner_response()` is granted to
+  `anon`, so a token holder can call it directly with the public anon key and
+  never pass through the parser. The `owner_response_address_lengths` CHECK from
+  `20260904020000_owner_response_address_limits.sql` is what an anonymous caller
+  cannot get around. Change all three together.
+- Length is measured after trimming. A posting requires name, street, postal
+  code and city; country is optional. A Finnish postal code (country empty,
+  "suomi", "finland" or "fi") must be exactly five digits; anywhere else any
+  non-empty value passes.
+- The signed-in inbox is the only place that reads a full phone number or an
+  address. The menu count is a `head: true` count — it reads neither.
+
+## Edge cases & known gaps
+- **The address wipe fires on "marked handled", not on "posted"** — the only
+  event the app has. Marked too early and the label data is gone; never marked
+  and the address is kept indefinitely (open question 7 of the doc).
+- An answer changes nothing about the disc. Nothing on the public list shows
+  that an owner has answered, and a "gives it up" answer does not release the
+  disc — the admin still marks it.
+- `disc_is_in_storage()` is false as soon as *any* retrieval row has a
+  `retrieved_at`, and nothing records a disc going back. A disc fetched, not
+  collected and returned to the koppi reads as out of it for good.
+- The reverse race: an owner answers "I'll collect it from the koppi" and the
+  disc is fetched home afterwards. Their answer names a place the disc has left;
+  only the admin sees it.
+- Marking handled with an id from another club is a silent no-op — the read is
+  club-scoped and a missing row returns `not-found`, which the route ignores.
+- The inbox has no history view: a handled answer is gone from the UI, and only
+  unhandled rows are ever queried.
+- A row whose `choice` is outside the enum is dropped from the list rather than
+  rendered as a blank card.
+
+## Open questions
+Carried from `docs/getting-a-disc-back-to-its-owner.md`: when exactly a shipping
+address is wiped (7); whether the page hands out the admin's full address for a
+collection (6); whether the page lists an owner's other discs (8); whether an
+answer should ever create a retrieval row by itself (2, decided "no" for now).

--- a/specs/06-messaging-and-templates.md
+++ b/specs/06-messaging-and-templates.md
@@ -1,0 +1,154 @@
+# SMS messaging & message templates
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+Tells a lost disc's owner that it has been found. The admin composes a message
+from a reusable template, hands it to their own phone as an `sms:` link, and
+records that it was sent so the disc's row shows a history. There is no SMS
+gateway: the app never sends anything itself.
+
+## Actors
+- **Club admin** — signed in. The only actor; every route here is behind login.
+- The **owner** only receives the text, from the admin's own phone.
+
+## User-facing behaviour
+1. Admin clicks the message icon on a disc row → `/message/send/<externalId>`,
+   "Viestin luonti" (composing a message).
+2. The page seeds the phone number from the disc and the message body from the
+   club's default template; both stay editable.
+3. Picking another template from "Viestipohja" replaces the body.
+4. "Esikatselu" (preview) renders the body with tokens substituted and newlines
+   as `<br/>`, live as it is typed.
+5. "Lähetä tekstiviesti" (send sms) opens
+   `sms:<number>&body=<substituted message>` — the OS's own messaging app takes
+   over from there.
+6. "Merkitse viesti lähetetyksi" (mark the message as sent) posts the rendered
+   body to the route's action and writes a `message_log` row; the button then
+   reads "Lähetetty" and is disabled.
+7. Earlier messages for the same disc appear under "Lähetetyt viestit".
+8. "Peru" (cancel) leaves for the disc list.
+9. From a multi-disc selection, "Lähetä sms N henkilölle" opens
+   `/message/send-batch?ids=<uuid,uuid,…>` and the same composer is worked
+   through one owner at a time, with a "Kiekko 3 / 12" progress line. Recording
+   a send *or* cancelling moves on; the last one returns to the list.
+10. `/message-templates` ("Viestipohjat") lists this club's templates, the
+    default one outlined. Per template: "Merkitse oletukseksi" (make default),
+    "Muokkaa" (edit), "Poista" (delete, confirmed).
+11. `/message-template/create` and `/message-template/:id/edit` are a textarea
+    plus an "Oletusviestipohja" (default template) checkbox, with the token help
+    line above.
+
+## Data
+**`message_templates`** — `id`, `created_at`, `updated_at`, `club_id`,
+`content`, `is_default`. At most one default per club, kept by resetting every
+`is_default` for the club before setting the new one (no unique index enforces
+it). Mapped by `app/models/MessageTemplateMapper.ts` → `MessageTemplateDTO`.
+
+**`message_log`** — one row per "marked as sent".
+
+| Column | Notes |
+|---|---|
+| `id` | |
+| `sent_at` | written as the string `'now()'` |
+| `external_id` | uuid of the disc — the key since `20260902000000_message_log_external_id.sql`; nullable, indexed |
+| `internal_disc_id` | legacy Google Sheet row number; NOT NULL dropped, nothing writes it any more |
+| `club_id` | from `APP_CLUB_ID` |
+| `content` | the substituted body, newlines already converted to `<br/>` |
+
+Mapped by `app/models/MessageLogMapper.ts` → `MessageLogDTO`.
+
+**Why uuid-keyed:** `internal_disc_id` is a Sheet row number, so a web-added disc
+has none. Both the send page and its log were addressed by that id, which made
+web-added discs unmessageable. The migration backfilled `external_id` by joining
+on `(internal_disc_id, club_id)` — a Sheet row number is only unique within its
+club — and left the old column for the history it already holds.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/message/send/:externalId` | GET, POST | signed in | Compose for one disc; POST records the send |
+| `/message/send-batch?ids=…` | GET, POST | signed in | Compose for a selection; POST records one send |
+| `/message-templates` | GET, POST | signed in | List; POST is `action=delete` or `action=default` |
+| `/message-template/create` | GET, POST | **none in the route** — see gaps | Create a template |
+| `/message-template/:id/edit` | GET, POST | signed in on GET only | Edit a template |
+
+## Token grammar
+`replaceTokensWithValues(message, disc, baseUrl)` in
+`app/features/messaging/messageContent.ts`. Three tokens, literal square
+brackets, `replaceAll` so every occurrence is filled — not just the first.
+
+| Token | Substituted with | Empty case |
+|---|---|---|
+| `[colour]` | `disc.discColour` | empty string, not the literal token |
+| `[disc]` | `disc.discName` | empty string |
+| `[link]` | `<baseUrl>/kiekko/<owner_link_token>` | empty string when the disc has no token, rather than a url ending in "undefined" |
+
+There is no escaping and no other syntax; anything else is left alone.
+`baseUrl` is `new URL(request.url).origin` from the loader — read from the
+request, not `window.location`, so the server render and the browser's agree.
+The tokens are documented to the admin by
+`app/features/messaging/TemplateTokenHelp.tsx`, shown on both template forms.
+
+## Transport & configuration
+- **No SMS provider, no API key, no outbound HTTP.** The "send" button is an
+  `sms:` URI; the admin's phone or desktop OS sends the actual message.
+  Newlines become `%0a` in the `body` parameter (`convertLineBreaks`) and
+  grouping spaces are stripped from the number (`toDiallable`).
+- Postage details the message may refer to live in `app/config/shipping.ts`;
+  per-club payment and contact details in `app/config/clubs.ts`.
+- The only env vars this feature touches: `APP_CLUB_ID` (club scoping on every
+  template and log query) and the Supabase pair used by
+  `createSupabaseServerClient`.
+
+## Rules & constraints
+- Every template and log query filters `club_id = APP_CLUB_ID`; a template of
+  another club cannot be read, edited or deleted.
+- Batch selection (`sendBatchSelection.ts`): ids come from the `ids` query
+  parameter, split on commas, trimmed, uuid-validated, deduplicated, and kept
+  **in the order the admin saw them**. `MAX_BATCH_SIZE = 100`, because the
+  selection travels in a URL; a larger selection is reported ("Valitsit N
+  kiekkoa…") rather than quietly truncated. An empty selection redirects to `/`.
+- Discs without a phone number are dropped from the batch by
+  `SelectedDiscsActions`, not by the loader.
+- `/message/send/:externalId` validates the uuid before querying and 404s
+  ("Kiekkoa ei löytynyt.") on a malformed id or a disc this club does not have.
+- The composer is remounted with `key={disc.externalId}` in a batch — that is
+  what re-seeds the number, template and body for the next owner. The advance
+  callback is guarded by a ref so a re-render cannot skip an owner.
+- `recordMessageSent` re-validates the external id and posts the one from the
+  *loaded* disc, not from the URL.
+- Template content is required (`'Sisältö on pakollinen'`, 422); nothing else is
+  validated — length, tokens and markup are all free.
+- The batch loader fetches sent history only for the discs actually found, in
+  one `in()` query rather than one per disc.
+
+## Edge cases & known gaps
+- **`/message-template/create` has no auth check at all** — no loader, and the
+  action does not call `isUserLoggedIn`. Only the RLS policies on
+  `message_templates` stand between an anonymous POST and a new template. Every
+  sibling route guards.
+- `/message-template/:id/edit` guards its loader but not its action.
+- `markAsSent` ignores the Supabase error and unconditionally
+  `console.log`s `Error: undefined` on success. A failed insert is reported to
+  the admin as "Lähetetty".
+- The phone field in `MessageComposer` is `type="email" name="email"
+  placeholder="Sähköpostiosoite"` — leftover markup; the value is used as a
+  phone number and the name is never read.
+- The `sms:` href uses `&body=` rather than `?body=`; it works on iOS, not
+  uniformly elsewhere.
+- Message content is rendered with `dangerouslySetInnerHTML` in the preview, the
+  sent-message history and the template list. The content is admin-authored, but
+  nothing sanitises it.
+- Nothing verifies a message was actually sent — "marked as sent" is the
+  admin's assertion. Equally, an admin who sends and forgets to mark leaves no
+  log row.
+- `getMessageTemplates` orders by `created_at DESC` only; the commented-out
+  `is_default` ordering means the default template is not first in the dropdown.
+- The batch position is component state, not a URL — deliberate, so the back
+  button cannot re-send.
+- A `message_log` row for a since-deleted disc keeps only its legacy
+  `internal_disc_id`; it had no `external_id` to backfill from.
+
+## Open questions
+None recorded.

--- a/specs/07-notifications.md
+++ b/specs/07-notifications.md
@@ -1,0 +1,74 @@
+# Found-disc & bin-full notifications
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+Two public, anonymous forms reached by scanning a QR code on a poster at a course:
+one to report that a disc was found and dropped into the collection bin, one to
+report that the bin is full. Reports land in an admin inbox at `/notifications`,
+where a club volunteer reads, marks and deletes them.
+
+## Actors
+- **Anonymous visitor at the course** — scans the poster, submits either form. No account, no session.
+- **Club admin (signed in)** — reads the inbox, marks notifications read, deletes them, downloads QR posters.
+
+## User-facing behaviour
+1. Visitor scans the found-disc QR and lands on `/notify/<courseSlug>`; the form shows the course name and one button, "Ilmoita kiekosta" ("report a disc"). Submitting stores a notification and shows "Kiitos ilmoituksesta!" ("thanks for the report").
+2. "Lisää yhteystiedot" ("add contact details") expands optional Nimi / Puhelinnumero / Sähköposti / Viesti (name / phone / email / message) fields, all free text, all optional.
+3. Visiting `/notify` with no slug shows the same form plus a radio list of *all* courses in `app/config/courses.ts`; the course is required, but only by a client-side check in `NotifyForm.tsx`.
+4. After success the found-disc form offers "Lähetä uusi ilmoitus" ("send another"), which just reloads the page.
+5. Visitor scans the bin-full QR and lands on `/bin/full/<courseSlug>`; one button, "Laatikko on täynnä" ("the bin is full"). Submitting stores a notification and shows the thank-you screen.
+6. If a bin-full report for that course was already submitted from this browser inside the rate-limit window, the *loader* already renders the thank-you screen — the form is never shown, and a POST is silently discarded (still answered with success).
+7. An unknown course slug on either route throws a 404 `Response` with the body "Rataa ei löytynyt" ("course not found").
+8. Admin opens "Ilmoitukset" ("notifications") from the admin menu. Two sections: "Ilmoitukset löydetyistä kiekoista" (found discs) and "Ilmoitukset täysistä löytökiekkolaatikoista" (full bins). Unread rows get a blue left border; empty sections read "Ei ilmoituksia."
+9. "Merkitse luetuksi" ("mark as read") stamps `read_at` and the row loses its unread styling; the button then disappears. There is no way to mark a row unread again.
+10. "Poista" ("delete") and "Poista kaikki" ("delete all") delete, each behind a `window.confirm`.
+11. Each section has per-course QR poster buttons that generate an A4 PDF in the browser and download it.
+
+## Data
+| Table | Columns | Notes |
+|---|---|---|
+| `disc_found_notifications` | `id`, `created_at`, `club_id`, `course_name`, `contact_name`, `contact_phone`, `contact_email`, `message`, `read_at` | Everything but `id`/`created_at`/`club_id` is nullable — the form's only required input is the submit button. `course_name` is the display name string, not a slug or FK. |
+| `bin_full_notifications` | `id`, `created_at`, `club_id`, `course_name NOT NULL`, `read_at` | Created by `supabase/migrations/20260424000000_bin_full_notifications.sql`. No payload beyond which course and when. |
+
+- `read_at` NULL means unread; it is the only state a notification has.
+- `club_id` comes from the `APP_CLUB_ID` env var at insert time, **not** from the course's `clubId`. Nothing enforces that `course_name` belongs to `club_id`.
+- Mappers: `app/models/DiscFoundNotificationMapper.ts`, `app/models/BinFullNotificationMapper.ts` (snake_case row -> camelCase DTO; typed `raw: any`).
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/notify` | GET, POST | anonymous | Found-disc form with a course radio list (`app/routes/notify._index.tsx`) |
+| `/notify/:courseSlug` | GET, POST | anonymous | Found-disc form for one course (`app/routes/notify.$courseSlug.tsx`) |
+| `/bin/full/:courseSlug` | GET, POST | anonymous | Bin-full report for one course (`app/routes/bin.full.$courseSlug.tsx`) |
+| `/notifications` | GET, POST | signed in (`isUserLoggedIn`, else redirect to `/sign-in`) | Admin inbox (`app/routes/notifications.tsx`) |
+
+POST intents on `/notifications` (`app/features/notifications/handleNotificationAction.server.ts`):
+`markAsRead`, `delete`, `deleteAll` (found-disc) and `markBinFullAsRead`, `deleteBinFull`, `deleteAllBinFull` (bin-full). Every intent returns `{}`; unknown intents and a missing `notificationId` are no-ops.
+
+## Rules & constraints
+- **What an anonymous caller can do:** insert one `disc_found_notifications` row (any course name, any/empty contact fields) or one `bin_full_notifications` row per POST. Both inserts go through `createConnection()` — the plain anon key — so the DB `Allow public insert` policy (`WITH CHECK (true)`) is what permits them. See `docs/rls.md` and the bin-full migration.
+- **What an anonymous caller cannot do:** read, update or delete any notification. SELECT/UPDATE/DELETE policies on both tables are `TO authenticated`. The admin inbox uses `createSupabaseServerClient(request)` (cookie session), so an unauthenticated read returns nothing even if the route guard were bypassed.
+- **No field validation, no length limits, no sanitising** on the found-disc form. `contactEmail` is `type="email"` (browser-side only). Empty strings are normalised to `null`.
+- **Rate limit (bin-full only)**, `app/features/notifications/binFullRateLimit.server.ts`:
+  - Window: 10 minutes (`RATE_LIMIT_MS = 10 * 60 * 1000`).
+  - Keyed by **cookie only** — never by IP, user agent or DB lookup. One cookie per course, named `bin_full_rl_<slug>`, `path=/bin/full`, `sameSite=lax`, `httpOnly`, `maxAge=600`. Its value is the epoch ms of the last POST.
+  - Every POST rewrites the cookie, so repeated clicks *restart* the window rather than expire it.
+  - The found-disc form has no rate limit at all.
+- **Club scoping:** reads, mark-as-read and single deletes filter `.eq('club_id', APP_CLUB_ID)`. `deleteAllNotifications` / `deleteAllBinFullNotifications` do **not** — they run `.delete().gte('id', 0)` across every club.
+- **Insert failures are swallowed:** both `create*Notification` functions `console.error` and return void; the action still returns `{ success: true }`, so the visitor always sees the thank-you screen.
+- **QR posters** are generated client-side with `qrcode` + a lazily imported `@react-pdf/renderer` (`QrPosterButtons.tsx`, `BinFullQrPosterButtons.tsx`). The encoded URL is `window.location.origin + /notify/<slug>` or `/bin/full/<slug>`, so the poster inherits whatever host generated it. The logo is picked by `course.clubId === 1 ? 'ps-logo.png' : 'TT-Logo-transparent.png'`. Downloads as `<slug>-qr.pdf` / `<slug>-bin-full-qr.pdf`. Failures are logged to the console only.
+- Bin-full posters are offered for a hardcoded slug list: `BIN_FULL_COURSE_SLUGS = ['oittaa']`. Found-disc posters are offered for every course.
+- `app/root.tsx` hides the admin menu on paths starting with `/notify` for anonymous visitors. `/bin/full/*` is not in that check, but `AdminMenu` returns `null` without a signed-in user anyway.
+
+## Edge cases & known gaps
+- Both poster button lists and the `/notify` course radio list iterate **all** courses, not the ones belonging to `APP_CLUB_ID`. A club admin sees the other club's courses, and a report filed against another club's course is still stored under this instance's `club_id`.
+- "Poista kaikki" deletes other clubs' notifications too (no `club_id` filter).
+- The bin-full rate limit is per browser: clearing cookies, a private window or a second phone bypasses it immediately. It is spam friction, not a real limit.
+- `docs/rls.md` documents `disc_found_notifications` but not `bin_full_notifications`; that table's policies exist only in its migration.
+- Anonymous inserts rely on `SUPABASE_KEY` (the anon key, present in page source) plus a permissive `WITH CHECK (true)`, so anyone can write arbitrary rows to both tables directly, bypassing the forms and the cookie rate limit. This is the opposite of the deliberate no-INSERT-policy approach used for `disc_owner_responses` (see `docs/rls.md`).
+- No notification count is surfaced in the admin menu (unlike "Vastaukset" / "Noutolista"), so unread reports are only visible after opening the page.
+- No tests cover this feature — no unit or e2e specs reference the notify, bin-full or notifications routes.
+
+## Open questions
+None recorded.

--- a/specs/08-emptying-log.md
+++ b/specs/08-emptying-log.md
@@ -1,0 +1,59 @@
+# Emptying log
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+Records when a course's lost-and-found collection bin was last checked/emptied,
+and shows that date to the public on the disc list so a visitor knows how fresh
+the inventory is. Despite the name, it is not an append-only log: it holds one
+row per course and overwrites the timestamp in place.
+
+## Actors
+- **Club admin (signed in)** — presses "Merkitse tyhjennetyksi" ("mark as emptied") on `/emptying-log`.
+- **Anonymous visitor** — sees the resulting date on the public disc list, read-only.
+
+## User-facing behaviour
+1. Admin opens "Tyhjennysloki" ("emptying log") from the admin menu and sees one row per course: the course name and a button.
+2. Pressing "Merkitse tyhjennetyksi" sets that row's `emptied_at` to `now()` and the page reloads; the previous date is gone.
+3. On the public disc list, when at least one row exists for the club, a heading "Löytökiekot tarkistettu viimeksi" ("lost discs last checked") lists each course with a short `fi-FI` date.
+4. A row with no `emptied_at` renders as "Ei tiedossa" ("not known").
+5. The course name is shown next to the date only when the club has more than one row (`showCourseName` in `app/ui/EmptyingLogItem.tsx`).
+6. Anonymous visitors are redirected to `/sign-in` if they open `/emptying-log`.
+
+## Data
+`emptying_log`: `id`, `created_at`, `club_id`, `course_name`, `emptied_at` (nullable — a bin that has never been marked). No migration file exists for this table; it was created outside `supabase/migrations/`.
+
+- `course_name` is a plain string, not an FK to anything.
+- Rows are seeded manually in the DB. The app has **no INSERT path** — adding a course to the log requires a hand-written row.
+- Invariant not enforced anywhere: exactly one row per (club, course).
+- Mapper: `app/models/EmptyingLogMapper.ts` (`EmptyingLogDTO` in `app/types.ts`).
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/emptying-log` | GET | signed in (`isUserLoggedIn`, else redirect to `/sign-in`) | Lists every log row with its mark button (`app/routes/emptying-log.tsx`) |
+| `/emptying-log` | POST | signed in | `item` = row id -> `markBinEmptied` -> `markAsEmptied` (`app/features/emptyingLog/markBinEmptied.server.ts`) |
+| `/` (disc list) | GET | anonymous | Read-only display via `getEmptyingLogItemsForClub` in `app/features/discs/list/loadDiscListData.server.ts` |
+
+## Rules & constraints
+- Writes go through `createSupabaseServerClient(request)`, so RLS with the caller's session is the real gate; the route guard is a convenience redirect.
+- `getEmptyingLogItemsForClub(clubId, request)` filters `.eq('club_id', clubId)` — that is the public path.
+- `getEmptyingLogItems(request)` (the admin page) has **no club filter**: it lists every club's rows.
+- `markAsEmptied(courseId, request)` filters only on `id` — no `club_id` check.
+- `emptied_at` is set with the string `'now()'`, evaluated by Postgres, not by the app clock.
+- Missing POST body `item` is a silent no-op.
+
+## Relationship to bin-full notifications (spec 07)
+Separate and unlinked. A `bin_full_notifications` row is an anonymous *request* to
+come empty the bin; marking a row emptied here does not read, clear or mark read
+any bin-full notification, and vice versa. An admin acting on a full-bin report
+has to visit both `/notifications` and `/emptying-log`.
+
+## Edge cases & known gaps
+- History is destroyed on every press: only the latest emptying date survives.
+- `EmptyingLogPage.tsx` uses `{emptyingLogItems.length && ...}`, so an empty log renders a stray `0` on the page.
+- No confirmation dialog — a mis-click overwrites the date with no undo.
+- No tests reference this feature.
+
+## Open questions
+None recorded.

--- a/specs/09-google-sheets-sync.md
+++ b/specs/09-google-sheets-sync.md
@@ -1,0 +1,137 @@
+# Google Sheets sync
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+Both clubs originally kept their lost-disc inventory in a Google Sheet. This
+feature reads those sheets over the Sheets REST API and turns rows into `discs`
+rows. Discs are added through `/discs/add` now, so the in-app sync UI is
+**disabled**; what remains in use is a one-off command-line import script for
+Puskasoturit.
+
+## Actors
+- Club admin — runs the import script from a shell (needs `.env` credentials).
+- No anonymous or in-app path exists today: the sync route is not routable.
+
+## How a sync is triggered today
+| Path | State |
+|---|---|
+| `npm run import:puskasoturit [-- --dry-run]` → `scripts/importPuskasoturitDiscs.ts` | **The only working trigger.** Insert-only, no deletes. |
+| `/discs/sync` (`app/routes/discs.sync.tsx`) | **Disabled.** `app/routes.ts` lists `'**/discs.sync.tsx'` in `flatRoutes({ ignoredRouteFiles })`, so the URL 404s. The file, `app/features/discSync/*` and `app/models/syncDiscs.server.ts` are kept on disk; deleting that one line brings the page back. |
+| Cron / scheduled job | None exists. |
+
+`npm run archive:discs -- --before=YYYY-MM-DD` (`scripts/archiveStaleDiscs.ts`)
+is a sibling script, not a sync: it sets `archived_at` on old unresolved discs.
+
+## The two importers
+Both live in `app/import/`, both call
+`https://sheets.googleapis.com/v4/spreadsheets/<id>/values/<tab>?valueRenderOption=FORMATTED_VALUE&key=…`,
+both `slice(1)` off the header row and keep only rows that have an id, a disc
+name and a date. Column layouts differ entirely — indexes are hard-coded, so a
+column inserted in either sheet silently shifts the data.
+
+| | Puskasoturit (`PuskaSoturitImporter.ts`) | Talin Tallaajat (`TalinTallaajatImporter.ts`) |
+|---|---|---|
+| club_id | 1 | 2 |
+| Sheet tab | `Oittaa` | `Master` |
+| API key env var | `PUSKASOTURIT_SHEETS_KEY` | `TT_SHEETS_KEY` |
+| internal id column | 14 (last) | 0 (first) |
+| disc name / manufacturer / colour | 0 / 1 / 2 | 1 / — / 5 |
+| owner name / phone | 3 / 4 | 2 / 3 |
+| added at | 5, `dd/MM/y` | 9, `d.M.y` |
+| returned / for sale text | 10 / 11 | 11 / 12 |
+| extra columns | `additional_info` 12, `course` 13 | `owner_club_name` 6, `notified_at` 7, `additional_info` 8; no course |
+| Bad date cell | `parseSheetDate()` returns null (one row reads `9248`); the script reports and skips the row | `format(parse(...))` throws — an unparsable cell takes the whole import down |
+| API error | Explicit `throw` when `data.values` is missing | Unchecked; surfaces as "Cannot read properties of undefined" |
+
+`app/import/puskasoturitDiscFields.ts` is the Puskasoturit-only post-processing
+step used by the script: it normalizes course spellings (`Oiittaa` → `Oittaa`,
+`ÄIjänpelto` → `Äijänpelto`), and mines the free-text notes for
+`returned_to_owner_date`, `return_method` (`noud|nout` → picked up, `postit` →
+by mail) and `can_be_sold_or_donated_method` (`lahjoit` → donated,
+`myyd|muyyd` → sold). It duplicates the `ReturnMethod`/`DisposalMethod` numbers
+instead of importing them so the module stays free of `~/` aliases and runs
+under plain `node`'s TypeScript stripping; `puskasoturitDiscFields.test.ts`
+asserts the two copies still agree.
+
+## Matching a sheet row to a disc
+- The key is `(internal_disc_id, club_id)` — `internal_disc_id` is the sheet row
+  number and is only unique within a club.
+- `scripts/importPuskasoturitDiscs.ts` pages the whole set of existing
+  `internal_disc_id`s for the club (1000 rows per page), then inserts sheet rows
+  whose id is not in that set. It never updates and never deletes, so **an edit
+  made in the sheet after the row was imported is not propagated.**
+- `syncNewDiscs()` (disabled path) instead takes `MAX(internal_disc_id)` for the
+  club and inserts every sheet row above it — gaps below the maximum stay
+  missing.
+- `syncAllDiscs()` (disabled path) deletes every row for the club **where
+  `internal_disc_id IS NOT NULL`** and re-inserts the sheet wholesale, then
+  upserts `sync_log`.
+
+### Web-added discs
+Per the established decision, a disc added through `/discs/add` has
+`internal_disc_id = NULL` and a uuid `external_id`
+(`supabase/migrations/20260829010000_discs_internal_disc_id_nullable.sql`).
+Consequences:
+- It can never collide with a sheet row, and is never matched by a sync.
+- Every query on the sync path adds `.not('internal_disc_id', 'is', null)` —
+  in `syncAllDiscs` so the wipe does not destroy web-added discs, and in
+  `getLatestInternalDiscId` because Postgres sorts NULLs first on `ORDER BY …
+  DESC` and a NULL would otherwise be read as "the latest" and stall the sync.
+
+### Rows present on only one side
+| Situation | Result |
+|---|---|
+| In the sheet, not in the DB | Inserted (both the script and both sync modes). |
+| In the DB, not in the sheet, sheet-imported | Survives the script; deleted and not restored by `syncAllDiscs`. |
+| In the DB, web-added | Always left alone. |
+| Edited in the sheet after import | Ignored — no update path exists. |
+
+## Data
+- `discs` — written by both paths. `internal_disc_id` nullable (web-added),
+  `external_id` UUID NOT NULL UNIQUE with a `gen_random_uuid()` default, though
+  both writers generate the uuid in JS rather than relying on the default.
+- `sync_log` — `id`, `club_id`, `updated_at`; upserted by `saveSyncTime()` on
+  `club_id` conflict, one row per club, read by `fetchClubs()` and shown on the
+  (unreachable) sync page.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/discs/sync` | GET, POST | signed-in (`isUserLoggedIn`, else redirect `/sign-in`) | Disabled via `ignoredRouteFiles`; would list clubs and offer "Päivitä KAIKKI … data" (update all) and "Päivitä UUSI … data" (update new). |
+| `npm run import:puskasoturit` | CLI | `.env` credentials | Insert-only import of the Puskasoturit sheet. |
+
+## Rules & constraints
+- Env vars: `PUSKASOTURIT_SHEETS_KEY`, `TT_SHEETS_KEY` (Sheets API keys, one per
+  club); `SUPABASE_URL` + `SUPABASE_KEY` for reading; and for writing either
+  `SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_EMAIL` + `SUPABASE_PASSWORD`
+  (`scripts/supabaseClients.ts`). RLS lets only authenticated users write to
+  `discs`, so the anon key alone is not enough.
+- Spreadsheet ids and tab names are hard-coded in the importers; only the API
+  key comes from the environment.
+- Inserts are chunked 100 rows at a time in both paths.
+- `scripts/` and `app/import/puskasoturitDiscFields.ts` must not use the `~/`
+  alias — they run under `node --env-file=.env` with native TS stripping.
+- Club selection: the script uses `PUSKASOTURIT` from `app/config/clubs.ts`; the
+  disabled route takes `clubId` from the posted form, not `APP_CLUB_ID`.
+
+## Edge cases & known gaps
+- `syncAllDiscs()` calls `addDiscs()` and `saveSyncTime()` **without awaiting**,
+  and `addDiscs()` maps an async function over chunks without awaiting them —
+  the action can return before the inserts finish, and an insert error is
+  swallowed. The CLI script deliberately awaits chunk by chunk instead.
+- `syncAllDiscs()` is destructive: it deletes before it knows the insert
+  succeeded. No transaction, no backup.
+- The wipe-and-reinsert also discards any admin edit made in the app to a
+  sheet-imported disc, and mints a new `external_id`, breaking existing SMS
+  links and `message_log` references.
+- Talin Tallaajat has no course column, so its discs have no `course`; the
+  free-text field parsing in `puskasoturitDiscFields.ts` is Puskasoturit-only.
+- Only `parseSheetDate` and the `puskasoturitDiscFields` helpers are unit
+  tested; the fetch/map path of either importer is not.
+- The `DiscDTO.internalDiscId` coming out of the importers is the raw string
+  from the sheet; only `toDiscRow()` coerces it with `Number()`.
+
+## Open questions
+- Whether the Talin Tallaajat sheet still needs an import path at all, given no
+  script exists for it and the route is disabled.

--- a/specs/10-statistics.md
+++ b/specs/10-statistics.md
@@ -1,0 +1,111 @@
+# Statistics
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+A single admin page, "Statistiikka" (statistics), showing how many discs the
+club has taken in and given back, when it happened, and which disc models go
+missing most often. It is a rough operational overview, not a reporting tool:
+everything is computed in the browser from one fetch of the club's discs.
+
+## Actors
+- Club admin only. `app/routes/stats.tsx` redirects to `/sign-in` unless
+  `isUserLoggedIn(request)`. Linked from `app/ui/AdminMenu.tsx` as
+  `{ to: '/stats', label: 'Statistiikka' }`.
+
+## User-facing behaviour
+1. When an admin opens `/stats`, then two totals and three charts render from
+   the loader's disc array.
+2. "Myytyjen / lahjoitettujen kiekkojen määrä" (number of sold/donated discs) —
+   a count of discs with `canBeSoldOrDonated`.
+3. "Omistajille palautettujen kiekkojen määrä" (number of discs returned to
+   owners) — a count of discs with `isReturnedToOwner`.
+4. "Seuralle palautetut kiekot" (discs returned to the club) — a monthly bar
+   chart of discs by `added_at`.
+5. "Omistajille palautetut kiekot" — a monthly bar chart of discs by the date
+   they went back to their owner.
+6. When a bar in either monthly chart is clicked, then a second chart appears
+   below it breaking that month down by day; the clicked bar turns blue.
+7. "Top 10 kadotettua kiekkomallia" (top 10 most-lost disc models) — a
+   horizontal bar chart of the ten most frequent `disc_name` values.
+
+## Data source
+`getDiscsForStats()` in `app/models/discs.server.ts`:
+
+```
+select internal_disc_id, disc_name, can_be_sold_or_donated,
+       is_returned_to_owner, returned_to_owner_text, returned_to_owner_date,
+       added_at
+from discs where club_id = APP_CLUB_ID order by added_at asc
+```
+
+- One query, no aggregation in SQL, no filters — **archived, returned, disposed
+  and deleted-flagged discs are all included** in every chart.
+- Club scoping is by the `APP_CLUB_ID` env var, read server-side.
+- Every count and grouping happens in JS, in the components, on each render.
+
+## The charts
+| Chart | Component | Measures | Grouped by | Bucket |
+|---|---|---|---|---|
+| Seuralle palautetut kiekot | `DiscsReturnedToClub.tsx` | Discs taken into the club's inventory | `addedAt` | `"<month0>.<year>"` key, i.e. month within a year; drill-down by day of month |
+| Omistajille palautetut kiekot | `DiscsReturnedToOwner.tsx` | Discs with `isReturnedToOwner` **and** a resolvable return date | `returnedToOwnerDate`, falling back to a leading `d.M.yyyy` in `returnedToOwnerText` | `date-fns` month number **only — no year** (see gaps); drill-down by day of month |
+| Top 10 kadotettua kiekkomallia | `MostLostByDiscName.tsx` | Row count per `discName` | exact `discName` string | none — all time |
+
+Shared helpers are in `app/features/stats/statsUtils.ts`
+(`mapBySeparator` → `sortMappedData` → `getAddedDiscCountByMonth` /
+`getAddedDiscCountByDaysInMonth`, plus `getDonatedOrSoldDiscCount` and
+`getReturnedDiscCount`). Bars are sorted by date ascending; legends use
+`getMonthName(date, 'short')` in `fi-FI` for the monthly charts and `dd` for the
+daily ones.
+
+## Rendering
+- `app/ui/BarChart.tsx` — vertical bars as `<button>`s, so a bar is clickable
+  and keyboard-reachable; bar height is `value / (max + 30)`, so charts with
+  small numbers look flat and no bar is ever full height. Hard-coded red bars,
+  blue on hover/selection, a red debug-looking `border: solid 1px red` around
+  each chart via the `className` passed by the stats components.
+- `app/ui/HorizontalBarChart.tsx` — same `max + 30` width formula, fixed 10rem
+  label column, no click handling.
+- Neither chart has an axis, a scale, or a value shown other than the number
+  printed above/beside the bar; there is no charting library.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/stats` | GET | signed-in; otherwise redirect to `/sign-in` | Loads all discs for the club and renders `StatsPage`. |
+
+## Rules & constraints
+- Admin-only; the loader is the only authorization check.
+- Phone numbers are not selected at all here (the `owner_phone_number` masking
+  in `getDiscsForStats` is dead code for the current select list).
+- The whole club's disc table crosses the wire on every page load, and every
+  recomputation runs on the full array — the drill-down charts recompute
+  `getAddedDiscCountByDaysInMonth` twice per render (once for the data, once for
+  the legend). With a few thousand discs this is fine; there is no pagination,
+  memoization or caching, so it grows linearly and forever.
+
+## Edge cases & known gaps
+- `DiscsReturnedToOwner` groups by `getMonth(date)` alone, so **the same month
+  in different years is merged into one bar**; `DiscsReturnedToClub` includes
+  the year in its key. The two charts are not comparable.
+- `mapBySeparator` skips a row when the separator is falsy. `date-fns`
+  `getMonth` is 0-based, so **January is dropped from
+  `DiscsReturnedToOwner`** entirely. `DiscsReturnedToClub` is unaffected because
+  its separator is the string `"0.2026"`, which is truthy.
+- `DiscsReturnedToOwner`'s day drill-down is fed the *unfiltered* `data`, not
+  the filtered set, so a disc with a parsable return note but
+  `isReturnedToOwner = false` appears in the day chart though not in the month
+  chart.
+- `MostLostByDiscName` groups on the raw `discName`, so casing and spelling
+  variants ("Destroyer" vs "destroyer") count as different models, and ties at
+  the tenth place are broken arbitrarily.
+- The two headline counts include archived and long-resolved discs, so they are
+  all-time totals with no date range control.
+- No tests cover `statsUtils.ts` or any stats component.
+- Charts are unlabelled beyond the title; no empty state — a club with no data
+  renders an empty chart frame.
+
+## Open questions
+- Whether the monthly charts should exclude archived discs, and whether
+  "seuralle palautetut" (measured by `added_at`) is the intended meaning of
+  "returned to the club" as opposed to "found and logged".

--- a/specs/11-auth-and-authorization.md
+++ b/specs/11-auth-and-authorization.md
@@ -1,0 +1,69 @@
+# Auth & authorization
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+Keeps the club's admin pages and writes to the admin's own hands while the disc
+list, the QR notification forms and the owner link stay open to anyone. There is
+one role — signed in or not — implemented with Supabase email/password auth over
+cookie sessions, with row-level security in Postgres as the second line.
+
+## Actors
+- **Anonymous visitor** — reads the disc list, submits found/bin-full reports, answers from an owner link.
+- **Club admin** — one Supabase user per club instance; there is no user table, no roles, no per-user permissions.
+- **Command-line scripts** (`scripts/`) — sign in as an admin, or use a service-role key set only in a local `.env`.
+
+## User-facing behaviour
+1. When an admin posts email + password to `/sign-in`, then the session cookies are set and they are redirected to `/`.
+2. When either field is empty or Supabase rejects the credentials, then the form re-renders with a Finnish error and HTTP 422.
+3. When a signed-out visitor requests an admin page, then its loader redirects to `/sign-in`.
+4. When a signed-out client POSTs to a disc resource route, then it gets `401` with `Kirjautuminen on vanhentunut. Kirjaudu uudelleen.`
+5. When signed in, then `AdminMenu` appears above every page and the disc list gains admin-only columns and row actions.
+6. When "Kirjaudu ulos" is confirmed, then `supabase.auth.signOut()` runs in the browser; `root.tsx` sees the auth-state change and revalidates.
+
+## Data
+- Auth state lives entirely in Supabase's `auth` schema and in the browser's cookies. This app owns no users, roles or sessions table.
+- RLS is enabled by migration on `bin_full_notifications`, `disc_retrievals`, `disc_owner_responses`; `discs` and `disc_found_notifications` carry policies applied outside the migrations dir (documented in `docs/rls.md`).
+- `discs` policies: `SELECT` to `public`; `INSERT`/`DELETE`/`UPDATE` to `authenticated`. The `UPDATE` policy needs `USING` as well as `WITH CHECK` — without `USING` the statement silently affects zero rows (`supabase/migrations/20260829040000_discs_update_policy.sql`).
+- `disc_owner_responses` has **no INSERT policy at all**; anon instead gets `EXECUTE` on two `SECURITY DEFINER` functions, `owner_link_disc()` and `submit_owner_response()`. `disc_is_in_storage()` is revoked from `PUBLIC` and granted to nobody.
+- No RLS migration exists for `message_templates`, `message_log` or `emptying_log`; whatever policies they carry were applied by hand in Supabase.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/sign-in` | GET, POST | public | Email/password sign-in (`app/features/auth/signInWithForm.server.ts`) |
+| `/`, `/discs/data` | GET | public | Disc list; loader narrows fields for anonymous visitors |
+| `/notify`, `/notify/:courseSlug`, `/bin/full/:courseSlug` | GET, POST | public | QR report forms |
+| `/kiekko/:token` | GET, POST | token only | Owner link; `Referrer-Policy: no-referrer`, `X-Robots-Tag: noindex, nofollow` |
+| `/discs/add`, `/emptying-log`, `/message-templates`, `/message-template/:id/edit`, `/message/send/:externalId`, `/message/send-batch`, `/notifications`, `/stats` | GET (+POST) | admin, loader redirect | Admin pages |
+| `/retrieval`, `/vastaukset` | GET, POST | admin, checked in the feature module | Retrieval list, owner-answer inbox |
+| `/discs/create`, `/discs/delete`, `/discs/disposal`, `/discs/return`, `/discs/course`, `/discs/retrieval`, `/discs/batch` | POST JSON | admin, `requireAdminJson` | Disc resource routes |
+| `/message-template/create` | GET, POST | **no server-side check** | New-template form (see gaps) |
+| `/discs/sync` | — | 404 | Route file excluded in `app/routes.ts` |
+
+## Rules & constraints
+- **Session model.** `createSupabaseServerClientWithHeaders(request)` (`app/models/utils.ts`) builds a request-scoped `@supabase/ssr` server client that reads cookies from the request and collects `Set-Cookie` writes onto a `Headers` it returns. Any handler that establishes or refreshes a session **must** return those headers — `signInWithForm` and the `root.tsx` loader do; nothing else does.
+- `createSupabaseServerClient(request)` is the read-only convenience: same client, cookie writes deliberately dropped. Model functions that query under RLS use it.
+- **There is no single `requireUser` helper.** Three mechanisms coexist:
+  1. `isUserLoggedIn(request)` — `supabase.auth.getUser()`, true when a user id comes back. Called inline at the top of each admin page's loader, which returns `redirect('/sign-in')`.
+  2. `requireAdminJson(request)` (`app/lib/api/resourceRoute.server.ts`) — the shared preamble for the JSON disc routes: POST-only (405), `isUserLoggedIn` (401), parseable JSON body (400). Returns either `{ body }` or `{ response }`.
+  3. `isUserLoggedIn` called inside the feature loader/handler instead of the route, for `/retrieval` and `/vastaukset`.
+- **Route-level checks guard loaders, not actions.** On `/emptying-log`, `/notifications`, `/message-templates` and `/message-template/:id/edit` the check sits in the loader only; the `action` on those routes performs its write with no auth check of its own and relies on RLS.
+- **Keys.** `SUPABASE_KEY` is the **anon** key. It is deliberately public — `root.tsx` ships it to the browser in the loader's `env` object so `createBrowserClient` can run. Every server client (`createConnection`, `createFunctionConnection`, both SSR clients) uses the same anon key; a signed-in request differs only by carrying the session JWT from its cookies.
+- **The service-role key is never reachable from app code.** `SUPABASE_SERVICE_ROLE_KEY` appears nowhere under `app/` and is not in `.env.example`; only `scripts/supabaseClients.ts` reads it, optionally, for local maintenance scripts, falling back to signing in with `SUPABASE_EMAIL`/`SUPABASE_PASSWORD`.
+- Because the anon key is public, **RLS is the real boundary**: anything an anonymous client may not do must be refused by a policy, not only by a loader.
+- Anonymous field narrowing on the disc list happens in `loadDiscListData.server.ts` before the query — `additional_info` is never read, the phone number is cut to four digits, and `externalId` is stripped — so a policy-level `SELECT` to `public` on `discs` is safe.
+- `markRefusal` (`app/lib/api/resourceRoute.server.ts`) turns a zero-row UPDATE into a `403` naming RLS, because row-level security filters rather than raising.
+- Club scoping is enforced in application queries via `APP_CLUB_ID`, not by any RLS policy (see spec 12).
+- `AdminMenu` and `Header` are hidden on `/notify*` for signed-out visitors (`showHeader` in `root.tsx`); hiding UI is cosmetic, never the authorization.
+
+## Edge cases & known gaps
+- `/message-template/create` has **no loader and no auth check** — an anonymous visitor can render the form and POST it. Whether the insert lands depends solely on RLS on `message_templates`, for which there is no migration in this repo.
+- Likewise the unguarded `action`s on `/emptying-log`, `/notifications` and `/message-templates` — deletes and updates there are protected by RLS alone.
+- `root.tsx` uses `auth.getSession()` (cookie-derived, unverified) for UI state, while every gate uses `auth.getUser()` (verified against Supabase). The mismatch is intentional but means the menu can render for a session the gates would reject.
+- `signInWithForm` reads `email`/`password` with `!` and calls `.toString()` before the emptiness check, so a missing field throws and is swallowed by the `catch`, which logs and returns `undefined` rather than the 422.
+- No CSRF token, no rate limiting on `/sign-in`, no password reset or sign-up flow — accounts are created in the Supabase dashboard.
+- Sessions expire with Supabase's defaults; a stale tab discovers this as a `401` from a resource route rather than a redirect.
+
+## Open questions
+- Whether `message_templates`, `message_log` and `emptying_log` have RLS enabled at all — no migration in this repo says so.

--- a/specs/12-multi-club-configuration.md
+++ b/specs/12-multi-club-configuration.md
@@ -1,0 +1,82 @@
+# Multi-club configuration
+
+> Status: as-built (describes what exists today, not a wishlist)
+
+## Purpose
+One codebase serves two disc golf clubs, Puskasoturit ry (club id 1) and Talin
+Tallaajat ry (club id 2), as **two separate deployments of the same app**. The
+club a deployment serves comes from a single environment variable, `APP_CLUB_ID`,
+and everything club-specific is keyed on it.
+
+## Actors
+Deployment configuration; no user interacts with it directly. Visitors and
+admins only ever see the one club their instance serves.
+
+## User-facing behaviour
+1. When a page loads, then the header shows the club's logo and name and the tab shows the club's favicon.
+2. When the disc list renders, then it contains only that club's discs, and links to that club's own lost-discs page.
+3. When an admin adds a disc, then it is filed under `APP_CLUB_ID` — the club never comes from the request.
+4. When the instance is Talin Tallaajat, then the "Noutolista" menu item, the `/retrieval` page and the row action exist; on Puskasoturit they are absent everywhere.
+5. When an owner opens their SMS link, then the page works on both clubs and shows that club's MobilePay number and contact email.
+6. When an admin adds a disc on Puskasoturit, then a course picker is offered (Oittaa / Äijänpelto); on Talin Tallaajat there is none.
+
+## Data
+- `clubs` table — `id`, `name`, timestamps, joined `sync_log`. Read only by `fetchClubs()` (`app/models/clubs.server.ts`), mapped by `app/models/ClubMapper.ts`. Its only caller is `app/routes/discs.sync.tsx`, which is excluded from routing, so this table is effectively unused at runtime.
+- `discs.club_id`, `disc_found_notifications.club_id`, `bin_full_notifications.club_id`, `message_templates.club_id`, `message_log.club_id`, `emptying_log` (per course) all carry the club. Every query in `app/models/*.server.ts` filters on `process.env.APP_CLUB_ID`.
+- Club scoping is **application-level only** — no RLS policy mentions `club_id`. Both deployments point at the same Supabase project and the same rows.
+- `app/config/courses.ts` is the course catalog: a hard-coded array of `{ slug, name, clubId, clubName, discCourseName? }`. `discCourseName` is the short name the Google Sheet used and is what lands in `discs.course`; it is absent for Tali, which collects from one course.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+|---|---|---|---|
+| `/notify/:courseSlug` | GET, POST | public | Found-disc form for the course resolved by `getCourseBySlug` |
+| `/bin/full/:courseSlug` | GET, POST | public | Bin-full form, same slug resolution |
+| `/retrieval` | GET, POST | admin | Talin Tallaajat only; `isRetrievalListEnabled()` gates loader and action |
+| `/kiekko/:token` | GET, POST | token | Owner link — both clubs; club taken from `currentClubId()` and passed into the RPC |
+| `/discs/sync` | — | 404 | Per-club Sheets importers; route excluded in `app/routes.ts` |
+
+## Rules & constraints
+- `currentClubId()` (`app/config/clubs.ts`) is the single parse of `APP_CLUB_ID`; `PUSKASOTURIT = 1` and `TALIN_TALLAAJAT = 2` are the constants. A few older call sites still do `parseInt(process.env.APP_CLUB_ID!, 10)` inline (`app/root.tsx`, `app/routes/discs.add.tsx`, `app/features/discs/{submission,courseChange}/…`).
+- `APP_CLUB_NAME` is a separate, free-text env var; it is what the header and the `<title>` show. Nothing checks that it matches `APP_CLUB_ID`.
+- `root.tsx` forwards `CLUB_ID` and `CLUB_NAME` to the browser in the loader's `env` object, so client components take the club as a prop rather than reading the env.
+- Every write scopes on the club so that an id belonging to the other club cannot be acted on: disc create, delete, batch delete, the mark-* updates, retrieval errands (`queryDiscIdByExternalId.server.ts`), and owner-response handling all add `.eq('club_id', currentClubId())` or pass `p_club_id`.
+- `isRetrievalListEnabled()` reads the club itself rather than taking one, and returns true only for `TALIN_TALLAAJAT`. It is checked in four places: `loadRetrievalList`, `loadRetrievalCount`, `handleRetrievalRequest`, `handleRetrievedRequest`, plus the disc list's pending-retrieval lookup.
+- Course slugs are **global, not club-scoped**: `getCourseBySlug` searches the whole catalog, and `/notify/:courseSlug` and `/bin/full/:courseSlug` do not check `course.clubId === currentClubId()`.
+- `getDiscCourseNames(clubId)` returns the club's course names only when there is more than one; a single-course club gets `[]`, which is how the add form knows not to ask.
+- Per-club lookups all fall back rather than throw: `getClubLogo`/`getClubFavicon`/`getClubLostDiscsUrl`/`getClubPayment` return `null` for an unknown club so the element is left out, while `getClubContactEmail` falls back to Talin Tallaajat's address.
+- The Sheets importers are chosen by club id in `getImporter()` (`app/models/syncDiscs.server.ts`): `PuskaSoturitImporter` (spreadsheet `1dyROk…`, tab `Oittaa`, key `PUSKASOTURIT_SHEETS_KEY`) vs. `TalinTallaajatImporter` (spreadsheet `1_E4YY…`, tab `Master`, key `TT_SHEETS_KEY`). An unrecognised club id throws.
+- `vercel.json` carries only `{"framework": "react-router"}` — no per-club config. The two deployments differ purely by their Vercel environment variables.
+
+## What varies per club vs. what is shared
+| Varies per club | Where |
+|---|---|
+| Club id and display name | `APP_CLUB_ID`, `APP_CLUB_NAME` |
+| Logo and favicon | `CLUB_IMAGES` in `app/config/clubs.ts` |
+| Contact email | `CONTACT_EMAILS` |
+| Club's own lost-discs page URL | `LOST_DISCS_URLS` |
+| MobilePay number + payee name | `CLUB_PAYMENTS` |
+| Courses, slugs, and whether a disc records a course | `app/config/courses.ts` |
+| Retrieval list (Tali only) | `isRetrievalListEnabled()` |
+| Google Sheets importer, spreadsheet and API key | `app/import/`, `getImporter()` |
+| Which discs, notifications, templates and message log rows are visible | `club_id` filters in `app/models/*.server.ts` |
+
+| Shared across clubs | Where |
+|---|---|
+| Supabase project, database, and all tables | one `SUPABASE_URL` / `SUPABASE_KEY` per deployment, same project |
+| RLS policies (none mention `club_id`) | `docs/rls.md` |
+| Postage fee and the payee who receives it | `app/config/shipping.ts` |
+| Owner link page and owner-response flow | `app/features/discs/ownerResponse/` |
+| Disc parser, list, batch actions, stats, SMS templates, notifications, emptying log | `app/features/*` |
+| Finnish UI copy, admin menu, header layout | `app/ui/` |
+| Bin-full QR posters, currently only offered for `oittaa` | `BIN_FULL_COURSE_SLUGS` in `BinFullQrPosterButtons.tsx` |
+
+## Edge cases & known gaps
+- A visitor on either deployment can open `/notify/tali` or `/bin/full/oittaa` regardless of which club that course belongs to; the report is then filed under the *instance's* `APP_CLUB_ID` while naming the other club's course.
+- Both clubs share one database, so club separation depends entirely on every query remembering its `.eq('club_id', …)`. Nothing in the schema enforces it.
+- `APP_CLUB_ID` is read with `!` and `parseInt`; a missing or non-numeric value yields `NaN` and silently empty lists rather than a startup failure.
+- Adding a third club means editing four hard-coded maps in `app/config/clubs.ts`, the `courses` array, and `getImporter()` — there is no data-driven club registry.
+- `SUPABASE_FUNCTIONS_URL` is in `.env.example` but is referenced nowhere in the code.
+- `app/models/clubs.server.ts` and `ClubMapper.ts` are reachable only from the disabled `/discs/sync` route.
+
+## Open questions
+- None.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,32 @@
+# Specs
+
+Feature specifications for the lost-and-found app. This file is the index: one line
+per feature, linking to its own spec once written.
+
+## Features
+
+| # | Feature | What it covers | Code |
+|---|---------|----------------|------|
+| 1 | [Public disc list & search](01-public-disc-list.md) | Browsable/searchable list of lost discs, course filter, number search. Anonymous view + admin columns. | `features/discs/list/`, `routes/_index.tsx`, `routes/discs.data.tsx` |
+| 2 | [Disc submission](02-disc-submission.md) | Single-field free-text entry, text parser, browser draft storage, persistence. | `features/discs/submission/`, `routes/discs.add.tsx`, `routes/discs.create.tsx` |
+| 3 | [Disc lifecycle actions](03-disc-lifecycle-actions.md) | Return to owner/club, disposal, deletion, course change, retrieval list. | `features/discs/{return,disposal,deletion,courseChange,retrieval}/` |
+| 4 | [Batch operations](04-batch-operations.md) | Select many discs, apply one action to all. | `features/discs/batch/`, `routes/discs.batch.tsx` |
+| 5 | [Owner link & responses](05-owner-link-and-responses.md) | Token link from SMS: owner picks handover method, adds discs, gives address. Admin response inbox. | `features/discs/ownerResponse/`, `routes/kiekko.$token.tsx`, `routes/vastaukset.tsx` |
+| 6 | [SMS messaging & templates](06-messaging-and-templates.md) | Send to one owner or a batch, template CRUD with tokens, preview, message log. | `features/messaging/`, `routes/message*.tsx` |
+| 7 | [Found-disc & bin-full notifications](07-notifications.md) | Public QR forms at a course, rate limiting, admin inbox, QR posters. | `features/notifications/`, `routes/notify*.tsx`, `routes/bin.full.$courseSlug.tsx` |
+| 8 | [Emptying log](08-emptying-log.md) | Record and show when a course's collection bin was emptied. | `features/emptyingLog/`, `routes/emptying-log.tsx` |
+| 9 | [Google Sheets sync](09-google-sheets-sync.md) | Per-club importers pulling disc rows from Sheets, reconciled into the DB. | `import/`, `features/discSync/`, `models/syncDiscs.server.ts` |
+| 10 | [Statistics](10-statistics.md) | Returned-to-owner vs. club, most-lost disc names, trends over time. | `features/stats/`, `routes/stats.tsx` |
+| 11 | [Auth & authorization](11-auth-and-authorization.md) | Supabase sign-in, cookie sessions, admin-only routes, RLS policies. | `features/auth/`, `routes/sign-in.tsx`, `docs/rls.md` |
+| 12 | [Multi-club configuration](12-multi-club-configuration.md) | One deployment per club: club-scoped data, course catalog, per-club feature flags. | `APP_CLUB_ID`, `config/courses`, `models/clubs.server.ts` |
+
+All paths are relative to `app/`.
+
+Each spec follows [_TEMPLATE.md](_TEMPLATE.md) and describes the system **as built**,
+not as wished for. Known bugs and gaps are recorded under each spec's
+"Edge cases & known gaps".
+
+Before writing or changing a spec, read the `specs` skill
+(`.claude/skills/specs/SKILL.md`) — it covers when a spec must be written, how it
+is verified against the code afterwards, and how to write it so someone who does
+not know this codebase can follow it.

--- a/specs/_TEMPLATE.md
+++ b/specs/_TEMPLATE.md
@@ -1,0 +1,34 @@
+# <Feature name>
+
+> Status: as-built (describes what exists today, not a wishlist)
+>
+> Writing rules — reader who does not know this codebase, every abbreviation
+> explained on first use, plain words over jargon, as long as the subject needs.
+> See `.claude/skills/specs/SKILL.md`.
+
+## Purpose
+Two or three sentences: what problem this solves and for whom.
+
+## Actors
+Who uses it — anonymous visitor, club admin, system/cron.
+
+## User-facing behaviour
+Numbered scenarios in the form "When X, then Y". Cover the happy path first,
+then the notable variations. Keep each to one or two lines.
+
+## Data
+Tables, columns and enums this feature owns or depends on. Note which are
+nullable and why, and any invariants that are not enforced by the schema.
+
+## Routes & entry points
+| Route | Method(s) | Auth | Purpose |
+
+## Rules & constraints
+Validation limits, rate limits, authorization rules, club scoping. Anything a
+future change could break without a test noticing.
+
+## Edge cases & known gaps
+Things that are unhandled, deliberately out of scope, or a bit sharp.
+
+## Open questions
+Decisions not yet made. Empty is a fine answer.


### PR DESCRIPTION
Adds a `specs/` directory with one specification per major feature, indexed by
`specs/README.md` and structured by `specs/_TEMPLATE.md`. Each spec describes
what the code **does today**, so that a future change can tell what it will break.

Documentation only — no application code changes, nothing to lint or test.

## What is here

| Spec | Feature |
|---|---|
| 01 | Public disc list & search |
| 02 | Disc submission |
| 03 | Disc lifecycle actions |
| 04 | Batch operations |
| 05 | Owner link & owner responses |
| 06 | SMS messaging & message templates |
| 07 | Found-disc & bin-full notifications |
| 08 | Emptying log |
| 09 | Google Sheets sync |
| 10 | Statistics |
| 11 | Auth & authorization |
| 12 | Multi-club configuration |

Also adds a `specs` skill (`.claude/skills/specs/SKILL.md`) covering when a spec
must be written, how it is verified against the code once lint, typecheck and
tests are green, and how to write it for a reader who does not know this
codebase. `project-conventions` now points at it instead of carrying the rules.

## Gaps found while writing

Recorded under each spec's "Edge cases & known gaps" rather than fixed here, so
this PR stays reviewable as documentation. Roughly in priority order:

- **`/message-template/create` has no server-side auth check** — no loader, and
  the action never calls `isUserLoggedIn`. The only backstop would be row level
  security, but no migration in this repo enables it on `message_templates`,
  `message_log` or `emptying_log`, so the policy state cannot be verified from
  the code. Worth checking against the live Supabase project. The same
  loader-guarded-but-action-unguarded shape appears on `/emptying-log`,
  `/notifications`, `/message-templates` and `/message-template/:id/edit`.
- **Several deletes and queries are not club-scoped** — `deleteAllNotifications`
  and `deleteAllBinFullNotifications` run `.delete().gte('id', 0)` with no
  `club_id` filter, so one club's admin wipes every club's notifications.
  `getEmptyingLogItems` and `markAsEmptied` skip `club_id` too. Both deployments
  share one Supabase project and no policy mentions `club_id`, so separation is
  application-level only.
- **Returning a disc never closes its open `disc_retrievals` row** —
  `retrieved_at` stays empty for ever, which undercuts the retrieval-duration
  reporting the table was created for.
- **January is dropped from the "returned to owners" chart** — the month key is
  0-based and `mapBySeparator` skips falsy keys.
- **Several write paths report success after a swallowed error** — `markAsSent`
  and both notification creators log and continue, so the user sees a success
  message after a failed insert.
- Smaller ones in the specs: `archived_at` has no UI (only the `archive:discs`
  script writes it), phone search behaves differently for anonymous visitors and
  admins, the "koppi" rename is incomplete, and `handleBatchRequest.server.ts`
  has no test.

## Review notes

The specs were written by reading the code, the tests and the migrations. Where
a rationale could not be reconstructed it is marked as an open question rather
than guessed at, so anything in "Open questions" is a genuine gap in my
understanding and may be obvious to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)