### PR TITLE
feat(ui): give the admin menu a phone layout

### DIFF
--- a/app/ui/AdminMenu.tsx
+++ b/app/ui/AdminMenu.tsx
@@ -1,8 +1,10 @@
 import * as stylex from '@stylexjs/stylex';
 
-import { NavLink } from 'react-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { NavLink, useLocation } from 'react-router';
 
 import Button from '~/ui/Button';
+import { CloseIcon, MenuIcon } from '~/ui/icons';
 import { color, radius, space } from '~/styles/tokens.stylex';
 
 import type { JSX } from 'react';
@@ -17,6 +19,12 @@ const links: MenuLink[] = [
   { to: '/stats', label: 'Statistiikka' },
   { to: '/notifications', label: 'Ilmoitukset' },
 ];
+
+// The width at which the links stop being a row in the bar and start being a
+// panel behind the hamburger button. Kept in one place so the bar, the button
+// and the panel cannot disagree about it -- a link reachable in both at the same
+// width would sit twice in the tab order.
+const DESKTOP = '(min-width: 768px)';
 
 /**
  * A count in parentheses, or nothing.
@@ -49,6 +57,262 @@ function menuLinks(retrievalCount: number | null, responseCount: number | null):
   return [...links.slice(0, 2), ...responses, ...links.slice(2), ...retrieval];
 }
 
+type AdminMenuProps = {
+  supabase: any;
+  user: any;
+  /**
+   * Discs waiting to be fetched from the club's storage, or null when this club
+   * keeps no retrieval list -- and so has no menu item for it.
+   */
+  retrievalCount: number | null;
+  /** Owners' answers not yet dealt with, or null when nobody is signed in. */
+  responseCount: number | null;
+};
+
+export default function AdminMenu({
+  supabase,
+  user,
+  retrievalCount,
+  responseCount,
+}: AdminMenuProps): JSX.Element | null {
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const { pathname } = useLocation();
+
+  const closePanel = useCallback(() => setIsPanelOpen(false), []);
+
+  // Nothing behind the panel may scroll while it is open. Cleared on unmount as
+  // well as on close, so signing out from inside the panel cannot leave the
+  // next page permanently stuck.
+  useEffect(() => {
+    if (!isPanelOpen) {
+      return;
+    }
+
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isPanelOpen]);
+
+  // The panel only exists below the breakpoint. Widening the window past it
+  // hides the panel by CSS, so the state has to follow -- otherwise the scroll
+  // lock above would outlive the thing that asked for it.
+  useEffect(() => {
+    if (!isPanelOpen) {
+      return;
+    }
+
+    const desktop = window.matchMedia(DESKTOP);
+    const onChange = () => desktop.matches && closePanel();
+
+    desktop.addEventListener('change', onChange);
+
+    return () => desktop.removeEventListener('change', onChange);
+  }, [isPanelOpen, closePanel]);
+
+  // Focus starts on the close button, Escape closes, and Tab cycles inside the
+  // panel instead of walking into the page behind it. Focus goes back to the
+  // hamburger on close, so a keyboard user is not dropped at the top of the
+  // document.
+  useEffect(() => {
+    const panel = panelRef.current;
+
+    if (!isPanelOpen || panel == null) {
+      return;
+    }
+
+    closeRef.current?.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closePanel();
+        toggleRef.current?.focus();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusable = panel.querySelectorAll<HTMLElement>('a[href], button:not([disabled])');
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (first == null) {
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === first) {
+        last.focus();
+        event.preventDefault();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        first.focus();
+        event.preventDefault();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isPanelOpen, closePanel]);
+
+  const handleLogout = async () => {
+    if (!window.confirm('Haluatko varmasti kirjautua ulos?')) {
+      return;
+    }
+
+    await supabase.auth.signOut();
+  };
+
+  if (user?.email == null) {
+    return null;
+  }
+
+  const items = menuLinks(retrievalCount, responseCount);
+  // What is waiting on the two counted pages. While the panel is shut, the
+  // hamburger is the only place that can say so.
+  const pending = (retrievalCount ?? 0) + (responseCount ?? 0);
+
+  const logoutButton = (
+    <Button variant="contained" color="error" size="small" onClick={handleLogout}>
+      Kirjaudu ulos
+    </Button>
+  );
+
+  return (
+    <>
+      <nav {...stylex.props(styles.nav)} aria-label="Päävalikko">
+        <ul {...stylex.props(styles.list)}>
+          {items.map(({ to, label }) => (
+            <li key={to}>
+              <NavLink
+                to={to}
+                end={to === '/'}
+                className={({ isActive }) => stylex.props(styles.link, isActive && styles.activeLink).className ?? ''}
+              >
+                {label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+        <div {...stylex.props(styles.desktopActions)}>{logoutButton}</div>
+        <button
+          ref={toggleRef}
+          type="button"
+          {...stylex.props(styles.toggle)}
+          onClick={() => setIsPanelOpen(true)}
+          aria-label={pending > 0 ? `Avaa valikko, ${pending} odottaa käsittelyä` : 'Avaa valikko'}
+          aria-expanded={isPanelOpen}
+          aria-controls="admin-menu-panel"
+        >
+          <MenuIcon />
+          {pending > 0 && (
+            <span {...stylex.props(styles.badge)} aria-hidden="true">
+              {pending}
+            </span>
+          )}
+        </button>
+      </nav>
+
+      {isPanelOpen && (
+        <>
+          {/* Mouse-and-thumb convenience only: the keyboard closes the panel with
+              Escape or the close button, so the screen reader is better off not
+              hearing about this at all. tabIndex -1 keeps it out of the tab order,
+              which is what makes aria-hidden legitimate on a <button>. */}
+          <button
+            type="button"
+            {...stylex.props(styles.backdrop)}
+            onClick={closePanel}
+            tabIndex={-1}
+            aria-hidden="true"
+          />
+          <div
+            id="admin-menu-panel"
+            ref={panelRef}
+            {...stylex.props(styles.panel)}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Valikko"
+          >
+            <div {...stylex.props(styles.panelHeader)}>
+              <span {...stylex.props(styles.panelTitle)}>Valikko</span>
+              <button
+                ref={closeRef}
+                type="button"
+                {...stylex.props(styles.close)}
+                onClick={() => {
+                  closePanel();
+                  toggleRef.current?.focus();
+                }}
+                aria-label="Sulje valikko"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+            <ul {...stylex.props(styles.panelList)}>
+              {items.map(({ to, label }) => (
+                <li key={to}>
+                  <NavLink
+                    to={to}
+                    end={to === '/'}
+                    // Following a link to the page already open changes no
+                    // address, so closing cannot be left to the pathname alone.
+                    onClick={closePanel}
+                    className={({ isActive }) =>
+                      stylex.props(styles.panelLink, isActive && styles.panelLinkActive).className ?? ''
+                    }
+                  >
+                    {label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+            <div {...stylex.props(styles.panelFooter)}>{logoutButton}</div>
+          </div>
+        </>
+      )}
+      {/* The address changing means the panel has served its purpose -- this
+          catches the browser's back button, which no click handler sees. */}
+      <PanelCloserOnNavigation pathname={pathname} onNavigate={closePanel} />
+    </>
+  );
+}
+
+/**
+ * Closes the panel whenever the address changes.
+ *
+ * A tiny component of its own rather than an effect in `AdminMenu`, so the
+ * "close on navigation" rule is one readable thing and does not need a guard
+ * against firing on the first render.
+ */
+function PanelCloserOnNavigation({ pathname, onNavigate }: { pathname: string; onNavigate: () => void }): null {
+  const previous = useRef(pathname);
+
+  useEffect(() => {
+    if (previous.current !== pathname) {
+      previous.current = pathname;
+      onNavigate();
+    }
+  }, [pathname, onNavigate]);
+
+  return null;
+}
+
+const slideIn = stylex.keyframes({
+  from: { transform: 'translateX(100%)' },
+  to: { transform: 'translateX(0)' },
+});
+
+const fadeIn = stylex.keyframes({
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+});
+
 // StyleX has no descendant selectors, so hover/active styling is applied to the
 // links themselves rather than through the surrounding <nav>.
 const styles = stylex.create({
@@ -56,6 +320,7 @@ const styles = stylex.create({
     display: 'flex',
     flexWrap: 'wrap',
     alignItems: 'center',
+    justifyContent: { default: 'flex-end', [`@media ${DESKTOP}`]: 'flex-start' },
     gap: space.sm,
     padding: `${space.sm} ${space.md}`,
     backgroundColor: color.surfaceMuted,
@@ -65,7 +330,7 @@ const styles = stylex.create({
     boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
   },
   list: {
-    display: 'flex',
+    display: { default: 'none', [`@media ${DESKTOP}`]: 'flex' },
     flexWrap: 'wrap',
     alignItems: 'center',
     gap: space.xs,
@@ -89,61 +354,122 @@ const styles = stylex.create({
     fontWeight: 600,
     boxShadow: 'inset 0 -2px 0 0 currentColor',
   },
-  spacer: {
+  desktopActions: {
+    display: { default: 'none', [`@media ${DESKTOP}`]: 'block' },
     marginLeft: 'auto',
   },
+  toggle: {
+    display: { default: 'flex', [`@media ${DESKTOP}`]: 'none' },
+    position: 'relative',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '44px',
+    height: '44px',
+    padding: 0,
+    color: color.textPrimary,
+    backgroundColor: { default: 'transparent', ':hover': color.surface },
+    borderStyle: 'none',
+    borderRadius: radius.sm,
+    cursor: 'pointer',
+  },
+  badge: {
+    position: 'absolute',
+    top: '2px',
+    right: '2px',
+    minWidth: '18px',
+    height: '18px',
+    padding: '0 4px',
+    color: color.onAccent,
+    backgroundColor: color.danger,
+    borderRadius: '9px',
+    fontSize: '0.6875rem',
+    fontWeight: 700,
+    lineHeight: '18px',
+    textAlign: 'center',
+  },
+  backdrop: {
+    display: { default: 'block', [`@media ${DESKTOP}`]: 'none' },
+    position: 'fixed',
+    inset: 0,
+    width: '100%',
+    height: '100%',
+    padding: 0,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    borderStyle: 'none',
+    cursor: 'pointer',
+    animationName: fadeIn,
+    animationDuration: '0.2s',
+    zIndex: 998,
+  },
+  panel: {
+    display: { default: 'flex', [`@media ${DESKTOP}`]: 'none' },
+    flexDirection: 'column',
+    position: 'fixed',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: '80%',
+    maxWidth: '320px',
+    backgroundColor: color.surface,
+    boxShadow: '-2px 0 8px rgba(0,0,0,0.15)',
+    overflowY: 'auto',
+    animationName: slideIn,
+    animationDuration: '0.25s',
+    zIndex: 999,
+  },
+  panelHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: `${space.sm} ${space.md}`,
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: color.border,
+  },
+  panelTitle: {
+    color: color.textPrimary,
+    fontSize: '1.125rem',
+    fontWeight: 700,
+  },
+  close: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '44px',
+    height: '44px',
+    padding: 0,
+    color: color.textPrimary,
+    backgroundColor: { default: 'transparent', ':hover': color.surfaceMuted },
+    borderStyle: 'none',
+    borderRadius: radius.sm,
+    cursor: 'pointer',
+  },
+  panelList: {
+    margin: 0,
+    padding: `${space.sm} 0`,
+    listStyle: 'none',
+  },
+  panelLink: {
+    display: 'flex',
+    alignItems: 'center',
+    minHeight: '44px',
+    padding: `${space.sm} ${space.md}`,
+    color: { default: color.textSecondary, ':hover': color.accent },
+    backgroundColor: { default: 'transparent', ':hover': color.surfaceMuted },
+    fontSize: '1rem',
+    textDecoration: 'none',
+  },
+  panelLinkActive: {
+    color: color.accent,
+    backgroundColor: color.surfaceMuted,
+    fontWeight: 600,
+    boxShadow: `inset 3px 0 0 0 currentColor`,
+  },
+  panelFooter: {
+    marginTop: 'auto',
+    padding: space.md,
+    borderTopWidth: '1px',
+    borderTopStyle: 'solid',
+    borderTopColor: color.border,
+  },
 });
-
-type AdminMenuProps = {
-  supabase: any;
-  user: any;
-  /**
-   * Discs waiting to be fetched from the club's storage, or null when this club
-   * keeps no retrieval list -- and so has no menu item for it.
-   */
-  retrievalCount: number | null;
-  /** Owners' answers not yet dealt with, or null when nobody is signed in. */
-  responseCount: number | null;
-};
-
-export default function AdminMenu({
-  supabase,
-  user,
-  retrievalCount,
-  responseCount,
-}: AdminMenuProps): JSX.Element | null {
-  const handleLogout = async () => {
-    if (!window.confirm('Haluatko varmasti kirjautua ulos?')) {
-      return;
-    }
-
-    await supabase.auth.signOut();
-  };
-
-  if (user?.email == null) {
-    return null;
-  }
-
-  return (
-    <nav {...stylex.props(styles.nav)}>
-      <ul {...stylex.props(styles.list)}>
-        {menuLinks(retrievalCount, responseCount).map(({ to, label }) => (
-          <li key={to}>
-            <NavLink
-              to={to}
-              end={to === '/'}
-              className={({ isActive }) => stylex.props(styles.link, isActive && styles.activeLink).className ?? ''}
-            >
-              {label}
-            </NavLink>
-          </li>
-        ))}
-      </ul>
-      <div {...stylex.props(styles.spacer)}>
-        <Button variant="contained" color="error" size="small" onClick={handleLogout}>
-          Kirjaudu ulos
-        </Button>
-      </div>
-    </nav>
-  );
-}

--- a/app/ui/AdminMenu.tsx
+++ b/app/ui/AdminMenu.tsx
@@ -7,6 +7,7 @@ import Button from '~/ui/Button';
 import { CloseIcon, MenuIcon } from '~/ui/icons';
 import { color, radius, space } from '~/styles/tokens.stylex';
 
+import type { SupabaseClient, User } from '@supabase/supabase-js';
 import type { JSX } from 'react';
 
 type MenuLink = { to: string; label: string };
@@ -24,7 +25,12 @@ const links: MenuLink[] = [
 // panel behind the hamburger button. Kept in one place so the bar, the button
 // and the panel cannot disagree about it -- a link reachable in both at the same
 // width would sit twice in the tab order.
-const DESKTOP = '(min-width: 768px)';
+const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
+
+// What the Tab key can reach. Wider than the panel currently contains, so
+// adding a field to it later does not quietly punch a hole in the focus trap.
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 /**
  * A count in parentheses, or nothing.
@@ -58,8 +64,8 @@ function menuLinks(retrievalCount: number | null, responseCount: number | null):
 }
 
 type AdminMenuProps = {
-  supabase: any;
-  user: any;
+  supabase: SupabaseClient;
+  user: User | null | undefined;
   /**
    * Discs waiting to be fetched from the club's storage, or null when this club
    * keeps no retrieval list -- and so has no menu item for it.
@@ -78,59 +84,45 @@ export default function AdminMenu({
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const toggleRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
   const closeRef = useRef<HTMLButtonElement>(null);
   const { pathname } = useLocation();
+  const shownPathname = useRef(pathname);
 
   const closePanel = useCallback(() => setIsPanelOpen(false), []);
 
-  // Nothing behind the panel may scroll while it is open. Cleared on unmount as
-  // well as on close, so signing out from inside the panel cannot leave the
-  // next page permanently stuck.
-  useEffect(() => {
-    if (!isPanelOpen) {
-      return;
-    }
-
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isPanelOpen]);
-
-  // The panel only exists below the breakpoint. Widening the window past it
-  // hides the panel by CSS, so the state has to follow -- otherwise the scroll
-  // lock above would outlive the thing that asked for it.
-  useEffect(() => {
-    if (!isPanelOpen) {
-      return;
-    }
-
-    const desktop = window.matchMedia(DESKTOP);
-    const onChange = () => desktop.matches && closePanel();
-
-    desktop.addEventListener('change', onChange);
-
-    return () => desktop.removeEventListener('change', onChange);
-  }, [isPanelOpen, closePanel]);
-
-  // Focus starts on the close button, Escape closes, and Tab cycles inside the
-  // panel instead of walking into the page behind it. Focus goes back to the
-  // hamburger on close, so a keyboard user is not dropped at the top of the
-  // document.
+  // Everything the panel does to the rest of the page, in one effect, because
+  // the order of the undoing matters: the background stops being inert before
+  // focus is put back into it, and the scroll position it had is what it gets
+  // back.
   useEffect(() => {
     const panel = panelRef.current;
+    const backdrop = backdropRef.current;
 
     if (!isPanelOpen || panel == null) {
       return;
     }
+
+    const toggle = toggleRef.current;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    // `inert` is what actually makes the page behind the panel unreachable: no
+    // Tab, no click, and no screen-reader cursor either. `aria-modal` alone asks
+    // the screen reader nicely; this tells the browser. Anything that contains
+    // the panel or its backdrop is left alone, so the two survive being moved
+    // deeper into the page some day.
+    const background = Array.from(document.body.children).filter(
+      (element) => !element.contains(panel) && !(backdrop != null && element.contains(backdrop)),
+    );
+    background.forEach((element) => element.setAttribute('inert', ''));
 
     closeRef.current?.focus();
 
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         closePanel();
-        toggleRef.current?.focus();
         return;
       }
 
@@ -138,7 +130,7 @@ export default function AdminMenu({
         return;
       }
 
-      const focusable = panel.querySelectorAll<HTMLElement>('a[href], button:not([disabled])');
+      const focusable = panel.querySelectorAll<HTMLElement>(FOCUSABLE);
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
 
@@ -146,7 +138,12 @@ export default function AdminMenu({
         return;
       }
 
-      if (event.shiftKey && document.activeElement === first) {
+      // Focus that is somehow outside the panel is pulled back into it, not
+      // only wrapped around at the two ends.
+      if (!panel.contains(document.activeElement)) {
+        first.focus();
+        event.preventDefault();
+      } else if (event.shiftKey && document.activeElement === first) {
         last.focus();
         event.preventDefault();
       } else if (!event.shiftKey && document.activeElement === last) {
@@ -157,8 +154,47 @@ export default function AdminMenu({
 
     document.addEventListener('keydown', onKeyDown);
 
-    return () => document.removeEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      background.forEach((element) => element.removeAttribute('inert'));
+      document.body.style.overflow = previousOverflow;
+
+      // Closing anything -- the button, Escape, the backdrop, a navigation --
+      // ends here, so focus comes back to the hamburger from every one of them.
+      // Focus that has already gone somewhere deliberate is left where it is;
+      // only focus dropped on the document is rescued.
+      if (document.activeElement == null || document.activeElement === document.body) {
+        toggle?.focus();
+      }
+    };
   }, [isPanelOpen, closePanel]);
+
+  // The panel only exists below the breakpoint. Widening the window past it
+  // hides the panel by CSS, so the state has to follow -- otherwise the scroll
+  // lock and the inert background would outlive the thing that asked for them.
+  useEffect(() => {
+    if (!isPanelOpen) {
+      return;
+    }
+
+    const desktop = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    const onChange = () => desktop.matches && closePanel();
+
+    desktop.addEventListener('change', onChange);
+
+    return () => desktop.removeEventListener('change', onChange);
+  }, [isPanelOpen, closePanel]);
+
+  // The address changing means the panel has served its purpose. This is what
+  // catches the browser's back button, which no click handler sees.
+  useEffect(() => {
+    if (shownPathname.current === pathname) {
+      return;
+    }
+
+    shownPathname.current = pathname;
+    closePanel();
+  }, [pathname, closePanel]);
 
   const handleLogout = async () => {
     if (!window.confirm('Haluatko varmasti kirjautua ulos?')) {
@@ -187,27 +223,22 @@ export default function AdminMenu({
     <>
       <nav {...stylex.props(styles.nav)} aria-label="Päävalikko">
         <ul {...stylex.props(styles.list)}>
-          {items.map(({ to, label }) => (
-            <li key={to}>
-              <NavLink
-                to={to}
-                end={to === '/'}
-                className={({ isActive }) => stylex.props(styles.link, isActive && styles.activeLink).className ?? ''}
-              >
-                {label}
-              </NavLink>
-            </li>
+          {items.map((item) => (
+            <MenuNavLink key={item.to} {...item} variant="bar" />
           ))}
         </ul>
         <div {...stylex.props(styles.desktopActions)}>{logoutButton}</div>
         <button
           ref={toggleRef}
           type="button"
-          {...stylex.props(styles.toggle)}
+          {...stylex.props(styles.iconButton, styles.toggle)}
           onClick={() => setIsPanelOpen(true)}
           aria-label={pending > 0 ? `Avaa valikko, ${pending} odottaa käsittelyä` : 'Avaa valikko'}
           aria-expanded={isPanelOpen}
-          aria-controls="admin-menu-panel"
+          // Only while the panel is in the page: the panel is mounted on
+          // opening, and a reference to an id that does not exist is worse than
+          // no reference at all.
+          aria-controls={isPanelOpen ? PANEL_ID : undefined}
         >
           <MenuIcon />
           {pending > 0 && (
@@ -220,19 +251,13 @@ export default function AdminMenu({
 
       {isPanelOpen && (
         <>
-          {/* Mouse-and-thumb convenience only: the keyboard closes the panel with
-              Escape or the close button, so the screen reader is better off not
-              hearing about this at all. tabIndex -1 keeps it out of the tab order,
-              which is what makes aria-hidden legitimate on a <button>. */}
-          <button
-            type="button"
-            {...stylex.props(styles.backdrop)}
-            onClick={closePanel}
-            tabIndex={-1}
-            aria-hidden="true"
-          />
+          {/* Closing by tapping outside is a pointer convenience; the keyboard
+              has Escape and the close button. role="presentation" says as much,
+              and keeps the backdrop out of the tab order and the accessibility
+              tree without a focusable element pretending to be hidden. */}
+          <div ref={backdropRef} role="presentation" {...stylex.props(styles.backdrop)} onClick={closePanel} />
           <div
-            id="admin-menu-panel"
+            id={PANEL_ID}
             ref={panelRef}
             {...stylex.props(styles.panel)}
             role="dialog"
@@ -244,63 +269,59 @@ export default function AdminMenu({
               <button
                 ref={closeRef}
                 type="button"
-                {...stylex.props(styles.close)}
-                onClick={() => {
-                  closePanel();
-                  toggleRef.current?.focus();
-                }}
+                {...stylex.props(styles.iconButton, styles.close)}
+                onClick={closePanel}
                 aria-label="Sulje valikko"
               >
                 <CloseIcon />
               </button>
             </div>
             <ul {...stylex.props(styles.panelList)}>
-              {items.map(({ to, label }) => (
-                <li key={to}>
-                  <NavLink
-                    to={to}
-                    end={to === '/'}
-                    // Following a link to the page already open changes no
-                    // address, so closing cannot be left to the pathname alone.
-                    onClick={closePanel}
-                    className={({ isActive }) =>
-                      stylex.props(styles.panelLink, isActive && styles.panelLinkActive).className ?? ''
-                    }
-                  >
-                    {label}
-                  </NavLink>
-                </li>
+              {items.map((item) => (
+                // Following a link to the page already open changes no address,
+                // so closing cannot be left to the pathname alone.
+                <MenuNavLink key={item.to} {...item} variant="panel" onClick={closePanel} />
               ))}
             </ul>
             <div {...stylex.props(styles.panelFooter)}>{logoutButton}</div>
           </div>
         </>
       )}
-      {/* The address changing means the panel has served its purpose -- this
-          catches the browser's back button, which no click handler sees. */}
-      <PanelCloserOnNavigation pathname={pathname} onNavigate={closePanel} />
     </>
   );
 }
 
+const PANEL_ID = 'admin-menu-panel';
+
+type MenuNavLinkProps = MenuLink & {
+  /** Which of the two layouts this link is being drawn in. */
+  variant: 'bar' | 'panel';
+  onClick?: () => void;
+};
+
 /**
- * Closes the panel whenever the address changes.
+ * One list item, in the bar or in the panel.
  *
- * A tiny component of its own rather than an effect in `AdminMenu`, so the
- * "close on navigation" rule is one readable thing and does not need a guard
- * against firing on the first render.
+ * The same links appear in both layouts, so they are described once here and
+ * the layout only picks the styling. Only the styling differs; a label or a
+ * target cannot drift between the two.
  */
-function PanelCloserOnNavigation({ pathname, onNavigate }: { pathname: string; onNavigate: () => void }): null {
-  const previous = useRef(pathname);
+function MenuNavLink({ to, label, variant, onClick }: MenuNavLinkProps): JSX.Element {
+  const [base, active] =
+    variant === 'bar' ? [styles.link, styles.activeLink] : [styles.panelLink, styles.panelLinkActive];
 
-  useEffect(() => {
-    if (previous.current !== pathname) {
-      previous.current = pathname;
-      onNavigate();
-    }
-  }, [pathname, onNavigate]);
-
-  return null;
+  return (
+    <li>
+      <NavLink
+        to={to}
+        end={to === '/'}
+        onClick={onClick}
+        className={({ isActive }) => stylex.props(base, isActive && active).className ?? ''}
+      >
+        {label}
+      </NavLink>
+    </li>
+  );
 }
 
 const slideIn = stylex.keyframes({
@@ -320,7 +341,7 @@ const styles = stylex.create({
     display: 'flex',
     flexWrap: 'wrap',
     alignItems: 'center',
-    justifyContent: { default: 'flex-end', [`@media ${DESKTOP}`]: 'flex-start' },
+    justifyContent: { default: 'flex-end', [`@media ${DESKTOP_MEDIA_QUERY}`]: 'flex-start' },
     gap: space.sm,
     padding: `${space.sm} ${space.md}`,
     backgroundColor: color.surfaceMuted,
@@ -330,7 +351,7 @@ const styles = stylex.create({
     boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
   },
   list: {
-    display: { default: 'none', [`@media ${DESKTOP}`]: 'flex' },
+    display: { default: 'none', [`@media ${DESKTOP_MEDIA_QUERY}`]: 'flex' },
     flexWrap: 'wrap',
     alignItems: 'center',
     gap: space.xs,
@@ -355,22 +376,30 @@ const styles = stylex.create({
     boxShadow: 'inset 0 -2px 0 0 currentColor',
   },
   desktopActions: {
-    display: { default: 'none', [`@media ${DESKTOP}`]: 'block' },
+    display: { default: 'none', [`@media ${DESKTOP_MEDIA_QUERY}`]: 'block' },
     marginLeft: 'auto',
   },
-  toggle: {
-    display: { default: 'flex', [`@media ${DESKTOP}`]: 'none' },
-    position: 'relative',
+  // 44 by 44 is the smallest square that is reliably hittable with a thumb, and
+  // both of the phone layout's icon buttons want it.
+  iconButton: {
+    display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     width: '44px',
     height: '44px',
     padding: 0,
     color: color.textPrimary,
-    backgroundColor: { default: 'transparent', ':hover': color.surface },
     borderStyle: 'none',
     borderRadius: radius.sm,
     cursor: 'pointer',
+  },
+  toggle: {
+    display: { default: 'flex', [`@media ${DESKTOP_MEDIA_QUERY}`]: 'none' },
+    position: 'relative',
+    backgroundColor: { default: 'transparent', ':hover': color.surface },
+  },
+  close: {
+    backgroundColor: { default: 'transparent', ':hover': color.surfaceMuted },
   },
   badge: {
     position: 'absolute',
@@ -388,21 +417,17 @@ const styles = stylex.create({
     textAlign: 'center',
   },
   backdrop: {
-    display: { default: 'block', [`@media ${DESKTOP}`]: 'none' },
+    display: { default: 'block', [`@media ${DESKTOP_MEDIA_QUERY}`]: 'none' },
     position: 'fixed',
     inset: 0,
-    width: '100%',
-    height: '100%',
-    padding: 0,
     backgroundColor: 'rgba(0,0,0,0.5)',
-    borderStyle: 'none',
     cursor: 'pointer',
     animationName: fadeIn,
     animationDuration: '0.2s',
     zIndex: 998,
   },
   panel: {
-    display: { default: 'flex', [`@media ${DESKTOP}`]: 'none' },
+    display: { default: 'flex', [`@media ${DESKTOP_MEDIA_QUERY}`]: 'none' },
     flexDirection: 'column',
     position: 'fixed',
     top: 0,
@@ -431,19 +456,6 @@ const styles = stylex.create({
     fontSize: '1.125rem',
     fontWeight: 700,
   },
-  close: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '44px',
-    height: '44px',
-    padding: 0,
-    color: color.textPrimary,
-    backgroundColor: { default: 'transparent', ':hover': color.surfaceMuted },
-    borderStyle: 'none',
-    borderRadius: radius.sm,
-    cursor: 'pointer',
-  },
   panelList: {
     margin: 0,
     padding: `${space.sm} 0`,
@@ -463,7 +475,7 @@ const styles = stylex.create({
     color: color.accent,
     backgroundColor: color.surfaceMuted,
     fontWeight: 600,
-    boxShadow: `inset 3px 0 0 0 currentColor`,
+    boxShadow: 'inset 3px 0 0 0 currentColor',
   },
   panelFooter: {
     marginTop: 'auto',

--- a/app/ui/AdminMenu.tsx
+++ b/app/ui/AdminMenu.tsx
@@ -27,10 +27,9 @@ const links: MenuLink[] = [
 // width would sit twice in the tab order.
 const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
 
-// What the Tab key can reach. Wider than the panel currently contains, so
-// adding a field to it later does not quietly punch a hole in the focus trap.
-const FOCUSABLE =
-  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+// What the Tab key can reach inside the panel: its links, and its two buttons.
+// That is everything the panel contains; widen this if it ever grows a field.
+const FOCUSABLE = 'a[href], button:not([disabled])';
 
 /**
  * A count in parentheses, or nothing.
@@ -91,73 +90,28 @@ export default function AdminMenu({
 
   const closePanel = useCallback(() => setIsPanelOpen(false), []);
 
-  // Everything the panel does to the rest of the page, in one effect, because
-  // the order of the undoing matters: the background stops being inert before
-  // focus is put back into it, and the scroll position it had is what it gets
-  // back.
+  // The three things the panel does to the rest of the page. They are set up
+  // independently, but undone in one place and in one order, because focusing a
+  // button that is still inert would silently do nothing.
   useEffect(() => {
     const panel = panelRef.current;
-    const backdrop = backdropRef.current;
 
     if (!isPanelOpen || panel == null) {
       return;
     }
 
-    const toggle = toggleRef.current;
-
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    // `inert` is what actually makes the page behind the panel unreachable: no
-    // Tab, no click, and no screen-reader cursor either. `aria-modal` alone asks
-    // the screen reader nicely; this tells the browser. Anything that contains
-    // the panel or its backdrop is left alone, so the two survive being moved
-    // deeper into the page some day.
-    const background = Array.from(document.body.children).filter(
-      (element) => !element.contains(panel) && !(backdrop != null && element.contains(backdrop)),
-    );
-    background.forEach((element) => element.setAttribute('inert', ''));
+    const releaseBackground = makeBackgroundInert(panel, backdropRef.current);
+    const releaseScroll = lockScroll();
+    const releaseKeyboard = trapKeyboard(panel, closePanel);
 
     closeRef.current?.focus();
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closePanel();
-        return;
-      }
-
-      if (event.key !== 'Tab') {
-        return;
-      }
-
-      const focusable = panel.querySelectorAll<HTMLElement>(FOCUSABLE);
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-
-      if (first == null) {
-        return;
-      }
-
-      // Focus that is somehow outside the panel is pulled back into it, not
-      // only wrapped around at the two ends.
-      if (!panel.contains(document.activeElement)) {
-        first.focus();
-        event.preventDefault();
-      } else if (event.shiftKey && document.activeElement === first) {
-        last.focus();
-        event.preventDefault();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        first.focus();
-        event.preventDefault();
-      }
-    };
-
-    document.addEventListener('keydown', onKeyDown);
+    const toggle = toggleRef.current;
 
     return () => {
-      document.removeEventListener('keydown', onKeyDown);
-      background.forEach((element) => element.removeAttribute('inert'));
-      document.body.style.overflow = previousOverflow;
+      releaseKeyboard();
+      releaseBackground();
+      releaseScroll();
 
       // Closing anything -- the button, Escape, the backdrop, a navigation --
       // ends here, so focus comes back to the hamburger from every one of them.
@@ -172,6 +126,10 @@ export default function AdminMenu({
   // The panel only exists below the breakpoint. Widening the window past it
   // hides the panel by CSS, so the state has to follow -- otherwise the scroll
   // lock and the inert background would outlive the thing that asked for them.
+  //
+  // This is the one close path that returns focus nowhere: at that width the
+  // hamburger is `display: none`, so focusing it does nothing and focus stays on
+  // the document. See the spec's known gaps.
   useEffect(() => {
     if (!isPanelOpen) {
       return;
@@ -289,6 +247,83 @@ export default function AdminMenu({
       )}
     </>
   );
+}
+
+/**
+ * Makes everything except the panel unreachable, and gives back the undo.
+ *
+ * `inert` is what actually does it: no Tab, no click, and no screen-reader
+ * cursor either. `aria-modal` alone asks the screen reader nicely; this tells
+ * the browser. Anything that contains the panel or its backdrop is left alone,
+ * so the two survive being moved deeper into the page some day.
+ *
+ * The children are looked at once, on opening. See the spec's known gaps.
+ */
+function makeBackgroundInert(panel: HTMLElement, backdrop: HTMLElement | null): () => void {
+  const background = Array.from(document.body.children).filter(
+    (element) => !element.contains(panel) && !(backdrop != null && element.contains(backdrop)),
+  );
+
+  background.forEach((element) => element.setAttribute('inert', ''));
+
+  return () => background.forEach((element) => element.removeAttribute('inert'));
+}
+
+/**
+ * Stops the page behind the panel scrolling, and gives back the undo.
+ *
+ * The undo puts back whatever `overflow` was there before rather than blanking
+ * it, so the lock cannot quietly discard someone else's value.
+ */
+function lockScroll(): () => void {
+  const previous = document.body.style.overflow;
+  document.body.style.overflow = 'hidden';
+
+  return () => {
+    document.body.style.overflow = previous;
+  };
+}
+
+/**
+ * Keeps Tab inside the panel and makes Escape close it; gives back the undo.
+ *
+ * Focus that is somehow outside the panel is pulled back into it, not only
+ * wrapped around at the two ends.
+ */
+function trapKeyboard(panel: HTMLElement, close: () => void): () => void {
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      close();
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusable = panel.querySelectorAll<HTMLElement>(FOCUSABLE);
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (first == null) {
+      return;
+    }
+
+    if (!panel.contains(document.activeElement)) {
+      first.focus();
+      event.preventDefault();
+    } else if (event.shiftKey && document.activeElement === first) {
+      last.focus();
+      event.preventDefault();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      first.focus();
+      event.preventDefault();
+    }
+  };
+
+  document.addEventListener('keydown', onKeyDown);
+
+  return () => document.removeEventListener('keydown', onKeyDown);
 }
 
 const PANEL_ID = 'admin-menu-panel';

--- a/app/ui/AdminMenu.tsx
+++ b/app/ui/AdminMenu.tsx
@@ -90,9 +90,9 @@ export default function AdminMenu({
 
   const closePanel = useCallback(() => setIsPanelOpen(false), []);
 
-  // The three things the panel does to the rest of the page. They are set up
-  // independently, but undone in one place and in one order, because focusing a
-  // button that is still inert would silently do nothing.
+  // What the panel does to the rest of the page while it is open. Each piece is
+  // set up independently, but they are undone in one place and in one order,
+  // because focusing a button that is still inert would silently do nothing.
   useEffect(() => {
     const panel = panelRef.current;
 
@@ -102,7 +102,7 @@ export default function AdminMenu({
 
     const releaseBackground = makeBackgroundInert(panel, backdropRef.current);
     const releaseScroll = lockScroll();
-    const releaseKeyboard = trapKeyboard(panel, closePanel);
+    const releaseKeyboard = handlePanelKeys(panel, closePanel);
 
     closeRef.current?.focus();
 
@@ -285,12 +285,14 @@ function lockScroll(): () => void {
 }
 
 /**
- * Keeps Tab inside the panel and makes Escape close it; gives back the undo.
+ * Takes over the two keys a dialog owns, and gives back the undo.
+ *
+ * Tab is kept inside the panel; Escape closes it.
  *
  * Focus that is somehow outside the panel is pulled back into it, not only
  * wrapped around at the two ends.
  */
-function trapKeyboard(panel: HTMLElement, close: () => void): () => void {
+function handlePanelKeys(panel: HTMLElement, close: () => void): () => void {
   const onKeyDown = (event: KeyboardEvent) => {
     if (event.key === 'Escape') {
       close();

--- a/app/ui/icons.tsx
+++ b/app/ui/icons.tsx
@@ -86,6 +86,22 @@ export function DeleteIcon(props: IconProps): JSX.Element {
   );
 }
 
+export function MenuIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
+    </SvgIcon>
+  );
+}
+
+export function CloseIcon(props: IconProps): JSX.Element {
+  return (
+    <SvgIcon {...props}>
+      <path d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+    </SvgIcon>
+  );
+}
+
 export function ArrowUpwardIcon(props: IconProps): JSX.Element {
   return (
     <SvgIcon {...props}>

--- a/e2e/admin-menu.spec.ts
+++ b/e2e/admin-menu.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// The admin menu only exists for a signed-in admin, so these need a test
+// account:
+//   E2E_EMAIL=... E2E_PASSWORD=... npm run test:e2e
+// Without one the suite skips rather than failing.
+const EMAIL = process.env.E2E_EMAIL;
+const PASSWORD = process.env.E2E_PASSWORD;
+
+// Narrow enough to be below the 768px breakpoint in AdminMenu.
+const PHONE = { width: 390, height: 844 };
+
+async function signIn(page: Page): Promise<void> {
+  await page.goto('/sign-in');
+  await page.getByLabel('Sähköpostiosoite').fill(EMAIL!);
+  await page.getByLabel('Salasana').fill(PASSWORD!);
+  await page.getByRole('button', { name: 'Kirjaudu sisään' }).click();
+  await expect(page.getByRole('button', { name: 'Kirjaudu sisään' })).toHaveCount(0);
+}
+
+test.describe('admin menu on a phone-sized screen', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!EMAIL || !PASSWORD, 'Set E2E_EMAIL and E2E_PASSWORD to run these.');
+
+    await page.setViewportSize(PHONE);
+    await signIn(page);
+    await page.goto('/');
+  });
+
+  test('hides the links until the hamburger is pressed, then closes on a link', async ({ page }) => {
+    const panel = page.getByRole('dialog', { name: 'Valikko' });
+
+    // Not merely off-screen: the links are not in the page at all.
+    await expect(page.getByRole('link', { name: 'Tyhjennysloki' })).toHaveCount(0);
+    await expect(panel).toHaveCount(0);
+
+    await page.getByRole('button', { name: /^Avaa valikko/ }).click();
+
+    await expect(panel).toBeVisible();
+    await expect(panel.getByRole('link', { name: 'Tyhjennysloki' })).toBeVisible();
+
+    await panel.getByRole('link', { name: 'Tyhjennysloki' }).click();
+
+    await expect(page).toHaveURL(/\/emptying-log$/);
+    await expect(panel).toHaveCount(0);
+  });
+
+  test('traps focus, closes on Escape and gives focus back to the hamburger', async ({ page }) => {
+    const hamburger = page.getByRole('button', { name: /^Avaa valikko/ });
+
+    await hamburger.click();
+
+    // Focus lands on the close button, and Shift+Tab wraps to the last thing in
+    // the panel rather than escaping into the page behind it.
+    await expect(page.getByRole('button', { name: 'Sulje valikko' })).toBeFocused();
+    await page.keyboard.press('Shift+Tab');
+    await expect(page.getByRole('button', { name: 'Kirjaudu ulos' })).toBeFocused();
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.getByRole('dialog', { name: 'Valikko' })).toHaveCount(0);
+    await expect(hamburger).toBeFocused();
+  });
+
+  test('blocks scrolling of the page behind the panel', async ({ page }) => {
+    const overflow = () => page.evaluate(() => document.body.style.overflow);
+
+    await expect.poll(overflow).toBe('');
+
+    await page.getByRole('button', { name: /^Avaa valikko/ }).click();
+    await expect.poll(overflow).toBe('hidden');
+
+    await page.getByRole('button', { name: 'Sulje valikko' }).click();
+    await expect.poll(overflow).toBe('');
+  });
+});

--- a/e2e/admin-menu.spec.ts
+++ b/e2e/admin-menu.spec.ts
@@ -62,6 +62,37 @@ test.describe('admin menu on a phone-sized screen', () => {
     await expect(hamburger).toBeFocused();
   });
 
+  test('gives focus back to the hamburger when closed by tapping outside', async ({ page }) => {
+    const hamburger = page.getByRole('button', { name: /^Avaa valikko/ });
+
+    await hamburger.click();
+    await expect(page.getByRole('dialog', { name: 'Valikko' })).toBeVisible();
+
+    // The dimmed area covers the whole viewport, so the top-left corner is
+    // outside the panel, which sits on the right.
+    await page.mouse.click(10, 300);
+
+    await expect(page.getByRole('dialog', { name: 'Valikko' })).toHaveCount(0);
+    await expect(hamburger).toBeFocused();
+  });
+
+  test('makes the page behind the panel inert', async ({ page }) => {
+    const inertCount = () => page.locator('body > [inert]').count();
+
+    expect(await inertCount()).toBe(0);
+
+    await page.getByRole('button', { name: /^Avaa valikko/ }).click();
+
+    // The bar and the page content are both direct children of <body>; neither
+    // the panel nor its backdrop may be inert.
+    expect(await inertCount()).toBeGreaterThan(0);
+    await expect(page.getByRole('dialog', { name: 'Valikko' })).not.toHaveAttribute('inert', '');
+
+    await page.keyboard.press('Escape');
+
+    expect(await inertCount()).toBe(0);
+  });
+
   test('blocks scrolling of the page behind the panel', async ({ page }) => {
     const overflow = () => page.evaluate(() => document.body.style.overflow);
 

--- a/specs/11-auth-and-authorization.md
+++ b/specs/11-auth-and-authorization.md
@@ -18,7 +18,7 @@ cookie sessions, with row-level security in Postgres as the second line.
 2. When either field is empty or Supabase rejects the credentials, then the form re-renders with a Finnish error and HTTP 422.
 3. When a signed-out visitor requests an admin page, then its loader redirects to `/sign-in`.
 4. When a signed-out client POSTs to a disc resource route, then it gets `401` with `Kirjautuminen on vanhentunut. Kirjaudu uudelleen.`
-5. When signed in, then `AdminMenu` appears above every page and the disc list gains admin-only columns and row actions.
+5. When signed in, then `AdminMenu` appears above every page and the disc list gains admin-only columns and row actions. What that menu contains and how it behaves on a phone is [13](13-admin-navigation.md).
 6. When "Kirjaudu ulos" is confirmed, then `supabase.auth.signOut()` runs in the browser; `root.tsx` sees the auth-state change and revalidates.
 
 ## Data

--- a/specs/13-admin-navigation.md
+++ b/specs/13-admin-navigation.md
@@ -65,15 +65,18 @@ Below 768 pixels (the phone layout):
 8. When the admin presses the hamburger, then a panel slides in from the right
    over the page, holding the title "Valikko" (menu), a close button, the same
    links one per row, and the sign-out button. The rest of the page dims behind
-   it and cannot be scrolled or clicked.
+   it and, for as long as the panel is open, cannot be scrolled, clicked, tabbed
+   into or reached by a screen reader's cursor.
 9. When the panel is open, then keyboard focus is inside it: it moves to the
-   close button, Tab and Shift+Tab cycle within the panel and never reach the
-   page behind, and Escape closes it. On closing, focus returns to the hamburger
-   button, so a keyboard user is not dropped at the top of the document.
-10. When the admin follows a link, presses Escape, presses the close button, or
-    taps the dimmed area, then the panel closes. It also closes by itself
-    whenever the address changes — including the browser's back button — so it is
-    never left open over a page the admin has already navigated away from.
+   close button, Tab and Shift+Tab cycle within the panel, and focus that is
+   somehow outside it is pulled back in on the next Tab. Escape closes it.
+10. When the admin follows a link, presses Escape, presses the close button, taps
+    the dimmed area, or navigates with the browser's back button, then the panel
+    closes — and focus goes back to the hamburger button from every one of those,
+    so a keyboard user is never dropped at the top of the document. Focus that
+    has meanwhile moved somewhere deliberate is left alone; only focus dropped on
+    the document itself is rescued. The panel is never left open over a page the
+    admin has already navigated away from.
 
 ## Data
 
@@ -120,11 +123,25 @@ its links point at routes owned by other features:
   `aria-label="Valikko"` — and is mounted only while open. Mounting rather than
   hiding with a transform is deliberate: a panel that is merely translated
   off-screen keeps its links in the tab order and in the screen reader's
-  document, which is the bug this replaces.
+  document, which is the bug this replaces. The hamburger's `aria-controls`
+  points at the panel's id only while the panel is mounted, for the same reason:
+  a reference to an id that is not in the page is worse than no reference.
+- **The page behind the panel is made `inert`** — the HTML attribute that takes
+  an element and everything inside it out of reach: no clicks, no Tab, and no
+  screen-reader cursor either. Every child of `<body>` that does not contain the
+  panel or its backdrop gets the attribute while the panel is open. `aria-modal`
+  asks a screen reader to stay inside the dialog; `inert` is what actually
+  enforces it, and it is also what stops a pointer reaching the bar behind.
 - **Page scrolling is blocked** while the panel is open by setting
-  `document.body.style.overflow = 'hidden'`, cleared when the panel closes and
-  also when the component unmounts, so a sign-out mid-panel cannot leave the page
-  permanently unscrollable.
+  `document.body.style.overflow = 'hidden'`. On closing, the value that was there
+  before is put back rather than blanked, so the lock cannot quietly discard an
+  `overflow` some other component had set. The undoing also runs when the
+  component unmounts, so signing out from inside the panel cannot leave the next
+  page permanently unscrollable.
+- **Everything the panel does to the rest of the page is undone in one place**,
+  in a fixed order: the background stops being inert, the scroll position is
+  released, and only then does focus go back to the hamburger — focusing a button
+  that is still inert would silently do nothing.
 - **Touch targets in the phone layout are at least 44 by 44 pixels** (the
   hamburger, the close button, each link row), the smallest size that is reliably
   hittable with a thumb.
@@ -139,9 +156,9 @@ its links point at routes owned by other features:
 - The scroll lock is `overflow: hidden` on `<body>`. Older iOS Safari can still
   rubber-band the page behind the panel; the sturdier fix (fixing the body and
   restoring `scrollY` on close) was not worth its complexity here.
-- The link list is written twice, once for the bar and once for the panel, from
-  the same `menuLinks()` data. The two could drift; there is no test that they
-  hold the same labels.
+- `inert` is supported by every current browser but was only widely available
+  from 2023. On something older the fallbacks are what remain: `aria-modal`, the
+  backdrop over the page, and the links behind the panel being `display: none`.
 - The end-to-end (E2E) test for the phone layout needs a real admin account and
   skips itself unless `E2E_EMAIL` and `E2E_PASSWORD` are set, like the other
   signed-in E2E tests. There is no unit test, because this repo has no test setup

--- a/specs/13-admin-navigation.md
+++ b/specs/13-admin-navigation.md
@@ -1,0 +1,153 @@
+# Admin navigation menu
+
+> Status: as-built (describes what exists today, not a wishlist)
+>
+> Writing rules — reader who does not know this codebase, every abbreviation
+> explained on first use, plain words over jargon, as long as the subject needs.
+> See `.claude/skills/specs/SKILL.md`.
+
+## Purpose
+
+Every admin page of the app is reached from one bar of links at the top of the
+window: the disc list, adding discs, the message templates, the statistics and
+so on, plus signing out. Two of those links also carry a count, because they are
+the only place an admin learns that something is waiting for them — an owner has
+answered about their disc, or a disc has to be fetched from storage.
+
+The bar has to work on a phone, which is where the club's admins actually use
+this app: standing at a course with one hand free. On a narrow screen the flat
+row of eight links wrapped onto three or four lines and pushed the page content
+below the fold, so below 768 pixels the links move into a panel behind a
+hamburger button (the three-line icon that opens a menu).
+
+## Actors
+
+Club admin — a signed-in user. Nobody else ever sees this menu: `AdminMenu`
+returns nothing at all when there is no signed-in user, and `app/root.tsx`
+additionally leaves it out on the `/notify*` paths for anonymous visitors.
+
+## User-facing behaviour
+
+Shared by both screen widths:
+
+1. When a signed-in admin loads any page, then the menu shows one link per admin
+   page — "Kiekot" (discs), "Lisää kiekkoja" (add discs), "Vastaukset" (owners'
+   answers), "Tyhjennysloki" (emptying log), "Viestipohjat" (message templates),
+   "Statistiikka" (statistics), "Ilmoitukset" (notifications), "Noutolista"
+   (retrieval list) — and a "Kirjaudu ulos" (sign out) button.
+2. When a counted item has something waiting, then its label carries the number
+   in parentheses — "Vastaukset (3)". At zero the number is left off entirely,
+   because "(0)" reads as something to act on. "Vastaukset" is absent when nobody
+   is signed in and "Noutolista" when the club keeps no retrieval list; both
+   counts arrive from the loader in `app/root.tsx` as `null` in that case.
+3. When the admin is on the page a link points to, then that link is marked as
+   the current page for a screen reader (`aria-current="page"`) as well as
+   visually.
+4. When the admin presses "Kirjaudu ulos", then the browser asks for confirmation
+   ("Haluatko varmasti kirjautua ulos?" — do you really want to sign out?) and
+   only then signs out.
+
+From 768 pixels wide upwards (the desktop layout):
+
+5. The links sit in one horizontal row with the sign-out button pushed to the
+   right edge. There is no hamburger button.
+
+Below 768 pixels (the phone layout):
+
+6. The bar holds a single hamburger button on the right. The links are not in the
+   page at all until it is pressed — not merely off-screen, so a screen reader or
+   the Tab key cannot reach them either.
+7. When something is waiting on a counted page, then the hamburger button carries
+   a small round badge with the total of the two counts, and its accessible name
+   says so: "Avaa valikko, 3 odottaa käsittelyä" (open menu, 3 awaiting
+   handling). Without the badge the counts would be invisible while the menu is
+   shut, which is the whole reason those two links carry numbers.
+8. When the admin presses the hamburger, then a panel slides in from the right
+   over the page, holding the title "Valikko" (menu), a close button, the same
+   links one per row, and the sign-out button. The rest of the page dims behind
+   it and cannot be scrolled or clicked.
+9. When the panel is open, then keyboard focus is inside it: it moves to the
+   close button, Tab and Shift+Tab cycle within the panel and never reach the
+   page behind, and Escape closes it. On closing, focus returns to the hamburger
+   button, so a keyboard user is not dropped at the top of the document.
+10. When the admin follows a link, presses Escape, presses the close button, or
+    taps the dimmed area, then the panel closes. It also closes by itself
+    whenever the address changes — including the browser's back button — so it is
+    never left open over a page the admin has already navigated away from.
+
+## Data
+
+None of its own. It renders what `app/root.tsx` gives it:
+
+| Prop             | Type                         | Meaning                                                                                                                     |
+| ---------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `user`           | Supabase user or `undefined` | Renders nothing unless this has an `email`.                                                                                 |
+| `supabase`       | browser Supabase client      | Used only for `auth.signOut()`.                                                                                             |
+| `responseCount`  | `number \| null`             | Owners' answers not yet dealt with; `null` when nobody is signed in, and the "Vastaukset" link is then left out.            |
+| `retrievalCount` | `number \| null`             | Discs waiting to be fetched from storage; `null` when this club keeps no retrieval list, and "Noutolista" is then left out. |
+
+The counts come from `loadResponseCount` and `loadRetrievalCount`, both called in
+the root loader on every navigation, so they are as fresh as the current page.
+
+## Routes & entry points
+
+The menu owns no route. It is rendered by `app/root.tsx` above every page, and
+its links point at routes owned by other features:
+
+| Link           | Route                | Spec                                 |
+| -------------- | -------------------- | ------------------------------------ |
+| Kiekot         | `/`                  | [01](01-public-disc-list.md)         |
+| Lisää kiekkoja | `/discs/add`         | [02](02-disc-submission.md)          |
+| Vastaukset     | `/vastaukset`        | [05](05-owner-link-and-responses.md) |
+| Tyhjennysloki  | `/emptying-log`      | [08](08-emptying-log.md)             |
+| Viestipohjat   | `/message-templates` | [06](06-messaging-and-templates.md)  |
+| Statistiikka   | `/stats`             | [10](10-statistics.md)               |
+| Ilmoitukset    | `/notifications`     | [07](07-notifications.md)            |
+| Noutolista     | `/retrieval`         | [03](03-disc-lifecycle-actions.md)   |
+
+## Rules & constraints
+
+- **The menu is not authorization.** Hiding a link hides nothing: every route
+  above checks the session itself, and the database's row level security (RLS —
+  the PostgreSQL feature that decides row by row whether a role may read or write
+  it) is what actually stops an anonymous request. See
+  [11](11-auth-and-authorization.md).
+- **One breakpoint, 768 pixels**, expressed as `@media (min-width: 768px)` in the
+  StyleX styles. Below it the links exist only inside the panel; from it up only
+  in the bar. There is no width at which both are present, so a link is never
+  reachable twice by the Tab key.
+- **The panel is a modal dialog** — `role="dialog"`, `aria-modal="true"`,
+  `aria-label="Valikko"` — and is mounted only while open. Mounting rather than
+  hiding with a transform is deliberate: a panel that is merely translated
+  off-screen keeps its links in the tab order and in the screen reader's
+  document, which is the bug this replaces.
+- **Page scrolling is blocked** while the panel is open by setting
+  `document.body.style.overflow = 'hidden'`, cleared when the panel closes and
+  also when the component unmounts, so a sign-out mid-panel cannot leave the page
+  permanently unscrollable.
+- **Touch targets in the phone layout are at least 44 by 44 pixels** (the
+  hamburger, the close button, each link row), the smallest size that is reliably
+  hittable with a thumb.
+- The panel slides in with a CSS animation on mount. Closing is immediate: an
+  exit animation would mean keeping the panel mounted after it is logically shut,
+  which is exactly what the tab-order rule above forbids.
+
+## Edge cases & known gaps
+
+- Closing has no animation, for the reason given above. It looks slightly abrupt
+  next to the slide-in.
+- The scroll lock is `overflow: hidden` on `<body>`. Older iOS Safari can still
+  rubber-band the page behind the panel; the sturdier fix (fixing the body and
+  restoring `scrollY` on close) was not worth its complexity here.
+- The link list is written twice, once for the bar and once for the panel, from
+  the same `menuLinks()` data. The two could drift; there is no test that they
+  hold the same labels.
+- The end-to-end (E2E) test for the phone layout needs a real admin account and
+  skips itself unless `E2E_EMAIL` and `E2E_PASSWORD` are set, like the other
+  signed-in E2E tests. There is no unit test, because this repo has no test setup
+  for rendering React components.
+- Nested menu items are deliberately out of scope: no admin page has children.
+
+## Open questions
+
+None.

--- a/specs/13-admin-navigation.md
+++ b/specs/13-admin-navigation.md
@@ -139,9 +139,10 @@ its links point at routes owned by other features:
   component unmounts, so signing out from inside the panel cannot leave the next
   page permanently unscrollable.
 - **Everything the panel does to the rest of the page is undone in one place**,
-  in a fixed order: the background stops being inert, the scroll position is
+  in a fixed order: the background stops being inert, the scroll lock is
   released, and only then does focus go back to the hamburger — focusing a button
-  that is still inert would silently do nothing.
+  that is still inert would silently do nothing. Nothing is done about the scroll
+  _position_; it is never moved, so it needs no restoring.
 - **Touch targets in the phone layout are at least 44 by 44 pixels** (the
   hamburger, the close button, each link row), the smallest size that is reliably
   hittable with a thumb.
@@ -163,6 +164,17 @@ its links point at routes owned by other features:
   skips itself unless `E2E_EMAIL` and `E2E_PASSWORD` are set, like the other
   signed-in E2E tests. There is no unit test, because this repo has no test setup
   for rendering React components.
+- **Widening the window past 768 pixels is the one close path that returns focus
+  nowhere.** The panel closes as it should, but at that width the hamburger is
+  `display: none`, so focusing it does nothing and focus stays on the document —
+  the outcome the rule above otherwise avoids. Nobody resizing a window with a
+  mouse is likely to notice; nothing was added for it.
+- **The `inert` background is decided once, when the panel opens.** The children
+  of `<body>` are read at that moment, so an element added to `<body>` while the
+  panel is open is never made inert, and closing only clears the ones that were.
+  In practice nothing does that here — navigating closes the panel — but the rule
+  above is stated as if it held for the whole time the panel is open, and it does
+  not.
 - Nested menu items are deliberately out of scope: no admin page has children.
 
 ## Open questions

--- a/specs/13-admin-navigation.md
+++ b/specs/13-admin-navigation.md
@@ -61,7 +61,9 @@ Below 768 pixels (the phone layout):
    a small round badge with the total of the two counts, and its accessible name
    says so: "Avaa valikko, 3 odottaa käsittelyä" (open menu, 3 awaiting
    handling). Without the badge the counts would be invisible while the menu is
-   shut, which is the whole reason those two links carry numbers.
+   shut, which is the whole reason those two links carry numbers. This goes
+   beyond making the menu work on a phone, and was kept deliberately for that
+   reason.
 8. When the admin presses the hamburger, then a panel slides in from the right
    over the page, holding the title "Valikko" (menu), a close button, the same
    links one per row, and the sign-out button. The rest of the page dims behind
@@ -175,6 +177,10 @@ its links point at routes owned by other features:
   In practice nothing does that here — navigating closes the panel — but the rule
   above is stated as if it held for the whole time the panel is open, and it does
   not.
+- **The focus trap knows only about links and buttons.** Its selector is
+  `'a[href], button:not([disabled])'`, which is everything the panel contains
+  today. A field added to the panel later would sit outside the trap until the
+  selector is widened; nothing enforces that but the comment beside it.
 - Nested menu items are deliberately out of scope: no admin page has children.
 
 ## Open questions

--- a/specs/README.md
+++ b/specs/README.md
@@ -19,6 +19,7 @@ per feature, linking to its own spec once written.
 | 10 | [Statistics](10-statistics.md) | Returned-to-owner vs. club, most-lost disc names, trends over time. | `features/stats/`, `routes/stats.tsx` |
 | 11 | [Auth & authorization](11-auth-and-authorization.md) | Supabase sign-in, cookie sessions, admin-only routes, RLS policies. | `features/auth/`, `routes/sign-in.tsx`, `docs/rls.md` |
 | 12 | [Multi-club configuration](12-multi-club-configuration.md) | One deployment per club: club-scoped data, course catalog, per-club feature flags. | `APP_CLUB_ID`, `config/courses`, `models/clubs.server.ts` |
+| 13 | [Admin navigation menu](13-admin-navigation.md) | The top bar of admin links and its phone layout: hamburger button, slide-in panel, focus trap, scroll lock, waiting counts. | `ui/AdminMenu.tsx`, `root.tsx` |
 
 All paths are relative to `app/`.
 


### PR DESCRIPTION
## Summary

The admin menu's eight links wrapped onto three or four lines on a phone and pushed the page content below the fold. Below 768px the links now sit in a slide-in panel behind a hamburger button; from 768px up the bar is exactly as it was.

- **Panel is mounted only while open**, not translated off-screen. A panel parked at `translateX(100%)` keeps its links in the tab order and in the screen reader's document, so a keyboard user tabs into a menu they cannot see. The trade-off: closing has no exit animation (opening does). `aria-controls` is set only while the panel is mounted, so it never names a missing id.
- `role="dialog"` + `aria-modal`, focus moved to the close button and trapped inside (focus from outside is pulled back in, not just wrapped at the two ends).
- **The page behind is `inert`** — every `<body>` child that does not contain the panel or its backdrop. `aria-modal` only asks a screen reader to stay put; `inert` enforces it, and covers the pointer too.
- `overflow: hidden` on `<body>` while open, restoring the previous value rather than blanking it.
- Everything done to the rest of the page is undone in one effect cleanup, in order: un-inert, release the scroll lock, then restore focus to the hamburger. That way **every** close path — button, Escape, backdrop tap, link, back button — restores focus, and focus is never handed to a still-inert button.
- 44×44 touch targets. The hamburger carries a badge with `retrievalCount + responseCount` and says so in its accessible name: those two links carry numbers because they are the only warning that an owner has answered or a disc needs fetching, and hiding the menu would otherwise hide the warning. (Strictly an addition beyond "make it work on mobile" — say the word and it comes out.)
- Nested menu items are deliberately out of scope; no admin page has children.
- `specs/13-admin-navigation.md` is new — the menu was previously described only in fragments across five other specs.

## Test plan

- [x] `npm run lint`, `npm run typecheck`, `npm test` (349 pass), `npm run build`
- [x] Confirmed the built CSS really contains the 768px media query and the slide-in keyframe (StyleX resolves the interpolated media key)
- [ ] **`e2e/admin-menu.spec.ts` has not been run** — it needs `E2E_EMAIL` / `E2E_PASSWORD` and skips without them, like the other signed-in specs. Nothing in the phone layout has been seen in a real browser yet: `E2E_EMAIL=… E2E_PASSWORD=… npx playwright test e2e/admin-menu.spec.ts`. Five tests: links absent until opened and the panel closing on navigation; focus trap + Escape + focus restore; focus restore after a backdrop tap; the background going inert and back; the scroll lock going on and off. Until that runs, spec 13 §6–§10 are written but unverified.

## Notes

- `npm run format:check` fails on 20 pre-existing files (mostly `specs/*.md`), none of them touched here. Left alone rather than mixed into this diff.
- `app/ui/` is documented as presentational-only, and `AdminMenu` (which calls `supabase.auth.signOut()` and hard-codes admin routes) has never fitted that. This change makes it the largest domain-aware file in `ui/`. Not addressed here — moving it is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)